### PR TITLE
Cache: WIP (2/7) Cache inference at do_inference

### DIFF
--- a/judgearena/evaluate.py
+++ b/judgearena/evaluate.py
@@ -9,7 +9,6 @@ import pandas as pd
 from langchain_core.language_models.llms import LLM
 from langchain_core.prompts import ChatPromptTemplate
 
-from judgearena.inference import InferenceCache
 from judgearena.instruction_dataset import load_instructions
 from judgearena.instruction_dataset.arena_hard import (
     download_arena_hard,
@@ -274,7 +273,6 @@ def annotate_battles(
     truncate_input_chars: int | None = 8192,
     use_tqdm: bool = False,
     provide_explanation: bool = False,
-    inference_cache: InferenceCache | None = None,
     cache_metadata: list[dict] | None = None,
 ) -> list[JudgeAnnotation]:
     """
@@ -335,7 +333,6 @@ def annotate_battles(
         chat_model=judge_chat_model,
         inputs=inputs,
         use_tqdm=use_tqdm,
-        cache=inference_cache,
         cache_metadata=cache_metadata,
     )
 

--- a/judgearena/evaluate.py
+++ b/judgearena/evaluate.py
@@ -9,6 +9,7 @@ import pandas as pd
 from langchain_core.language_models.llms import LLM
 from langchain_core.prompts import ChatPromptTemplate
 
+from judgearena.inference import InferenceCache
 from judgearena.instruction_dataset import load_instructions
 from judgearena.instruction_dataset.arena_hard import (
     download_arena_hard,
@@ -273,6 +274,8 @@ def annotate_battles(
     truncate_input_chars: int | None = 8192,
     use_tqdm: bool = False,
     provide_explanation: bool = False,
+    inference_cache: InferenceCache | None = None,
+    cache_metadata: list[dict] | None = None,
 ) -> list[JudgeAnnotation]:
     """
     Directly evaluate from list of instructions and completions
@@ -332,6 +335,8 @@ def annotate_battles(
         chat_model=judge_chat_model,
         inputs=inputs,
         use_tqdm=use_tqdm,
+        cache=inference_cache,
+        cache_metadata=cache_metadata,
     )
 
     annotations = []

--- a/judgearena/generate.py
+++ b/judgearena/generate.py
@@ -50,8 +50,12 @@ def generate_instructions(
     if instructions_to_run.empty:
         return cached_df[["instruction_index", "completion"]].reset_index(drop=True)
 
-    model_factory = prepare_model if inference_cache is not None else make_model
-    chat_model = model_factory(model, max_tokens=max_tokens, **engine_kwargs)
+    chat_model = prepare_model(
+        model,
+        max_tokens=max_tokens,
+        cache=inference_cache,
+        **engine_kwargs,
+    )
 
     if system_prompt is None:
         system_prompt = (
@@ -70,7 +74,6 @@ def generate_instructions(
         chat_model=chat_model,
         inputs=inputs,
         use_tqdm=use_tqdm,
-        cache=inference_cache,
         cache_metadata=[
             {"instruction_id": index} for index in instructions_to_run.index
         ],

--- a/judgearena/generate.py
+++ b/judgearena/generate.py
@@ -5,10 +5,12 @@ from typing import TYPE_CHECKING
 import pandas as pd
 from langchain_core.prompts import ChatPromptTemplate
 
+from judgearena.inference import InferenceCache
 from judgearena.log import get_logger
 from judgearena.utils import (
     do_inference,
     make_model,
+    prepare_model,
     truncate,
 )
 
@@ -26,6 +28,7 @@ def generate_instructions(
     use_tqdm: bool = True,
     system_prompt: str | None = None,
     completion_store: SQLiteCompletionStore | None = None,
+    inference_cache: InferenceCache | None = None,
     pushed_by: str = "judgearena",
     **engine_kwargs,
 ) -> pd.DataFrame:
@@ -47,7 +50,8 @@ def generate_instructions(
     if instructions_to_run.empty:
         return cached_df[["instruction_index", "completion"]].reset_index(drop=True)
 
-    chat_model = make_model(model, max_tokens=max_tokens, **engine_kwargs)
+    model_factory = prepare_model if inference_cache is not None else make_model
+    chat_model = model_factory(model, max_tokens=max_tokens, **engine_kwargs)
 
     if system_prompt is None:
         system_prompt = (
@@ -62,7 +66,15 @@ def generate_instructions(
             for user_prompt in instructions_to_run
         ]
     )
-    completions = do_inference(chat_model=chat_model, inputs=inputs, use_tqdm=use_tqdm)
+    completions = do_inference(
+        chat_model=chat_model,
+        inputs=inputs,
+        use_tqdm=use_tqdm,
+        cache=inference_cache,
+        cache_metadata=[
+            {"instruction_id": index} for index in instructions_to_run.index
+        ],
+    )
     df_new = pd.DataFrame(
         {
             "completion": completions,

--- a/judgearena/inference.py
+++ b/judgearena/inference.py
@@ -22,6 +22,13 @@ from judgearena.cache_sqlite import (
 )
 
 _ROLE_MAP = {"human": "user", "ai": "assistant", "system": "system"}
+VLLM_TEMPERATURE = 0.6
+VLLM_TOP_P = 0.95
+VLLM_EXECUTION_ONLY_KWARGS = {
+    "enforce_eager",
+    "gpu_memory_utilization",
+    "tensor_parallel_size",
+}
 
 
 def canonicalize_chat_input(input_item: Any) -> str:
@@ -53,26 +60,27 @@ def build_model_descriptor(
     if provider not in {"Dummy", "VLLM"}:
         return None
 
-    backend_version = None
+    backend_version = importlib_metadata.version("vllm") if provider == "VLLM" else None
+    descriptor_kwargs = resolved_kwargs
     if provider == "VLLM":
-        try:
-            backend_version = importlib_metadata.version("vllm")
-        except importlib_metadata.PackageNotFoundError:
-            return None
+        descriptor_kwargs = {
+            key: value
+            for key, value in resolved_kwargs.items()
+            if key not in VLLM_EXECUTION_ONLY_KWARGS
+        }
 
     descriptor = {
         "schema_version": "judgearena-inference-cache/v1",
         "provider": provider,
         "model": model_name,
         "backend_version": backend_version,
-        "model_kwargs": resolved_kwargs,
+        "model_kwargs": descriptor_kwargs,
     }
     if provider == "VLLM":
-        descriptor["sampling"] = {"temperature": 0.6, "top_p": 0.95}
-    try:
-        stable_json_dumps(descriptor)
-    except TypeError:
-        return None
+        descriptor["sampling"] = {
+            "temperature": VLLM_TEMPERATURE,
+            "top_p": VLLM_TOP_P,
+        }
     return descriptor
 
 
@@ -83,6 +91,7 @@ class PreparedModel:
     model_spec: str
     descriptor: dict[str, Any] | None
     factory: Callable[[], Any]
+    cache: InferenceCache | None = None
     _model: Any = field(default=None, init=False, repr=False)
 
     def materialize(self) -> Any:
@@ -98,7 +107,6 @@ class InferenceCache:
     store_root: Path
     kind: CacheKind
     task: str
-    pushed_by: str = "judgearena"
 
     def open_store(self, model: PreparedModel) -> CompletionCache | JudgementCache:
         assert model.descriptor is not None
@@ -151,4 +159,4 @@ class InferenceCache:
                         "orientation": row_metadata.get("orientation"),
                     }
                 )
-        store.save(pd.DataFrame(rows), pushed_by=self.pushed_by)
+        store.save(pd.DataFrame(rows))

--- a/judgearena/inference.py
+++ b/judgearena/inference.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
+from abc import ABC, abstractmethod
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from importlib import metadata as importlib_metadata
 from pathlib import Path
-from typing import Any
+from typing import Any, ClassVar
 
 import pandas as pd
 
@@ -101,13 +102,17 @@ class PreparedModel:
 
 
 @dataclass(frozen=True)
-class InferenceCache:
-    """Select the role-specific store used by the inference cache boundary."""
+class InferenceCache(ABC):
+    """Share cache lifecycle while subclasses define role-specific rows."""
 
     store_root: Path
-    kind: CacheKind
     task: str
     pushed_by: str = "judgearena"
+
+    kind: ClassVar[CacheKind]
+    db_name: ClassVar[str]
+    output_column: ClassVar[str]
+    store_type: ClassVar[type[CompletionCache] | type[JudgementCache]]
 
     def open_store(self, model: PreparedModel) -> CompletionCache | JudgementCache:
         assert model.descriptor is not None
@@ -119,9 +124,7 @@ class InferenceCache:
             model.descriptor,
         )
         write_descriptor(folder, model.descriptor)
-        if self.kind == "completions":
-            return CompletionCache(folder / COMPLETION_DB_NAME)
-        return JudgementCache(folder / JUDGEMENT_DB_NAME)
+        return self.store_type(folder / self.db_name)
 
     def save_outputs(
         self,
@@ -132,32 +135,77 @@ class InferenceCache:
         metadata: list[dict[str, Any]],
         indices: list[int],
     ) -> None:
-        rows = []
-        for index, output in zip(indices, outputs, strict=True):
-            row_metadata = metadata[index]
-            common = {
-                "benchmark": self.task,
-                "instruction_id": row_metadata["instruction_id"],
-            }
-            if self.kind == "completions":
-                rows.append(
-                    {
-                        **common,
-                        "input_text": input_texts[index],
-                        "completion": output,
-                        "model": model.model_spec,
-                    }
-                )
-            else:
-                rows.append(
-                    {
-                        **common,
-                        "judge_input": input_texts[index],
-                        "judge_completion": output,
-                        "model_a": row_metadata["model_a"],
-                        "model_b": row_metadata["model_b"],
-                        "judge": model.model_spec,
-                        "orientation": row_metadata.get("orientation"),
-                    }
-                )
+        rows = [
+            self.make_row(
+                model=model,
+                input_text=input_texts[index],
+                output=output,
+                metadata=metadata[index],
+            )
+            for index, output in zip(indices, outputs, strict=True)
+        ]
         store.save(pd.DataFrame(rows), pushed_by=self.pushed_by)
+
+    @abstractmethod
+    def make_row(
+        self,
+        *,
+        model: PreparedModel,
+        input_text: str,
+        output: str,
+        metadata: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Convert one inference output to its role-specific storage row."""
+
+
+class CompletionInferenceCache(InferenceCache):
+    """Cache generated model completions."""
+
+    kind = "completions"
+    db_name = COMPLETION_DB_NAME
+    output_column = "completion"
+    store_type = CompletionCache
+
+    def make_row(
+        self,
+        *,
+        model: PreparedModel,
+        input_text: str,
+        output: str,
+        metadata: dict[str, Any],
+    ) -> dict[str, Any]:
+        return {
+            "input_text": input_text,
+            "completion": output,
+            "benchmark": self.task,
+            "instruction_id": metadata["instruction_id"],
+            "model": model.model_spec,
+        }
+
+
+class JudgementInferenceCache(InferenceCache):
+    """Cache raw judge completions."""
+
+    kind = "judgements"
+    db_name = JUDGEMENT_DB_NAME
+    output_column = "judge_completion"
+    store_type = JudgementCache
+
+    def make_row(
+        self,
+        *,
+        model: PreparedModel,
+        input_text: str,
+        output: str,
+        metadata: dict[str, Any],
+    ) -> dict[str, Any]:
+        return {
+            "judge_input": input_text,
+            "judge_completion": output,
+            "benchmark": self.task,
+            "instruction_id": metadata["instruction_id"],
+            "model_a": metadata["model_a"],
+            "model_b": metadata["model_b"],
+            "judge": model.model_spec,
+            "orientation": metadata.get("orientation"),
+        }

--- a/judgearena/inference.py
+++ b/judgearena/inference.py
@@ -107,6 +107,7 @@ class InferenceCache:
     store_root: Path
     kind: CacheKind
     task: str
+    pushed_by: str = "judgearena"
 
     def open_store(self, model: PreparedModel) -> CompletionCache | JudgementCache:
         assert model.descriptor is not None
@@ -159,4 +160,4 @@ class InferenceCache:
                         "orientation": row_metadata.get("orientation"),
                     }
                 )
-        store.save(pd.DataFrame(rows))
+        store.save(pd.DataFrame(rows), pushed_by=self.pushed_by)

--- a/judgearena/inference.py
+++ b/judgearena/inference.py
@@ -22,7 +22,6 @@ from judgearena.cache_sqlite import (
 )
 
 _ROLE_MAP = {"human": "user", "ai": "assistant", "system": "system"}
-_SECRET_KEYS = {"api_key", "password", "secret", "token"}
 
 
 def canonicalize_chat_input(input_item: Any) -> str:
@@ -61,25 +60,12 @@ def canonicalize_chat_input(input_item: Any) -> str:
     return stable_json_dumps(payload)
 
 
-def _contains_secret(value: Any) -> bool:
-    if isinstance(value, dict):
-        return any(
-            str(key).lower() in _SECRET_KEYS
-            or str(key).lower().endswith(("_api_key", "_password", "_secret", "_token"))
-            or _contains_secret(item)
-            for key, item in value.items()
-        )
-    if isinstance(value, (list, tuple)):
-        return any(_contains_secret(item) for item in value)
-    return False
-
-
 def build_model_descriptor(
     provider: str,
     model_name: str,
     resolved_kwargs: dict[str, Any],
 ) -> dict[str, Any] | None:
-    if provider not in {"Dummy", "VLLM"} or _contains_secret(resolved_kwargs):
+    if provider not in {"Dummy", "VLLM"}:
         return None
 
     backend_version = None
@@ -110,17 +96,7 @@ class PreparedModel:
     model_spec: str
     descriptor: dict[str, Any] | None
     factory: Callable[[], Any]
-    canonicalizer: Callable[[Any], str] | None
     _model: Any = field(default=None, init=False, repr=False)
-
-    @property
-    def cacheable(self) -> bool:
-        return self.descriptor is not None and self.canonicalizer is not None
-
-    def canonicalize(self, input_item: Any) -> str:
-        if self.canonicalizer is None:
-            raise TypeError(f"{self.model_spec} has no safe input canonicalizer.")
-        return self.canonicalizer(input_item)
 
     def materialize(self) -> Any:
         if self._model is None:

--- a/judgearena/inference.py
+++ b/judgearena/inference.py
@@ -25,6 +25,7 @@ _ROLE_MAP = {"human": "user", "ai": "assistant", "system": "system"}
 
 
 def canonicalize_chat_input(input_item: Any) -> str:
+    """Serialize a logical model input for content-addressed cache lookup."""
     if isinstance(input_item, str):
         payload = {"type": "text", "text": input_item}
     elif hasattr(input_item, "to_messages"):
@@ -65,6 +66,7 @@ def build_model_descriptor(
     model_name: str,
     resolved_kwargs: dict[str, Any],
 ) -> dict[str, Any] | None:
+    """Describe output-affecting settings without constructing the backend."""
     if provider not in {"Dummy", "VLLM"}:
         return None
 
@@ -93,6 +95,8 @@ def build_model_descriptor(
 
 @dataclass
 class PreparedModel:
+    """Carry cache identity while deferring backend construction until a miss."""
+
     model_spec: str
     descriptor: dict[str, Any] | None
     factory: Callable[[], Any]
@@ -106,6 +110,8 @@ class PreparedModel:
 
 @dataclass(frozen=True)
 class InferenceCache:
+    """Select the role-specific store used by the inference cache boundary."""
+
     store_root: Path
     kind: CacheKind
     task: str

--- a/judgearena/inference.py
+++ b/judgearena/inference.py
@@ -39,23 +39,6 @@ def canonicalize_chat_input(input_item: Any) -> str:
                 for message in input_item.to_messages()
             ],
         }
-    elif isinstance(input_item, list) and input_item:
-        if isinstance(input_item[0], tuple):
-            messages = [
-                {
-                    "role": "user" if role == "human" else role,
-                    "content": content,
-                }
-                for role, content in input_item
-            ]
-        elif isinstance(input_item[0], dict):
-            messages = [
-                {"role": message["role"], "content": message["content"]}
-                for message in input_item
-            ]
-        else:
-            raise TypeError(f"Unsupported inference input: {type(input_item)!r}")
-        payload = {"type": "messages", "messages": messages}
     else:
         raise TypeError(f"Unsupported inference input: {type(input_item)!r}")
     return stable_json_dumps(payload)

--- a/judgearena/inference.py
+++ b/judgearena/inference.py
@@ -1,0 +1,189 @@
+"""Lazy model preparation and inference-cache context."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from importlib import metadata as importlib_metadata
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+from judgearena.cache_sqlite import (
+    COMPLETION_DB_NAME,
+    JUDGEMENT_DB_NAME,
+    CacheKind,
+    CompletionCache,
+    JudgementCache,
+    cache_folder,
+    stable_json_dumps,
+    write_descriptor,
+)
+
+_ROLE_MAP = {"human": "user", "ai": "assistant", "system": "system"}
+_SECRET_KEYS = {"api_key", "password", "secret", "token"}
+
+
+def canonicalize_chat_input(input_item: Any) -> str:
+    if isinstance(input_item, str):
+        payload = {"type": "text", "text": input_item}
+    elif hasattr(input_item, "to_messages"):
+        payload = {
+            "type": "messages",
+            "messages": [
+                {
+                    "role": _ROLE_MAP.get(message.type, message.type),
+                    "content": message.content,
+                }
+                for message in input_item.to_messages()
+            ],
+        }
+    elif isinstance(input_item, list) and input_item:
+        if isinstance(input_item[0], tuple):
+            messages = [
+                {
+                    "role": "user" if role == "human" else role,
+                    "content": content,
+                }
+                for role, content in input_item
+            ]
+        elif isinstance(input_item[0], dict):
+            messages = [
+                {"role": message["role"], "content": message["content"]}
+                for message in input_item
+            ]
+        else:
+            raise TypeError(f"Unsupported inference input: {type(input_item)!r}")
+        payload = {"type": "messages", "messages": messages}
+    else:
+        raise TypeError(f"Unsupported inference input: {type(input_item)!r}")
+    return stable_json_dumps(payload)
+
+
+def _contains_secret(value: Any) -> bool:
+    if isinstance(value, dict):
+        return any(
+            str(key).lower() in _SECRET_KEYS
+            or str(key).lower().endswith(("_api_key", "_password", "_secret", "_token"))
+            or _contains_secret(item)
+            for key, item in value.items()
+        )
+    if isinstance(value, (list, tuple)):
+        return any(_contains_secret(item) for item in value)
+    return False
+
+
+def build_model_descriptor(
+    provider: str,
+    model_name: str,
+    resolved_kwargs: dict[str, Any],
+) -> dict[str, Any] | None:
+    if provider not in {"Dummy", "VLLM"} or _contains_secret(resolved_kwargs):
+        return None
+
+    backend_version = None
+    if provider == "VLLM":
+        try:
+            backend_version = importlib_metadata.version("vllm")
+        except importlib_metadata.PackageNotFoundError:
+            return None
+
+    descriptor = {
+        "schema_version": "judgearena-inference-cache/v1",
+        "provider": provider,
+        "model": model_name,
+        "backend_version": backend_version,
+        "model_kwargs": resolved_kwargs,
+    }
+    if provider == "VLLM":
+        descriptor["sampling"] = {"temperature": 0.6, "top_p": 0.95}
+    try:
+        stable_json_dumps(descriptor)
+    except TypeError:
+        return None
+    return descriptor
+
+
+@dataclass
+class PreparedModel:
+    model_spec: str
+    descriptor: dict[str, Any] | None
+    factory: Callable[[], Any]
+    canonicalizer: Callable[[Any], str] | None
+    _model: Any = field(default=None, init=False, repr=False)
+
+    @property
+    def cacheable(self) -> bool:
+        return self.descriptor is not None and self.canonicalizer is not None
+
+    def canonicalize(self, input_item: Any) -> str:
+        if self.canonicalizer is None:
+            raise TypeError(f"{self.model_spec} has no safe input canonicalizer.")
+        return self.canonicalizer(input_item)
+
+    def materialize(self) -> Any:
+        if self._model is None:
+            self._model = self.factory()
+        return self._model
+
+
+@dataclass(frozen=True)
+class InferenceCache:
+    store_root: Path
+    kind: CacheKind
+    task: str
+    pushed_by: str = "judgearena"
+
+    def open_store(self, model: PreparedModel) -> CompletionCache | JudgementCache:
+        assert model.descriptor is not None
+        folder = cache_folder(
+            self.store_root,
+            self.kind,
+            self.task,
+            model.model_spec,
+            model.descriptor,
+        )
+        write_descriptor(folder, model.descriptor)
+        if self.kind == "completions":
+            return CompletionCache(folder / COMPLETION_DB_NAME)
+        return JudgementCache(folder / JUDGEMENT_DB_NAME)
+
+    def save_outputs(
+        self,
+        store: CompletionCache | JudgementCache,
+        model: PreparedModel,
+        input_texts: list[str],
+        outputs: list[str],
+        metadata: list[dict[str, Any]],
+        indices: list[int],
+    ) -> None:
+        rows = []
+        for index, output in zip(indices, outputs, strict=True):
+            row_metadata = metadata[index]
+            common = {
+                "benchmark": self.task,
+                "instruction_id": row_metadata["instruction_id"],
+            }
+            if self.kind == "completions":
+                rows.append(
+                    {
+                        **common,
+                        "input_text": input_texts[index],
+                        "completion": output,
+                        "model": model.model_spec,
+                    }
+                )
+            else:
+                rows.append(
+                    {
+                        **common,
+                        "judge_input": input_texts[index],
+                        "judge_completion": output,
+                        "model_a": row_metadata["model_a"],
+                        "model_b": row_metadata["model_b"],
+                        "judge": model.model_spec,
+                        "orientation": row_metadata.get("orientation"),
+                    }
+                )
+        store.save(pd.DataFrame(rows), pushed_by=self.pushed_by)

--- a/judgearena/utils.py
+++ b/judgearena/utils.py
@@ -239,13 +239,10 @@ def do_inference(
     input_hashes = [input_hash(input_text) for input_text in input_texts]
     with cache.open_store(chat_model) as store:
         cached_rows = store.query(input_hashes)
-        output_column = (
-            "completion" if cache.kind == "completions" else "judge_completion"
-        )
         cached_outputs = dict(
             zip(
                 cached_rows["input_hash"],
-                cached_rows[output_column],
+                cached_rows[cache.output_column],
                 strict=True,
             )
         )

--- a/judgearena/utils.py
+++ b/judgearena/utils.py
@@ -14,6 +14,13 @@ from langchain_openai import ChatOpenAI
 from tqdm.asyncio import tqdm
 from tqdm.contrib.logging import logging_redirect_tqdm
 
+from judgearena.cache_sqlite import input_hash
+from judgearena.inference import (
+    InferenceCache,
+    PreparedModel,
+    build_model_descriptor,
+    canonicalize_chat_input,
+)
 from judgearena.instruction_dataset.arena_hard import (
     download_arena_hard,
     is_arena_hard_dataset,
@@ -127,7 +134,7 @@ def safe_text(value: object, truncate_chars: int | None) -> str:
     return truncate(str(value), max_len=truncate_chars)
 
 
-def do_inference(chat_model, inputs, use_tqdm: bool = False):
+def _do_inference_uncached(chat_model, inputs, use_tqdm: bool = False):
     # Retries on rate-limit/server errors with exponential backoff.
     # Async path retries individual calls; batch path splits into 4^attempt chunks on failure.
     invoke_kwargs = {
@@ -204,6 +211,67 @@ def do_inference(chat_model, inputs, use_tqdm: bool = False):
     # when using OpenAI, the output is AIMessage not a string...
     res = [x.content if hasattr(x, "content") else x for x in res]
     return res
+
+
+def do_inference(
+    chat_model,
+    inputs,
+    use_tqdm: bool = False,
+    *,
+    cache: InferenceCache | None = None,
+    cache_metadata: list[dict] | None = None,
+):
+    inputs = list(inputs)
+    if not isinstance(chat_model, PreparedModel):
+        if cache is not None:
+            logger.warning("Caching requires a PreparedModel; running uncached.")
+        return _do_inference_uncached(chat_model, inputs, use_tqdm)
+
+    if cache is None or not chat_model.cacheable:
+        return _do_inference_uncached(chat_model.materialize(), inputs, use_tqdm)
+    if cache_metadata is None or len(cache_metadata) != len(inputs):
+        raise ValueError("cache_metadata must contain one row per inference input.")
+
+    try:
+        input_texts = [chat_model.canonicalize(item) for item in inputs]
+    except TypeError as error:
+        logger.warning("Input cannot be safely cached (%s); running uncached.", error)
+        return _do_inference_uncached(chat_model.materialize(), inputs, use_tqdm)
+
+    input_hashes = [input_hash(input_text) for input_text in input_texts]
+    with cache.open_store(chat_model) as store:
+        cached_rows = store.query(input_hashes)
+        output_column = (
+            "completion" if cache.kind == "completions" else "judge_completion"
+        )
+        cached_outputs = dict(
+            zip(
+                cached_rows["input_hash"],
+                cached_rows[output_column],
+                strict=True,
+            )
+        )
+        outputs = [cached_outputs.get(key) for key in input_hashes]
+        missing_indices = [
+            index for index, output in enumerate(outputs) if output is None
+        ]
+        if missing_indices:
+            generated = _do_inference_uncached(
+                chat_model.materialize(),
+                [inputs[index] for index in missing_indices],
+                use_tqdm,
+            )
+            for index, output in zip(missing_indices, generated, strict=True):
+                outputs[index] = output
+            cache.save_outputs(
+                store,
+                chat_model,
+                input_texts,
+                generated,
+                cache_metadata,
+                missing_indices,
+            )
+    return outputs
 
 
 class DummyModel:
@@ -389,6 +457,58 @@ class ChatVLLM:
         )
 
 
+def _resolve_model_config(
+    model: str,
+    max_tokens: int | None,
+    engine_kwargs: dict,
+) -> tuple[str, str, dict]:
+    resolved_kwargs = engine_kwargs.copy()
+    resolved_kwargs["max_tokens"] = max_tokens or 8192
+    model_provider, model_name = model.split("/", 1)
+
+    if model_provider != "VLLM":
+        resolved_kwargs.pop("max_model_len", None)
+        resolved_kwargs.pop("chat_template", None)
+    if model_provider == "VLLM":
+        resolved_kwargs = {
+            key: value for key, value in resolved_kwargs.items() if value is not None
+        }
+        resolved_kwargs["chat_template"] = resolved_kwargs.get("chat_template")
+    elif model_provider == "LlamaCpp":
+        resolved_kwargs["model_path"] = model_name
+    elif model_provider not in {"Dummy", "OpenRouter"}:
+        resolved_kwargs["model"] = model_name
+    return model_provider, model_name, resolved_kwargs
+
+
+def prepare_model(
+    model: str,
+    max_tokens: int | None = 8192,
+    **engine_kwargs,
+) -> PreparedModel:
+    provider, model_name, resolved_kwargs = _resolve_model_config(
+        model, max_tokens, engine_kwargs
+    )
+    descriptor = build_model_descriptor(provider, model_name, resolved_kwargs)
+    if descriptor is None:
+        logger.warning(
+            "Caching disabled for %s because its resolved configuration cannot "
+            "be described safely.",
+            model,
+        )
+    factory_kwargs = engine_kwargs.copy()
+    return PreparedModel(
+        model_spec=model,
+        descriptor=descriptor,
+        factory=lambda: make_model(
+            model,
+            max_tokens=max_tokens,
+            **factory_kwargs,
+        ),
+        canonicalizer=canonicalize_chat_input if descriptor is not None else None,
+    )
+
+
 def make_model(model: str, max_tokens: int | None = 8192, **engine_kwargs):
     """Instantiate a model wrapper from a provider/model-name string.
 
@@ -398,34 +518,17 @@ def make_model(model: str, max_tokens: int | None = 8192, **engine_kwargs):
         max_tokens: Maximum tokens the model may generate.
         **engine_kwargs: Engine-specific options forwarded to the model wrapper.
     """
-    # Avoid mutating the original engine_kwargs dictionary
-    # NOTE: this is a shallow copy since we are not modifying any
-    # mutable objects in the dictionary.
-    engine_kwargs = engine_kwargs.copy()
-
-    # Dedicated arguments like max_tokens always win over engine_kwargs.
-    engine_kwargs["max_tokens"] = max_tokens or 8192
-
-    model_provider = model.split("/")[0]
-
-    # vLLM-engine-only kwargs must not leak to remote-API providers
-    # (OpenRouter, OpenAI, Together): langchain-openai forwards unknown
-    # kwargs via model_kwargs into chat.completions.create, which rejects them.
-    if model_provider != "VLLM":
-        engine_kwargs.pop("max_model_len", None)
-        engine_kwargs.pop("chat_template", None)
+    model_provider, model_name, engine_kwargs = _resolve_model_config(
+        model, max_tokens, engine_kwargs
+    )
 
     if model_provider == "Dummy":
         return DummyModel(model)
 
-    model_name = "/".join(model.split("/")[1:])
     logger.info("Loading %s(model=%s)", model_provider, model_name)
 
     # Use our custom ChatVLLM wrapper which properly applies chat templates
     if model_provider == "VLLM":
-        engine_kwargs = {k: v for k, v in engine_kwargs.items() if v is not None}
-        engine_kwargs["chat_template"] = engine_kwargs.get("chat_template", None)
-
         return ChatVLLM(
             model=model_name,
             **engine_kwargs,
@@ -444,10 +547,6 @@ def make_model(model: str, max_tokens: int | None = 8192, **engine_kwargs):
             LlamaCpp,
             ChatOpenAI,
         ]
-        if model_provider == "LlamaCpp":
-            engine_kwargs["model_path"] = model_name
-        else:
-            engine_kwargs["model"] = model_name
 
         try:
             from langchain_together.llms import Together

--- a/judgearena/utils.py
+++ b/judgearena/utils.py
@@ -16,6 +16,8 @@ from tqdm.contrib.logging import logging_redirect_tqdm
 
 from judgearena.cache_sqlite import input_hash
 from judgearena.inference import (
+    VLLM_TEMPERATURE,
+    VLLM_TOP_P,
     InferenceCache,
     PreparedModel,
     build_model_descriptor,
@@ -219,26 +221,20 @@ def do_inference(
     inputs,
     use_tqdm: bool = False,
     *,
-    cache: InferenceCache | None = None,
     cache_metadata: list[dict] | None = None,
 ):
     """Reuse raw outputs by rendered input and invoke the model only for misses."""
     inputs = list(inputs)
     if not isinstance(chat_model, PreparedModel):
-        if cache is not None:
-            logger.warning("Caching requires a PreparedModel; running uncached.")
         return _do_inference_uncached(chat_model, inputs, use_tqdm)
 
+    cache = chat_model.cache
     if cache is None or chat_model.descriptor is None:
         return _do_inference_uncached(chat_model.materialize(), inputs, use_tqdm)
     if cache_metadata is None or len(cache_metadata) != len(inputs):
         raise ValueError("cache_metadata must contain one row per inference input.")
 
-    try:
-        input_texts = [canonicalize_chat_input(item) for item in inputs]
-    except TypeError as error:
-        logger.warning("Input cannot be safely cached (%s); running uncached.", error)
-        return _do_inference_uncached(chat_model.materialize(), inputs, use_tqdm)
+    input_texts = [canonicalize_chat_input(item) for item in inputs]
 
     input_hashes = [input_hash(input_text) for input_text in input_texts]
     with cache.open_store(chat_model) as store:
@@ -346,8 +342,8 @@ class ChatVLLM:
         self.llm = LLM(model=model, trust_remote_code=True, **vllm_kwargs)
         self.sampling_params = SamplingParams(
             max_tokens=max_tokens,
-            temperature=0.6,
-            top_p=0.95,
+            temperature=VLLM_TEMPERATURE,
+            top_p=VLLM_TOP_P,
         )
 
         # Resolve chat template:
@@ -487,17 +483,22 @@ def _resolve_model_config(
 def prepare_model(
     model: str,
     max_tokens: int | None = 8192,
+    *,
+    cache: InferenceCache | None = None,
     **engine_kwargs,
 ) -> PreparedModel:
     """Prepare cache identity and a lazy factory without loading the backend."""
     provider, model_name, resolved_kwargs = _resolve_model_config(
         model, max_tokens, engine_kwargs
     )
-    descriptor = build_model_descriptor(provider, model_name, resolved_kwargs)
-    if descriptor is None:
+    descriptor = (
+        build_model_descriptor(provider, model_name, resolved_kwargs)
+        if cache is not None
+        else None
+    )
+    if cache is not None and descriptor is None:
         logger.warning(
-            "Caching disabled for %s because its resolved configuration cannot "
-            "be described safely.",
+            "Caching is not supported for %s; running uncached.",
             model,
         )
     factory_kwargs = engine_kwargs.copy()
@@ -509,6 +510,7 @@ def prepare_model(
             max_tokens=max_tokens,
             **factory_kwargs,
         ),
+        cache=cache,
     )
 
 

--- a/judgearena/utils.py
+++ b/judgearena/utils.py
@@ -227,13 +227,13 @@ def do_inference(
             logger.warning("Caching requires a PreparedModel; running uncached.")
         return _do_inference_uncached(chat_model, inputs, use_tqdm)
 
-    if cache is None or not chat_model.cacheable:
+    if cache is None or chat_model.descriptor is None:
         return _do_inference_uncached(chat_model.materialize(), inputs, use_tqdm)
     if cache_metadata is None or len(cache_metadata) != len(inputs):
         raise ValueError("cache_metadata must contain one row per inference input.")
 
     try:
-        input_texts = [chat_model.canonicalize(item) for item in inputs]
+        input_texts = [canonicalize_chat_input(item) for item in inputs]
     except TypeError as error:
         logger.warning("Input cannot be safely cached (%s); running uncached.", error)
         return _do_inference_uncached(chat_model.materialize(), inputs, use_tqdm)
@@ -505,7 +505,6 @@ def prepare_model(
             max_tokens=max_tokens,
             **factory_kwargs,
         ),
-        canonicalizer=canonicalize_chat_input if descriptor is not None else None,
     )
 
 

--- a/judgearena/utils.py
+++ b/judgearena/utils.py
@@ -135,6 +135,7 @@ def safe_text(value: object, truncate_chars: int | None) -> str:
 
 
 def _do_inference_uncached(chat_model, inputs, use_tqdm: bool = False):
+    """Run the existing retry path for cache misses or cache-disabled calls."""
     # Retries on rate-limit/server errors with exponential backoff.
     # Async path retries individual calls; batch path splits into 4^attempt chunks on failure.
     invoke_kwargs = {
@@ -221,6 +222,7 @@ def do_inference(
     cache: InferenceCache | None = None,
     cache_metadata: list[dict] | None = None,
 ):
+    """Reuse raw outputs by rendered input and invoke the model only for misses."""
     inputs = list(inputs)
     if not isinstance(chat_model, PreparedModel):
         if cache is not None:
@@ -462,6 +464,7 @@ def _resolve_model_config(
     max_tokens: int | None,
     engine_kwargs: dict,
 ) -> tuple[str, str, dict]:
+    """Resolve constructor kwargs once for both descriptors and materialization."""
     resolved_kwargs = engine_kwargs.copy()
     resolved_kwargs["max_tokens"] = max_tokens or 8192
     model_provider, model_name = model.split("/", 1)
@@ -486,6 +489,7 @@ def prepare_model(
     max_tokens: int | None = 8192,
     **engine_kwargs,
 ) -> PreparedModel:
+    """Prepare cache identity and a lazy factory without loading the backend."""
     provider, model_name, resolved_kwargs = _resolve_model_config(
         model, max_tokens, engine_kwargs
     )

--- a/tests/test_inference_cache.py
+++ b/tests/test_inference_cache.py
@@ -4,7 +4,7 @@ import judgearena.evaluate as evaluate
 import judgearena.generate as generate
 import judgearena.inference as inference
 import judgearena.utils as utils
-from judgearena.inference import InferenceCache
+from judgearena.inference import CompletionInferenceCache, JudgementInferenceCache
 from judgearena.utils import do_inference, prepare_model
 
 
@@ -26,8 +26,8 @@ class EchoModel:
 
 
 def test_generate_and_judge_full_hits_do_not_materialize_models(tmp_path, monkeypatch):
-    completion_cache = InferenceCache(tmp_path, "completions", "arena-hard")
-    judgement_cache = InferenceCache(tmp_path, "judgements", "arena-hard")
+    completion_cache = CompletionInferenceCache(tmp_path, "arena-hard")
+    judgement_cache = JudgementInferenceCache(tmp_path, "arena-hard")
     battle_model = "VLLM/Qwen/Qwen3-8B"
     judge_model = "VLLM/Qwen/Qwen3-32B"
     monkeypatch.setattr(inference.importlib_metadata, "version", lambda _name: "0.10.2")
@@ -87,7 +87,7 @@ def test_generate_and_judge_full_hits_do_not_materialize_models(tmp_path, monkey
 
 
 def test_mixed_hits_and_misses_preserve_order(tmp_path, monkeypatch):
-    cache = InferenceCache(tmp_path, "completions", "arena-hard")
+    cache = CompletionInferenceCache(tmp_path, "arena-hard")
     monkeypatch.setattr(
         utils, "make_model", lambda *_args, **_kwargs: ConstantModel("cached")
     )
@@ -115,7 +115,7 @@ def test_mixed_hits_and_misses_preserve_order(tmp_path, monkeypatch):
 
 def test_vllm_descriptor_contains_output_configuration(tmp_path, monkeypatch):
     monkeypatch.setattr(inference.importlib_metadata, "version", lambda _name: "0.10.2")
-    cache = InferenceCache(tmp_path, "completions", "arena-hard")
+    cache = CompletionInferenceCache(tmp_path, "arena-hard")
 
     model = prepare_model(
         "VLLM/Qwen/Qwen3-8B",

--- a/tests/test_inference_cache.py
+++ b/tests/test_inference_cache.py
@@ -1,0 +1,137 @@
+import pandas as pd
+
+import judgearena.evaluate as evaluate
+import judgearena.generate as generate
+import judgearena.inference as inference
+import judgearena.utils as utils
+from judgearena.inference import InferenceCache
+from judgearena.utils import do_inference, prepare_model
+
+
+class ConstantModel:
+    def __init__(self, output):
+        self.output = output
+
+    def batch(self, inputs, **_kwargs):
+        return [self.output] * len(inputs)
+
+
+class EchoModel:
+    def __init__(self):
+        self.calls = []
+
+    def batch(self, inputs, **_kwargs):
+        self.calls.append(inputs)
+        return [f"generated:{item}" for item in inputs]
+
+
+def test_generate_and_judge_full_hits_do_not_materialize_models(tmp_path, monkeypatch):
+    completion_cache = InferenceCache(tmp_path, "completions", "arena-hard")
+    judgement_cache = InferenceCache(tmp_path, "judgements", "arena-hard")
+    battle_model = "VLLM/Qwen/Qwen3-8B"
+    judge_model = "VLLM/Qwen/Qwen3-32B"
+    monkeypatch.setattr(inference.importlib_metadata, "version", lambda _name: "0.10.2")
+
+    def fake_model(model, **_kwargs):
+        output = (
+            "Candidate answer" if model == battle_model else "score A: 1 score B: 0"
+        )
+        return ConstantModel(output)
+
+    monkeypatch.setattr(utils, "make_model", fake_model)
+    instructions = pd.Series(["Which answer is better?"], index=[1])
+    completions = generate.generate_instructions(
+        instructions,
+        battle_model,
+        use_tqdm=False,
+        inference_cache=completion_cache,
+    )
+    metadata = [
+        {
+            "instruction_id": "1",
+            "model_a": "candidate",
+            "model_b": "baseline",
+            "orientation": "direct",
+        }
+    ]
+    arguments = {
+        "instructions": instructions.tolist(),
+        "completions_A": completions["completion"].tolist(),
+        "completions_B": ["Baseline answer"],
+        "inference_cache": judgement_cache,
+        "cache_metadata": metadata,
+    }
+
+    first = evaluate.annotate_battles(
+        judge_chat_model=prepare_model(judge_model),
+        **arguments,
+    )
+
+    def fail_if_materialized(*_args, **_kwargs):
+        raise AssertionError("cache hit materialized the model")
+
+    monkeypatch.setattr(utils, "make_model", fail_if_materialized)
+    cached_completions = generate.generate_instructions(
+        instructions,
+        battle_model,
+        use_tqdm=False,
+        inference_cache=completion_cache,
+    )
+    second = evaluate.annotate_battles(
+        judge_chat_model=prepare_model(judge_model),
+        **arguments,
+    )
+
+    assert cached_completions["completion"].tolist() == ["Candidate answer"]
+    assert first[0].judge_completion == "score A: 1 score B: 0"
+    assert second[0].judge_completion == first[0].judge_completion
+
+
+def test_mixed_hits_and_misses_preserve_order(tmp_path, monkeypatch):
+    cache = InferenceCache(tmp_path, "completions", "arena-hard")
+    monkeypatch.setattr(
+        utils, "make_model", lambda *_args, **_kwargs: ConstantModel("cached")
+    )
+    do_inference(
+        prepare_model("Dummy/test-model"),
+        ["hit"],
+        cache=cache,
+        cache_metadata=[{"instruction_id": "hit"}],
+    )
+
+    backend = EchoModel()
+    monkeypatch.setattr(utils, "make_model", lambda *_args, **_kwargs: backend)
+    outputs = do_inference(
+        prepare_model("Dummy/test-model"),
+        ["miss-a", "hit", "miss-b"],
+        cache=cache,
+        cache_metadata=[
+            {"instruction_id": "a"},
+            {"instruction_id": "hit"},
+            {"instruction_id": "b"},
+        ],
+    )
+
+    assert outputs == ["generated:miss-a", "cached", "generated:miss-b"]
+    assert backend.calls == [["miss-a", "miss-b"]]
+
+
+def test_vllm_descriptor_contains_resolved_backend_configuration(monkeypatch):
+    monkeypatch.setattr(inference.importlib_metadata, "version", lambda _name: "0.10.2")
+
+    model = prepare_model(
+        "VLLM/Qwen/Qwen3-8B",
+        max_tokens=32,
+        max_model_len=4096,
+        tensor_parallel_size=2,
+    )
+
+    assert model.descriptor["backend_version"] == "0.10.2"
+    assert model.descriptor["model_kwargs"] == {
+        "max_tokens": 32,
+        "max_model_len": 4096,
+        "tensor_parallel_size": 2,
+        "chat_template": None,
+    }
+    assert model.descriptor["sampling"] == {"temperature": 0.6, "top_p": 0.95}
+    assert prepare_model("OpenRouter/provider/model").descriptor is None

--- a/tests/test_inference_cache.py
+++ b/tests/test_inference_cache.py
@@ -58,12 +58,11 @@ def test_generate_and_judge_full_hits_do_not_materialize_models(tmp_path, monkey
         "instructions": instructions.tolist(),
         "completions_A": completions["completion"].tolist(),
         "completions_B": ["Baseline answer"],
-        "inference_cache": judgement_cache,
         "cache_metadata": metadata,
     }
 
     first = evaluate.annotate_battles(
-        judge_chat_model=prepare_model(judge_model),
+        judge_chat_model=prepare_model(judge_model, cache=judgement_cache),
         **arguments,
     )
 
@@ -78,7 +77,7 @@ def test_generate_and_judge_full_hits_do_not_materialize_models(tmp_path, monkey
         inference_cache=completion_cache,
     )
     second = evaluate.annotate_battles(
-        judge_chat_model=prepare_model(judge_model),
+        judge_chat_model=prepare_model(judge_model, cache=judgement_cache),
         **arguments,
     )
 
@@ -93,18 +92,16 @@ def test_mixed_hits_and_misses_preserve_order(tmp_path, monkeypatch):
         utils, "make_model", lambda *_args, **_kwargs: ConstantModel("cached")
     )
     do_inference(
-        prepare_model("Dummy/test-model"),
+        prepare_model("Dummy/test-model", cache=cache),
         ["hit"],
-        cache=cache,
         cache_metadata=[{"instruction_id": "hit"}],
     )
 
     backend = EchoModel()
     monkeypatch.setattr(utils, "make_model", lambda *_args, **_kwargs: backend)
     outputs = do_inference(
-        prepare_model("Dummy/test-model"),
+        prepare_model("Dummy/test-model", cache=cache),
         ["miss-a", "hit", "miss-b"],
-        cache=cache,
         cache_metadata=[
             {"instruction_id": "a"},
             {"instruction_id": "hit"},
@@ -116,12 +113,16 @@ def test_mixed_hits_and_misses_preserve_order(tmp_path, monkeypatch):
     assert backend.calls == [["miss-a", "miss-b"]]
 
 
-def test_vllm_descriptor_contains_resolved_backend_configuration(monkeypatch):
+def test_vllm_descriptor_contains_output_configuration(tmp_path, monkeypatch):
     monkeypatch.setattr(inference.importlib_metadata, "version", lambda _name: "0.10.2")
+    cache = InferenceCache(tmp_path, "completions", "arena-hard")
 
     model = prepare_model(
         "VLLM/Qwen/Qwen3-8B",
         max_tokens=32,
+        cache=cache,
+        enforce_eager=True,
+        gpu_memory_utilization=0.9,
         max_model_len=4096,
         tensor_parallel_size=2,
     )
@@ -130,8 +131,7 @@ def test_vllm_descriptor_contains_resolved_backend_configuration(monkeypatch):
     assert model.descriptor["model_kwargs"] == {
         "max_tokens": 32,
         "max_model_len": 4096,
-        "tensor_parallel_size": 2,
         "chat_template": None,
     }
     assert model.descriptor["sampling"] == {"temperature": 0.6, "top_p": 0.95}
-    assert prepare_model("OpenRouter/provider/model").descriptor is None
+    assert prepare_model("OpenRouter/provider/model", cache=cache).descriptor is None


### PR DESCRIPTION
# Description

> [!NOTE]
> WIP: This cache stack is on hold until the task-YAML stack ending in #93 merges. The current implementation is not final and may change when it is adapted to the merged task runtime.

Moves cache lookup and writes to `do_inference`.

- `PreparedModel` defers backend construction until an input misses the cache.
- Cache identity combines the canonical model input with the validated model descriptor.
- Mixed batches run only missing inputs and restore the original output order.
- Completion and judgement cache classes define their own stored rows.

This is stacked on #94.
