### PR TITLE
Cache: WIP (3/7) Cache inference across model providers

### DIFF
--- a/judgearena/inference.py
+++ b/judgearena/inference.py
@@ -114,6 +114,8 @@ def build_model_descriptor(
 
     Omitted hosted settings retain provider defaults. LlamaCpp model identity
     remains path-based, so moving the same GGUF creates a different cache cell.
+    Local-engine versions must be installed to derive their cache keys. VLLM
+    tokenizer-template changes require a distinct model revision or template.
     """
     input_mode = provider_input_mode(provider, resolved_kwargs)
     if input_mode is None:
@@ -153,7 +155,6 @@ class PreparedModel:
 
     model_spec: str
     descriptor: dict[str, Any] | None
-    input_mode: InputMode | None
     factory: Callable[[], Any]
     cache: InferenceCache | None = None
     _model: Any = field(default=None, init=False, repr=False)

--- a/judgearena/inference.py
+++ b/judgearena/inference.py
@@ -7,7 +7,7 @@ from collections.abc import Callable
 from dataclasses import dataclass, field
 from importlib import metadata as importlib_metadata
 from pathlib import Path
-from typing import Any, ClassVar
+from typing import Any, ClassVar, Literal
 
 import pandas as pd
 
@@ -23,6 +23,15 @@ from judgearena.cache_sqlite import (
 )
 
 _ROLE_MAP = {"human": "user", "ai": "assistant", "system": "system"}
+_CHAT_PROVIDERS = {"ChatOpenAI", "Dummy", "OpenRouter", "VLLM"}
+_TEXT_PROVIDERS = {"LlamaCpp", "OpenAI", "Together"}
+_CREDENTIAL_KEYS = {
+    "api_key",
+    "authorization",
+    "openai_api_key",
+    "token",
+    "together_api_key",
+}
 VLLM_TEMPERATURE = 0.6
 VLLM_TOP_P = 0.95
 VLLM_EXECUTION_ONLY_KWARGS = {
@@ -31,42 +40,90 @@ VLLM_EXECUTION_ONLY_KWARGS = {
     "tensor_parallel_size",
 }
 
+InputMode = Literal["auto", "chat", "text"]
 
-def canonicalize_chat_input(input_item: Any) -> str:
-    """Serialize a logical model input for content-addressed cache lookup."""
+
+def provider_input_mode(
+    provider: str, resolved_kwargs: dict[str, Any] | None = None
+) -> InputMode | None:
+    if provider == "VLLM" and not (resolved_kwargs or {}).get("chat_template"):
+        return "auto"
+    if provider in _CHAT_PROVIDERS:
+        return "chat"
+    if provider in _TEXT_PROVIDERS:
+        return "text"
+    return None
+
+
+def _canonical_messages(input_item: Any) -> list[dict[str, Any]]:
     if isinstance(input_item, str):
-        payload = {"type": "text", "text": input_item}
-    elif hasattr(input_item, "to_messages"):
-        payload = {
-            "type": "messages",
-            "messages": [
-                {
-                    "role": _ROLE_MAP.get(message.type, message.type),
-                    "content": message.content,
-                }
-                for message in input_item.to_messages()
-            ],
-        }
+        return [{"role": "user", "content": input_item}]
+    if hasattr(input_item, "to_messages"):
+        return [
+            {
+                "role": _ROLE_MAP.get(message.type, message.type),
+                "content": message.content,
+            }
+            for message in input_item.to_messages()
+        ]
+    raise TypeError(f"Unsupported inference input: {type(input_item)!r}")
+
+
+def _canonical_text(input_item: Any) -> str:
+    if isinstance(input_item, str):
+        return input_item
+    if hasattr(input_item, "to_string"):
+        return input_item.to_string()
+    raise TypeError(f"Unsupported inference input: {type(input_item)!r}")
+
+
+def canonicalize_model_input(input_item: Any, input_mode: InputMode) -> str:
+    """Serialize the exact chat or flattened text input seen by the backend."""
+    if input_mode == "text":
+        payload = {"type": "text", "text": _canonical_text(input_item)}
+    elif input_mode == "chat":
+        payload = {"type": "messages", "messages": _canonical_messages(input_item)}
     else:
-        raise TypeError(f"Unsupported inference input: {type(input_item)!r}")
+        payload = {
+            "type": "auto",
+            "messages": _canonical_messages(input_item),
+            "text": _canonical_text(input_item),
+        }
     return stable_json_dumps(payload)
+
+
+def _without_credentials(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {
+            key: _without_credentials(item)
+            for key, item in value.items()
+            if str(key).lower().replace("-", "_") not in _CREDENTIAL_KEYS
+        }
+    if isinstance(value, (list, tuple)):
+        return [_without_credentials(item) for item in value]
+    return value
 
 
 def build_model_descriptor(
     provider: str,
     model_name: str,
     resolved_kwargs: dict[str, Any],
+    endpoint: str | None = None,
 ) -> dict[str, Any] | None:
-    """Describe output-affecting settings without constructing the backend."""
-    if provider not in {"Dummy", "VLLM"}:
+    """Describe the configured request without constructing the backend.
+
+    Omitted hosted settings retain provider defaults. LlamaCpp model identity
+    remains path-based, so moving the same GGUF creates a different cache cell.
+    """
+    input_mode = provider_input_mode(provider, resolved_kwargs)
+    if input_mode is None:
         return None
 
-    backend_version = importlib_metadata.version("vllm") if provider == "VLLM" else None
-    descriptor_kwargs = resolved_kwargs
+    descriptor_kwargs = _without_credentials(resolved_kwargs)
     if provider == "VLLM":
         descriptor_kwargs = {
             key: value
-            for key, value in resolved_kwargs.items()
+            for key, value in descriptor_kwargs.items()
             if key not in VLLM_EXECUTION_ONLY_KWARGS
         }
 
@@ -74,14 +131,19 @@ def build_model_descriptor(
         "schema_version": "judgearena-inference-cache/v1",
         "provider": provider,
         "model": model_name,
-        "backend_version": backend_version,
+        "input_mode": input_mode,
         "model_kwargs": descriptor_kwargs,
     }
     if provider == "VLLM":
+        descriptor["backend_version"] = importlib_metadata.version("vllm")
         descriptor["sampling"] = {
             "temperature": VLLM_TEMPERATURE,
             "top_p": VLLM_TOP_P,
         }
+    elif provider == "LlamaCpp":
+        descriptor["backend_version"] = importlib_metadata.version("llama-cpp-python")
+    if endpoint is not None:
+        descriptor["endpoint"] = endpoint.rstrip("/")
     return descriptor
 
 
@@ -91,6 +153,7 @@ class PreparedModel:
 
     model_spec: str
     descriptor: dict[str, Any] | None
+    input_mode: InputMode | None
     factory: Callable[[], Any]
     cache: InferenceCache | None = None
     _model: Any = field(default=None, init=False, repr=False)

--- a/judgearena/inference.py
+++ b/judgearena/inference.py
@@ -25,13 +25,6 @@ from judgearena.cache_sqlite import (
 _ROLE_MAP = {"human": "user", "ai": "assistant", "system": "system"}
 _CHAT_PROVIDERS = {"ChatOpenAI", "Dummy", "OpenRouter", "VLLM"}
 _TEXT_PROVIDERS = {"LlamaCpp", "OpenAI", "Together"}
-_CREDENTIAL_KEYS = {
-    "api_key",
-    "authorization",
-    "openai_api_key",
-    "token",
-    "together_api_key",
-}
 VLLM_TEMPERATURE = 0.6
 VLLM_TOP_P = 0.95
 VLLM_EXECUTION_ONLY_KWARGS = {
@@ -92,18 +85,6 @@ def canonicalize_model_input(input_item: Any, input_mode: InputMode) -> str:
     return stable_json_dumps(payload)
 
 
-def _without_credentials(value: Any) -> Any:
-    if isinstance(value, dict):
-        return {
-            key: _without_credentials(item)
-            for key, item in value.items()
-            if str(key).lower().replace("-", "_") not in _CREDENTIAL_KEYS
-        }
-    if isinstance(value, (list, tuple)):
-        return [_without_credentials(item) for item in value]
-    return value
-
-
 def build_model_descriptor(
     provider: str,
     model_name: str,
@@ -121,7 +102,7 @@ def build_model_descriptor(
     if input_mode is None:
         return None
 
-    descriptor_kwargs = _without_credentials(resolved_kwargs)
+    descriptor_kwargs = resolved_kwargs.copy()
     if provider == "VLLM":
         descriptor_kwargs = {
             key: value

--- a/judgearena/utils.py
+++ b/judgearena/utils.py
@@ -22,7 +22,6 @@ from judgearena.inference import (
     PreparedModel,
     build_model_descriptor,
     canonicalize_model_input,
-    provider_input_mode,
 )
 from judgearena.instruction_dataset.arena_hard import (
     download_arena_hard,
@@ -235,10 +234,8 @@ def do_inference(
     if cache_metadata is None or len(cache_metadata) != len(inputs):
         raise ValueError("cache_metadata must contain one row per inference input.")
 
-    assert chat_model.input_mode is not None
-    input_texts = [
-        canonicalize_model_input(item, chat_model.input_mode) for item in inputs
-    ]
+    input_mode = chat_model.descriptor["input_mode"]
+    input_texts = [canonicalize_model_input(item, input_mode) for item in inputs]
 
     input_hashes = [input_hash(input_text) for input_text in input_texts]
     with cache.open_store(chat_model) as store:
@@ -515,7 +512,6 @@ def prepare_model(
     provider, model_name, resolved_kwargs = _resolve_model_config(
         model, max_tokens, engine_kwargs
     )
-    input_mode = provider_input_mode(provider, resolved_kwargs)
     descriptor = (
         build_model_descriptor(
             provider,
@@ -526,6 +522,13 @@ def prepare_model(
         if cache is not None
         else None
     )
+    routing = (resolved_kwargs.get("extra_body") or {}).get("provider") or {}
+    if (
+        cache is not None
+        and provider == "OpenRouter"
+        and (not routing.get("order") or routing.get("allow_fallbacks") is not False)
+    ):
+        logger.warning("OpenRouter cache identity uses unpinned provider routing.")
     if cache is not None and descriptor is None:
         logger.warning(
             "Caching is not supported for %s; running uncached.",
@@ -535,7 +538,6 @@ def prepare_model(
     return PreparedModel(
         model_spec=model,
         descriptor=descriptor,
-        input_mode=input_mode,
         factory=lambda: make_model(
             model,
             max_tokens=max_tokens,

--- a/judgearena/utils.py
+++ b/judgearena/utils.py
@@ -21,7 +21,8 @@ from judgearena.inference import (
     InferenceCache,
     PreparedModel,
     build_model_descriptor,
-    canonicalize_chat_input,
+    canonicalize_model_input,
+    provider_input_mode,
 )
 from judgearena.instruction_dataset.arena_hard import (
     download_arena_hard,
@@ -234,7 +235,10 @@ def do_inference(
     if cache_metadata is None or len(cache_metadata) != len(inputs):
         raise ValueError("cache_metadata must contain one row per inference input.")
 
-    input_texts = [canonicalize_chat_input(item) for item in inputs]
+    assert chat_model.input_mode is not None
+    input_texts = [
+        canonicalize_model_input(item, chat_model.input_mode) for item in inputs
+    ]
 
     input_hashes = [input_hash(input_text) for input_text in input_texts]
     with cache.open_store(chat_model) as store:
@@ -452,6 +456,29 @@ class ChatVLLM:
         )
 
 
+_REMOTE_ENDPOINTS = {
+    "ChatOpenAI": "https://api.openai.com/v1",
+    "OpenAI": "https://api.openai.com/v1",
+    "OpenRouter": "https://openrouter.ai/api/v1",
+    "Together": "https://api.together.xyz/v1/completions",
+}
+
+
+def _resolve_model_endpoint(provider: str, resolved_kwargs: dict) -> str | None:
+    if provider == "OpenRouter":
+        return _REMOTE_ENDPOINTS[provider]
+    for key in ("base_url", "openai_api_base", "together_api_base"):
+        if resolved_kwargs.get(key):
+            return str(resolved_kwargs[key])
+    if provider in {"ChatOpenAI", "OpenAI"}:
+        return (
+            os.getenv("OPENAI_BASE_URL")
+            or os.getenv("OPENAI_API_BASE")
+            or _REMOTE_ENDPOINTS[provider]
+        )
+    return _REMOTE_ENDPOINTS.get(provider)
+
+
 def _resolve_model_config(
     model: str,
     max_tokens: int | None,
@@ -488,8 +515,14 @@ def prepare_model(
     provider, model_name, resolved_kwargs = _resolve_model_config(
         model, max_tokens, engine_kwargs
     )
+    input_mode = provider_input_mode(provider, resolved_kwargs)
     descriptor = (
-        build_model_descriptor(provider, model_name, resolved_kwargs)
+        build_model_descriptor(
+            provider,
+            model_name,
+            resolved_kwargs,
+            endpoint=_resolve_model_endpoint(provider, resolved_kwargs),
+        )
         if cache is not None
         else None
     )
@@ -502,6 +535,7 @@ def prepare_model(
     return PreparedModel(
         model_spec=model,
         descriptor=descriptor,
+        input_mode=input_mode,
         factory=lambda: make_model(
             model,
             max_tokens=max_tokens,

--- a/tests/test_inference_cache.py
+++ b/tests/test_inference_cache.py
@@ -166,6 +166,8 @@ def test_supported_provider_descriptors(
 ):
     versions = {"vllm": "0.10.2", "llama-cpp-python": "0.3.0"}
     monkeypatch.setattr(inference.importlib_metadata, "version", versions.__getitem__)
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENAI_API_BASE", raising=False)
     cache = CompletionInferenceCache(tmp_path, "arena-hard")
 
     descriptor = prepare_model(model_spec, cache=cache).descriptor
@@ -174,19 +176,25 @@ def test_supported_provider_descriptors(
     assert descriptor.get("endpoint") == expected_endpoint
 
 
-def test_hosted_descriptor_hashes_routing_endpoint_without_credentials(tmp_path):
+def test_hosted_descriptor_hashes_routing_endpoint_without_credentials(
+    tmp_path, monkeypatch, caplog
+):
     cache = CompletionInferenceCache(tmp_path, "arena-hard")
     unpinned = prepare_model(
         "OpenRouter/org/model",
         cache=cache,
         api_key="secret",
     ).descriptor
+    assert "uses unpinned provider routing" in caplog.text
+
+    caplog.clear()
     pinned = prepare_model(
         "OpenRouter/org/model",
         cache=cache,
         api_key="secret",
         extra_body={"provider": {"order": ["Together"], "allow_fallbacks": False}},
     ).descriptor
+    assert "uses unpinned provider routing" not in caplog.text
 
     assert unpinned != pinned
     assert "secret" not in json.dumps(pinned)
@@ -199,6 +207,19 @@ def test_hosted_descriptor_hashes_routing_endpoint_without_credentials(tmp_path)
         base_url="https://gateway.example/v1/",
     ).descriptor
     assert gateway["endpoint"] == "https://gateway.example/v1"
+
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://ambient.example/v1")
+    ambient = prepare_model("ChatOpenAI/model", cache=cache).descriptor
+    assert ambient["endpoint"] == "https://ambient.example/v1"
+
+
+def test_unsupported_provider_runs_uncached(tmp_path, caplog):
+    cache = CompletionInferenceCache(tmp_path, "arena-hard")
+
+    model = prepare_model("Unsupported/model", cache=cache)
+
+    assert model.descriptor is None
+    assert "Caching is not supported" in caplog.text
 
 
 @pytest.mark.parametrize(

--- a/tests/test_inference_cache.py
+++ b/tests/test_inference_cache.py
@@ -176,14 +176,11 @@ def test_supported_provider_descriptors(
     assert descriptor.get("endpoint") == expected_endpoint
 
 
-def test_hosted_descriptor_hashes_routing_endpoint_without_credentials(
-    tmp_path, monkeypatch, caplog
-):
+def test_hosted_descriptor_hashes_routing_and_endpoint(tmp_path, monkeypatch, caplog):
     cache = CompletionInferenceCache(tmp_path, "arena-hard")
     unpinned = prepare_model(
         "OpenRouter/org/model",
         cache=cache,
-        api_key="secret",
     ).descriptor
     assert "uses unpinned provider routing" in caplog.text
 
@@ -191,14 +188,11 @@ def test_hosted_descriptor_hashes_routing_endpoint_without_credentials(
     pinned = prepare_model(
         "OpenRouter/org/model",
         cache=cache,
-        api_key="secret",
         extra_body={"provider": {"order": ["Together"], "allow_fallbacks": False}},
     ).descriptor
     assert "uses unpinned provider routing" not in caplog.text
 
     assert unpinned != pinned
-    assert "secret" not in json.dumps(pinned)
-    assert "api_key" not in pinned["model_kwargs"]
     assert pinned["model_kwargs"]["extra_body"]["provider"]["order"] == ["Together"]
 
     gateway = prepare_model(

--- a/tests/test_inference_cache.py
+++ b/tests/test_inference_cache.py
@@ -1,10 +1,19 @@
+import json
+
 import pandas as pd
+import pytest
+from langchain_core.prompts import ChatPromptTemplate
 
 import judgearena.evaluate as evaluate
 import judgearena.generate as generate
 import judgearena.inference as inference
 import judgearena.utils as utils
-from judgearena.inference import CompletionInferenceCache, JudgementInferenceCache
+from judgearena.inference import (
+    CompletionInferenceCache,
+    JudgementInferenceCache,
+    canonicalize_model_input,
+    provider_input_mode,
+)
 from judgearena.utils import do_inference, prepare_model
 
 
@@ -134,4 +143,77 @@ def test_vllm_descriptor_contains_output_configuration(tmp_path, monkeypatch):
         "chat_template": None,
     }
     assert model.descriptor["sampling"] == {"temperature": 0.6, "top_p": 0.95}
-    assert prepare_model("OpenRouter/provider/model", cache=cache).descriptor is None
+
+
+@pytest.mark.parametrize(
+    ("model_spec", "expected_mode", "expected_endpoint"),
+    [
+        ("Dummy/model", "chat", None),
+        ("VLLM/org/model", "auto", None),
+        ("OpenRouter/org/model", "chat", "https://openrouter.ai/api/v1"),
+        ("ChatOpenAI/model", "chat", "https://api.openai.com/v1"),
+        ("OpenAI/model", "text", "https://api.openai.com/v1"),
+        ("Together/org/model", "text", "https://api.together.xyz/v1/completions"),
+        ("LlamaCpp/./models/model.gguf", "text", None),
+    ],
+)
+def test_supported_provider_descriptors(
+    tmp_path,
+    monkeypatch,
+    model_spec,
+    expected_mode,
+    expected_endpoint,
+):
+    versions = {"vllm": "0.10.2", "llama-cpp-python": "0.3.0"}
+    monkeypatch.setattr(inference.importlib_metadata, "version", versions.__getitem__)
+    cache = CompletionInferenceCache(tmp_path, "arena-hard")
+
+    descriptor = prepare_model(model_spec, cache=cache).descriptor
+
+    assert descriptor["input_mode"] == expected_mode
+    assert descriptor.get("endpoint") == expected_endpoint
+
+
+def test_hosted_descriptor_hashes_routing_endpoint_without_credentials(tmp_path):
+    cache = CompletionInferenceCache(tmp_path, "arena-hard")
+    unpinned = prepare_model(
+        "OpenRouter/org/model",
+        cache=cache,
+        api_key="secret",
+    ).descriptor
+    pinned = prepare_model(
+        "OpenRouter/org/model",
+        cache=cache,
+        api_key="secret",
+        extra_body={"provider": {"order": ["Together"], "allow_fallbacks": False}},
+    ).descriptor
+
+    assert unpinned != pinned
+    assert "secret" not in json.dumps(pinned)
+    assert "api_key" not in pinned["model_kwargs"]
+    assert pinned["model_kwargs"]["extra_body"]["provider"]["order"] == ["Together"]
+
+    gateway = prepare_model(
+        "ChatOpenAI/model",
+        cache=cache,
+        base_url="https://gateway.example/v1/",
+    ).descriptor
+    assert gateway["endpoint"] == "https://gateway.example/v1"
+
+
+@pytest.mark.parametrize(
+    ("provider", "expected_type"),
+    [("OpenRouter", "messages"), ("Together", "text"), ("VLLM", "auto")],
+)
+def test_input_canonicalization_matches_provider_mode(provider, expected_type):
+    prompt = ChatPromptTemplate.from_messages(
+        [("system", "System"), ("user", "Question")]
+    ).invoke({})
+
+    payload = json.loads(
+        canonicalize_model_input(prompt, provider_input_mode(provider))
+    )
+
+    assert payload["type"] == expected_type
+    if expected_type in {"auto", "text"}:
+        assert payload["text"] == prompt.to_string()


### PR DESCRIPTION
# Description

> [!NOTE]
> WIP: This cache stack is on hold until the task-YAML stack ending in #93 merges. The current implementation is not final and may change when it is adapted to the merged task runtime.

Extends cache descriptors and input hashing across the providers exposed by `make_model`.

- Records whether the backend receives chat messages, flattened text or VLLM auto input.
- Includes hosted endpoints, OpenRouter routing and output-affecting model settings.
- Excludes VLLM execution-only settings from the descriptor.
- Warns when OpenRouter routing is unpinned and keeps unsupported providers uncached.

This is stacked on #95.
