### PR TITLE
Cache: WIP (6/7) Synchronize inference caches through Hugging Face

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,40 @@ judgearena \
 
 While any key in `--engine_kwargs` is forwarded to the underlying engine (e.g. `vllm.LLM`, `LlamaCpp`, `ChatOpenAI`), existing dedicated flags such as `--max_model_len` and `--chat_template` have higher precedence.
 
+### Inference Cache
+
+Set `--store_root` to cache model completions and raw judge outputs:
+
+```bash
+judgearena \
+  --task arena-hard-v2.0 \
+  --model_A VLLM/Qwen/Qwen2.5-0.5B-Instruct \
+  --model_B VLLM/Qwen/Qwen2.5-1.5B-Instruct \
+  --judge_model VLLM/Qwen/Qwen2.5-32B-Instruct-GPTQ-Int8 \
+  --store_root ./cache
+```
+
+Cache synchronization with a Hugging Face dataset repository is explicit and separate from benchmark execution. Fetch or push one role and task with `judgearena-cache`:
+
+```bash
+judgearena-cache \
+  --action fetch \
+  --store_root ./cache \
+  --hf_repo organization/cache-dataset \
+  --kind completions \
+  --task arena-hard-v2.0 \
+  --model VLLM/Qwen/Qwen2.5-0.5B-Instruct
+
+judgearena-cache \
+  --action push \
+  --store_root ./cache \
+  --hf_repo organization/cache-dataset \
+  --kind judgements \
+  --task arena-hard-v2.0
+```
+
+`--kind` is either `completions` or `judgements`; `--model` is optional. Fetch merges matching remote rows into the local cache. Push first merges the current remote folder, then uploads its `metadata.json` and SQLite database together. When another writer updates the same folder concurrently, the command fetches the new remote rows and retries.
+
 ## 🎨 Model Specification
 
 Models are specified using the format: `{LangChain Backend}/{Model Path}`

--- a/judgearena/cache_hf.py
+++ b/judgearena/cache_hf.py
@@ -1,0 +1,295 @@
+"""Filtered Hugging Face synchronization for inference-cache folders."""
+
+from __future__ import annotations
+
+import argparse
+import tempfile
+from pathlib import Path, PurePosixPath
+from typing import Any
+from urllib.parse import quote
+
+from huggingface_hub import CommitOperationAdd, HfApi, hf_hub_download
+from huggingface_hub.errors import HfHubHTTPError
+
+from judgearena.cache_sqlite import (
+    COMPLETION_DB_NAME,
+    DESCRIPTOR_FILENAME,
+    JUDGEMENT_DB_NAME,
+    CacheKind,
+    CompletionCache,
+    JudgementCache,
+    cache_model_folder,
+    read_descriptor,
+    write_descriptor,
+)
+
+_DB_NAMES = {
+    "completions": COMPLETION_DB_NAME,
+    "judgements": JUDGEMENT_DB_NAME,
+}
+_STORE_TYPES = {
+    "completions": CompletionCache,
+    "judgements": JudgementCache,
+}
+
+
+def _cache_prefix(kind: CacheKind, task: str, model_spec: str | None) -> str:
+    if model_spec is not None:
+        return cache_model_folder("", kind, task, model_spec).as_posix() + "/"
+    return f"{kind}/{quote(task, safe='')}/"
+
+
+def list_remote_cache_folders(
+    api: HfApi,
+    hf_repo: str,
+    *,
+    kind: CacheKind,
+    task: str,
+    model_spec: str | None = None,
+    revision: str | None = None,
+) -> list[str]:
+    """List complete remote cache folders matching the supplied filters."""
+    files = set(
+        api.list_repo_files(
+            repo_id=hf_repo,
+            repo_type="dataset",
+            revision=revision,
+        )
+    )
+    prefix = _cache_prefix(kind, task, model_spec)
+    db_name = _DB_NAMES[kind]
+    return sorted(
+        {
+            str(PurePosixPath(path).parent)
+            for path in files
+            if path.startswith(prefix)
+            and path.endswith(f"/{DESCRIPTOR_FILENAME}")
+            and f"{PurePosixPath(path).parent}/{db_name}" in files
+        }
+    )
+
+
+def list_local_cache_folders(
+    store_root: Path,
+    *,
+    kind: CacheKind,
+    task: str,
+    model_spec: str | None = None,
+) -> list[Path]:
+    """List complete local cache folders matching the supplied filters."""
+    base = (
+        cache_model_folder(store_root, kind, task, model_spec)
+        if model_spec is not None
+        else store_root / kind / quote(task, safe="")
+    )
+    if not base.exists():
+        return []
+    db_name = _DB_NAMES[kind]
+    return sorted(
+        metadata.parent
+        for metadata in base.rglob(DESCRIPTOR_FILENAME)
+        if (metadata.parent / db_name).exists()
+    )
+
+
+def _download_cache_folder(
+    hf_repo: str,
+    repo_folder: str,
+    *,
+    kind: CacheKind,
+    revision: str,
+    local_dir: Path,
+) -> Path:
+    for filename in (DESCRIPTOR_FILENAME, _DB_NAMES[kind]):
+        hf_hub_download(
+            repo_id=hf_repo,
+            repo_type="dataset",
+            filename=f"{repo_folder}/{filename}",
+            revision=revision,
+            local_dir=local_dir,
+        )
+    return local_dir / repo_folder
+
+
+def merge_cache_folder(
+    local_folder: Path,
+    remote_folder: Path,
+    *,
+    kind: CacheKind,
+) -> int:
+    """Merge a downloaded folder into a local cache using row provenance."""
+    remote_descriptor = read_descriptor(remote_folder)
+    local_metadata = local_folder / DESCRIPTOR_FILENAME
+    if local_metadata.exists():
+        if read_descriptor(local_folder) != remote_descriptor:
+            raise ValueError(f"Descriptor mismatch for cache folder {local_folder}.")
+    else:
+        write_descriptor(local_folder, remote_descriptor)
+
+    db_name = _DB_NAMES[kind]
+    store = _STORE_TYPES[kind](local_folder / db_name)
+    return store.merge_from(remote_folder / db_name)
+
+
+def fetch_cache(
+    store_root: Path,
+    hf_repo: str,
+    *,
+    kind: CacheKind,
+    task: str,
+    model_spec: str | None = None,
+    api: HfApi | None = None,
+) -> int:
+    """Fetch and merge matching cache folders from a dataset repository."""
+    api = api or HfApi()
+    revision = api.repo_info(repo_id=hf_repo, repo_type="dataset").sha
+    folders = list_remote_cache_folders(
+        api,
+        hf_repo,
+        kind=kind,
+        task=task,
+        model_spec=model_spec,
+        revision=revision,
+    )
+    for repo_folder in folders:
+        with tempfile.TemporaryDirectory() as temporary_dir:
+            remote_folder = _download_cache_folder(
+                hf_repo,
+                repo_folder,
+                kind=kind,
+                revision=revision,
+                local_dir=Path(temporary_dir),
+            )
+            merge_cache_folder(
+                store_root / repo_folder,
+                remote_folder,
+                kind=kind,
+            )
+    return len(folders)
+
+
+def _is_commit_conflict(error: HfHubHTTPError) -> bool:
+    return error.response is not None and error.response.status_code in {409, 412}
+
+
+def push_cache_folder(
+    store_root: Path,
+    local_folder: Path,
+    hf_repo: str,
+    *,
+    kind: CacheKind,
+    api: HfApi | None = None,
+    max_retries: int = 3,
+) -> Any:
+    """Pull, merge, and atomically push one folder with optimistic retry."""
+    api = api or HfApi()
+    repo_folder = local_folder.relative_to(store_root).as_posix()
+    db_name = _DB_NAMES[kind]
+    read_descriptor(local_folder)
+
+    for attempt in range(max_retries):
+        parent_commit = api.repo_info(repo_id=hf_repo, repo_type="dataset").sha
+        files = set(
+            api.list_repo_files(
+                repo_id=hf_repo,
+                repo_type="dataset",
+                revision=parent_commit,
+            )
+        )
+        if f"{repo_folder}/{DESCRIPTOR_FILENAME}" in files:
+            with tempfile.TemporaryDirectory() as temporary_dir:
+                remote_folder = _download_cache_folder(
+                    hf_repo,
+                    repo_folder,
+                    kind=kind,
+                    revision=parent_commit,
+                    local_dir=Path(temporary_dir),
+                )
+                merge_cache_folder(local_folder, remote_folder, kind=kind)
+
+        operations = [
+            CommitOperationAdd(
+                path_in_repo=f"{repo_folder}/{DESCRIPTOR_FILENAME}",
+                path_or_fileobj=local_folder / DESCRIPTOR_FILENAME,
+            ),
+            CommitOperationAdd(
+                path_in_repo=f"{repo_folder}/{db_name}",
+                path_or_fileobj=local_folder / db_name,
+            ),
+        ]
+        try:
+            return api.create_commit(
+                repo_id=hf_repo,
+                repo_type="dataset",
+                operations=operations,
+                commit_message=f"Sync JudgeArena cache {repo_folder}",
+                parent_commit=parent_commit,
+            )
+        except HfHubHTTPError as error:
+            if not _is_commit_conflict(error) or attempt == max_retries - 1:
+                raise
+
+
+def push_cache(
+    store_root: Path,
+    hf_repo: str,
+    *,
+    kind: CacheKind,
+    task: str,
+    model_spec: str | None = None,
+    api: HfApi | None = None,
+    max_retries: int = 3,
+) -> list[Any]:
+    """Push all matching local cache folders to a dataset repository."""
+    api = api or HfApi()
+    return [
+        push_cache_folder(
+            store_root,
+            folder,
+            hf_repo,
+            kind=kind,
+            api=api,
+            max_retries=max_retries,
+        )
+        for folder in list_local_cache_folders(
+            store_root,
+            kind=kind,
+            task=task,
+            model_spec=model_spec,
+        )
+    ]
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Sync JudgeArena inference caches.")
+    parser.add_argument("--action", choices=["fetch", "push"], required=True)
+    parser.add_argument("--store_root", type=Path, required=True)
+    parser.add_argument("--hf_repo", required=True)
+    parser.add_argument("--kind", choices=["completions", "judgements"], required=True)
+    parser.add_argument("--task", required=True)
+    parser.add_argument(
+        "--model",
+        dest="model_spec",
+        help="Optional full Provider/model filter.",
+    )
+    return parser
+
+
+def cli(argv: list[str] | None = None) -> None:
+    args = _build_parser().parse_args(argv)
+    kwargs = {
+        "kind": args.kind,
+        "task": args.task,
+        "model_spec": args.model_spec,
+    }
+    if args.action == "fetch":
+        count = fetch_cache(args.store_root, args.hf_repo, **kwargs)
+    else:
+        count = len(
+            push_cache(
+                args.store_root,
+                args.hf_repo,
+                **kwargs,
+            )
+        )
+    print(f"{args.action.capitalize()}ed {count} cache folders.")

--- a/judgearena/cache_sqlite.py
+++ b/judgearena/cache_sqlite.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+import os
 import sqlite3
 import uuid
 from datetime import UTC, datetime
@@ -39,6 +40,17 @@ def cache_folder(
     model_spec: str,
     descriptor: dict[str, Any],
 ) -> Path:
+    return cache_model_folder(store_root, kind, task, model_spec) / descriptor_hash(
+        descriptor
+    )
+
+
+def cache_model_folder(
+    store_root: Path | str,
+    kind: CacheKind,
+    task: str,
+    model_spec: str,
+) -> Path:
     provider, model = model_spec.split("/", 1)
     return (
         Path(store_root)
@@ -46,7 +58,6 @@ def cache_folder(
         / quote(task, safe="")
         / quote(provider, safe="")
         / quote(model, safe="")
-        / descriptor_hash(descriptor)
     )
 
 
@@ -60,6 +71,13 @@ def write_descriptor(folder: Path, descriptor: dict[str, Any]) -> Path:
 
     path.write_text(json.dumps(descriptor, indent=2, sort_keys=True) + "\n")
     return path
+
+
+def read_descriptor(folder: Path) -> dict[str, Any]:
+    descriptor = json.loads((folder / DESCRIPTOR_FILENAME).read_text())
+    if folder.name != descriptor_hash(descriptor):
+        raise ValueError(f"Descriptor hash does not match cache folder {folder}.")
+    return descriptor
 
 
 class _SQLiteCache:
@@ -107,6 +125,31 @@ class _SQLiteCache:
         with self._connect() as conn:
             cursor = conn.execute(f"DELETE FROM {self.table}{where}", params)
         return cursor.rowcount
+
+    def merge_from(self, other_db: Path) -> int:
+        """Atomically merge another cache database using pushed_at last-write-wins."""
+        self.close()
+        frames = []
+        for db_path in (other_db, self.db_path):
+            if db_path.exists():
+                with sqlite3.connect(db_path) as conn:
+                    frames.append(pd.read_sql(f"SELECT * FROM {self.table}", conn))
+        rows = (
+            pd.concat(frames, ignore_index=True)
+            .sort_values("pushed_at", kind="stable")
+            .drop_duplicates("input_hash", keep="last")
+        )
+
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        temporary_db = self.db_path.with_name(f".{self.db_path.name}.{uuid.uuid4()}")
+        try:
+            with sqlite3.connect(temporary_db) as conn:
+                conn.execute(self.schema)
+                rows.to_sql(self.table, conn, if_exists="append", index=False)
+            os.replace(temporary_db, self.db_path)
+        finally:
+            temporary_db.unlink(missing_ok=True)
+        return len(rows)
 
     def close(self) -> None:
         if self._conn is not None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project.scripts]
 judgearena = "judgearena.cli:cli"
+judgearena-cache = "judgearena.cache_hf:cli"
 
 [project]
 name = "judgearena"

--- a/tests/test_cache_hf.py
+++ b/tests/test_cache_hf.py
@@ -1,0 +1,157 @@
+import shutil
+from types import SimpleNamespace
+
+import pandas as pd
+from huggingface_hub.errors import HfHubHTTPError
+from requests import Response
+
+import judgearena.cache_hf as cache_hf
+from judgearena.cache_sqlite import (
+    COMPLETION_DB_NAME,
+    CompletionCache,
+    cache_folder,
+    write_descriptor,
+)
+
+DESCRIPTOR = {"provider": "Dummy", "model": "model"}
+
+
+def _create_cache(root, task, model, prompts):
+    folder = cache_folder(root, "completions", task, model, DESCRIPTOR)
+    write_descriptor(folder, DESCRIPTOR)
+    rows = pd.DataFrame(
+        [
+            {
+                "input_text": prompt,
+                "completion": f"answer:{prompt}",
+                "benchmark": task,
+                "instruction_id": str(index),
+                "model": model,
+            }
+            for index, prompt in enumerate(prompts)
+        ]
+    )
+    with CompletionCache(folder / COMPLETION_DB_NAME) as cache:
+        cache.save(rows, pushed_by="test")
+    return folder
+
+
+class FakeHub:
+    def __init__(self, remote_root):
+        self.remote_root = remote_root
+        self.sha = "head-0"
+        self.commits = []
+        self.on_first_commit = None
+
+    def repo_info(self, **_kwargs):
+        return SimpleNamespace(sha=self.sha)
+
+    def list_repo_files(self, **_kwargs):
+        return [
+            path.relative_to(self.remote_root).as_posix()
+            for path in self.remote_root.rglob("*")
+            if path.is_file()
+        ]
+
+    def create_commit(self, *, operations, parent_commit, **_kwargs):
+        operations = list(operations)
+        self.commits.append((parent_commit, operations))
+        if self.on_first_commit is not None:
+            callback, self.on_first_commit = self.on_first_commit, None
+            callback()
+            self.sha = "head-1"
+            response = Response()
+            response.status_code = 409
+            raise HfHubHTTPError("conflict", response=response)
+        for operation in operations:
+            destination = self.remote_root / operation.path_in_repo
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(operation.path_or_fileobj, destination)
+        self.sha = "head-2"
+        return SimpleNamespace(oid=self.sha)
+
+
+def _stub_download(monkeypatch, remote_root):
+    def download(*, filename, local_dir, **_kwargs):
+        destination = local_dir / filename
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(remote_root / filename, destination)
+        return str(destination)
+
+    monkeypatch.setattr(cache_hf, "hf_hub_download", download)
+
+
+def test_fetch_cache_applies_task_and_model_filters(tmp_path, monkeypatch):
+    remote_root = tmp_path / "remote"
+    wanted = _create_cache(remote_root, "arena-hard", "Dummy/model", ["wanted"])
+    _create_cache(remote_root, "other-task", "Dummy/model", ["other"])
+    api = FakeHub(remote_root)
+    _stub_download(monkeypatch, remote_root)
+
+    count = cache_hf.fetch_cache(
+        tmp_path / "local",
+        "org/cache",
+        kind="completions",
+        task="arena-hard",
+        model_spec="Dummy/model",
+        api=api,
+    )
+
+    local_db = tmp_path / "local" / wanted.relative_to(remote_root) / COMPLETION_DB_NAME
+    assert count == 1
+    assert CompletionCache(local_db).query()["completion"].tolist() == ["answer:wanted"]
+
+
+def test_merge_cache_folder_uses_newer_row(tmp_path):
+    local = _create_cache(tmp_path / "local", "task", "Dummy/model", ["same"])
+    remote = _create_cache(tmp_path / "remote", "task", "Dummy/model", ["same"])
+    with CompletionCache(remote / COMPLETION_DB_NAME) as cache:
+        cache.save(
+            pd.DataFrame(
+                [
+                    {
+                        "input_text": "same",
+                        "completion": "newer",
+                        "benchmark": "task",
+                        "instruction_id": "0",
+                        "model": "Dummy/model",
+                    }
+                ]
+            ),
+            pushed_by="remote",
+        )
+
+    cache_hf.merge_cache_folder(local, remote, kind="completions")
+
+    assert CompletionCache(local / COMPLETION_DB_NAME).query()[
+        "completion"
+    ].tolist() == ["newer"]
+
+
+def test_push_remerges_after_parent_conflict_and_uploads_atomically(
+    tmp_path, monkeypatch
+):
+    local_root = tmp_path / "local"
+    remote_root = tmp_path / "remote"
+    local = _create_cache(local_root, "task", "Dummy/model", ["local"])
+    remote = _create_cache(remote_root, "task", "Dummy/model", ["remote"])
+    api = FakeHub(remote_root)
+    _stub_download(monkeypatch, remote_root)
+    api.on_first_commit = lambda: _create_cache(
+        remote_root, "task", "Dummy/model", ["concurrent"]
+    )
+
+    cache_hf.push_cache_folder(
+        local_root,
+        local,
+        "org/cache",
+        kind="completions",
+        api=api,
+    )
+
+    assert [parent for parent, _ in api.commits] == ["head-0", "head-1"]
+    assert all(len(operations) == 2 for _, operations in api.commits)
+    outputs = (
+        CompletionCache(remote / COMPLETION_DB_NAME).query()["completion"].tolist()
+    )
+    assert sorted(outputs) == ["answer:concurrent", "answer:local", "answer:remote"]


### PR DESCRIPTION
# Description

> [!NOTE]
> WIP: This cache stack is on hold until the task-YAML stack ending in #93 merges. The current implementation is not final and may change when it is adapted to the merged task runtime.

Adds an explicit CLI for sharing inference caches through a Hugging Face dataset repository.

- Fetches and pushes folders filtered by role, task and optional model.
- Validates descriptors and merges duplicate input hashes by the latest `pushed_at`.
- Uploads `metadata.json` and the SQLite database in one commit.
- Retries parent-commit conflicts after fetching and merging the newer remote rows.
- Documents local caching and the fetch/push commands in the README.

Synchronization remains separate from benchmark execution.

This is stacked on #98.
