### PR TITLE
Meta-eval: (1/7) Declare meta-evaluation as a packaged task

### DIFF
--- a/judgearena/arenas_utils.py
+++ b/judgearena/arenas_utils.py
@@ -34,8 +34,8 @@ def _download_arena_dataset(
     )
 
 
-def _extract_instruction_text(turn: dict) -> str:
-    """Extract plain instruction text from a conversation turn.
+def extract_turn_text(turn: dict) -> str:
+    """Extract plain text from a conversation turn (user or assistant).
 
     Handles both the 100k schema (content is a plain string) and the 140k
     schema (content is an array of {type, text, ...} objects). Moderated or
@@ -170,7 +170,7 @@ def _load_arena_dataframe(
         df["question_id"] = df["id"]
 
     df["lang"] = df["conversation_a"].apply(
-        lambda conv: detect_language(_extract_instruction_text(conv[0])).lower()
+        lambda conv: detect_language(extract_turn_text(conv[0])).lower()
     )
 
     cols = [

--- a/judgearena/benchmarks/arena.py
+++ b/judgearena/benchmarks/arena.py
@@ -1,0 +1,30 @@
+"""Helpers shared by the runners that read human arena battles."""
+
+from __future__ import annotations
+
+from judgearena.tasks.schema import ResolvedTaskSpec
+
+
+def resolve_task_languages(
+    task: ResolvedTaskSpec, requested: list[str] | None, *, setting: str
+) -> list[str]:
+    """Narrow a task variant's languages by an explicit runtime filter.
+
+    A variant such as ``elo-lmarena-140k-en`` already preselects languages, so
+    the runtime filter may only narrow within that selection. ``setting`` names
+    the config field in the error message.
+    """
+    selected = list(requested or [])
+    if task.selection is None:
+        return selected
+
+    variant_languages = list(task.selection.values)
+    if not selected:
+        return variant_languages
+    narrowed = [lang for lang in selected if lang in set(variant_languages)]
+    if not narrowed:
+        raise ValueError(
+            f"{setting} {requested} has no overlap with the languages of task "
+            f"{task.task!r} ({variant_languages})."
+        )
+    return narrowed

--- a/judgearena/benchmarks/elo/runner.py
+++ b/judgearena/benchmarks/elo/runner.py
@@ -7,13 +7,14 @@ from typing import TYPE_CHECKING
 import numpy as np
 import pandas as pd
 
-from judgearena.arenas_utils import _extract_instruction_text
+from judgearena.arenas_utils import extract_turn_text
 from judgearena.artifacts import (
     prepare_run_directory,
     safe_filename,
     write_run_metadata_safely,
 )
 from judgearena.battles import Leaderboard, summarize_bootstrap, write_battles
+from judgearena.benchmarks.arena import resolve_task_languages
 from judgearena.benchmarks.elo.rating import (
     arena_anchor_battles,
     prefs_to_battle_results,
@@ -153,22 +154,9 @@ def run_elo(cfg: "RunConfig", task: ResolvedTaskSpec | None = None) -> dict:
     logger.info("Step 1: Loading battles from %s", arena)
     df_arena_all = load_battles(task)
 
-    # Filter by language: a task variant (e.g. elo-lmarena-140k-en) preselects
-    # languages; elo.languages narrows further within that selection.
-    selected_languages = list(cfg.elo.languages or [])
-    if task.selection is not None:
-        variant_languages = list(task.selection.values)
-        if selected_languages:
-            selected_languages = [
-                lang for lang in selected_languages if lang in set(variant_languages)
-            ]
-            if not selected_languages:
-                raise ValueError(
-                    f"elo.languages {cfg.elo.languages} has no overlap with the "
-                    f"languages of task {cfg.task!r} ({variant_languages})."
-                )
-        else:
-            selected_languages = variant_languages
+    selected_languages = resolve_task_languages(
+        task, cfg.elo.languages, setting="elo.languages"
+    )
 
     df_battles = df_arena_all
     if selected_languages:
@@ -210,7 +198,7 @@ def run_elo(cfg: "RunConfig", task: ResolvedTaskSpec | None = None) -> dict:
     # Extract user instructions (first turn of conversation_a)
     instructions = pd.Series(
         [
-            _extract_instruction_text(row["conversation_a"][0])
+            extract_turn_text(row["conversation_a"][0])
             for _, row in df_battles.iterrows()
         ],
         name="instruction",
@@ -283,9 +271,9 @@ def run_elo(cfg: "RunConfig", task: ResolvedTaskSpec | None = None) -> dict:
 
     opponent_completions = [
         (
-            _extract_instruction_text(row["conversation_a"][1])
+            extract_turn_text(row["conversation_a"][1])
             if use_model_a_as_opponent[i]
-            else _extract_instruction_text(row["conversation_b"][1])
+            else extract_turn_text(row["conversation_b"][1])
         )
         for i, (_, row) in enumerate(df_battles.iterrows())
     ]
@@ -451,15 +439,15 @@ def run_elo(cfg: "RunConfig", task: ResolvedTaskSpec | None = None) -> dict:
             )
 
             cal_instructions = [
-                _extract_instruction_text(df_arena_all.loc[i, "conversation_a"][0])
+                extract_turn_text(df_arena_all.loc[i, "conversation_a"][0])
                 for i in cal_battles.index
             ]
             cal_completions_a = [
-                _extract_instruction_text(df_arena_all.loc[i, "conversation_a"][1])
+                extract_turn_text(df_arena_all.loc[i, "conversation_a"][1])
                 for i in cal_battles.index
             ]
             cal_completions_b = [
-                _extract_instruction_text(df_arena_all.loc[i, "conversation_b"][1])
+                extract_turn_text(df_arena_all.loc[i, "conversation_b"][1])
                 for i in cal_battles.index
             ]
 

--- a/judgearena/benchmarks/meta_eval/__init__.py
+++ b/judgearena/benchmarks/meta_eval/__init__.py
@@ -1,0 +1,1 @@
+"""Meta-evaluation of a judge against human arena votes."""

--- a/judgearena/benchmarks/meta_eval/runner.py
+++ b/judgearena/benchmarks/meta_eval/runner.py
@@ -1,0 +1,132 @@
+"""Select the human-labeled battles a judge meta-evaluation will score."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from judgearena.artifacts import (
+    prepare_run_directory,
+    safe_filename,
+    write_run_metadata_safely,
+)
+from judgearena.benchmarks.arena import resolve_task_languages
+from judgearena.benchmarks.meta_eval.sampling import (
+    MetaEvalSamplingError,
+    normalize_human_winner,
+    sample_battles_per_model,
+    select_top_models,
+)
+from judgearena.datasets import load_battles
+from judgearena.log import get_logger
+from judgearena.tasks.schema import MetaEvalProtocol, ResolvedTaskSpec
+from judgearena.utils.eval import Report
+
+if TYPE_CHECKING:
+    from judgearena.config import RunConfig
+
+logger = get_logger(__name__)
+
+SAMPLE_FILENAME = "sample.parquet"
+# Identity and label columns only: the conversations stay in the pinned arena
+# snapshot, and question_id joins back to them.
+SAMPLE_COLUMNS = ("question_id", "model_a", "model_b", "winner", "lang")
+
+
+class MetaEvalSampleReport(Report):
+    """The human-labeled battle sample a meta-evaluation run will judge."""
+
+    task: str
+    """Task ID that selected the arena and its language variant."""
+    arena: str
+    """Arena supplying the human votes."""
+    judge_model: str
+    """Judge the sample was drawn for."""
+    languages: list[str]
+    """Language codes the sample was restricted to (empty means all)."""
+    top_models: list[str]
+    """Most-battled models; only battles between two of them are sampled."""
+    n_battles: int
+    """Sampled battles, counting a battle once per model it was drawn for."""
+    battles_per_language: dict[str, int]
+    """Sampled battle count per language code."""
+    human_winner_counts: dict[str, int]
+    """Sampled battle count per human verdict (model_a, model_b, tie)."""
+
+    def render(self) -> None:
+        print(f"\n=== Meta-eval sample: {self.task} ===")
+        print(f"Arena: {self.arena}  |  Judge: {self.judge_model}")
+        print(f"Models: {len(self.top_models)}  |  Battles: {self.n_battles}")
+        print(f"  Languages: {_format_counts(self.battles_per_language)}")
+        print(f"  Human votes: {_format_counts(self.human_winner_counts)}")
+
+
+def _format_counts(counts: dict[str, int]) -> str:
+    return ", ".join(f"{key}={value}" for key, value in sorted(counts.items()))
+
+
+def run_meta_eval(cfg: RunConfig, task: ResolvedTaskSpec | None = None) -> dict:
+    """Sample the battles a judge will be scored against."""
+    protocol = task.spec.protocol if task is not None else None
+    if not isinstance(protocol, MetaEvalProtocol):
+        raise ValueError(f"Task {cfg.task!r} does not define a meta-eval protocol.")
+    if cfg.meta_eval is None:
+        raise ValueError(f"Task {cfg.task!r} requires meta-eval runtime settings.")
+
+    run_started_at = datetime.now(UTC)
+    languages = resolve_task_languages(
+        task, cfg.meta_eval.languages, setting="meta_eval.languages"
+    )
+
+    logger.info("Loading human battles from %s", protocol.arena)
+    battles = load_battles(task)
+    battles["winner"] = battles["winner"].map(normalize_human_winner)
+    if languages:
+        battles = battles[battles["lang"].isin(languages)]
+    if battles.empty:
+        raise MetaEvalSamplingError(
+            f"Task {cfg.task!r} has no battles in languages {languages}."
+        )
+
+    top_models, df_top = select_top_models(battles, top_models=cfg.meta_eval.top_models)
+    sample = sample_battles_per_model(
+        df_top,
+        top_models,
+        battles_per_model=cfg.meta_eval.battles_per_model,
+        seed=cfg.run.seed,
+    )
+    logger.info(
+        "Sampled %d battles among the top %d models.", len(sample), len(top_models)
+    )
+
+    report = MetaEvalSampleReport(
+        task=cfg.task,
+        arena=protocol.arena,
+        judge_model=cfg.judge.model,
+        languages=languages,
+        top_models=top_models,
+        n_battles=len(sample),
+        battles_per_language=sample["lang"].value_counts().to_dict(),
+        human_winner_counts=sample["winner"].value_counts().to_dict(),
+    )
+    results = report.to_dict()
+    report.render()
+
+    res_dir = prepare_run_directory(
+        cfg,
+        Path(cfg.run.result_folder)
+        / f"{safe_filename(cfg.task)}-{safe_filename(cfg.judge.model)}",
+    )
+    result_path = report.save(res_dir / "results.json")
+    sample[list(SAMPLE_COLUMNS)].to_parquet(res_dir / SAMPLE_FILENAME, index=False)
+    write_run_metadata_safely(
+        output_dir=res_dir,
+        entrypoint="judgearena.benchmarks.meta_eval.runner.run_meta_eval",
+        run=cfg.model_dump(),
+        results=results,
+        input_payloads={"question_id": sample["question_id"].astype(str).tolist()},
+        started_at_utc=run_started_at,
+    )
+    logger.info("Meta-eval sample written to %s", res_dir)
+    return {**results, "result_path": str(result_path)}

--- a/judgearena/benchmarks/meta_eval/sampling.py
+++ b/judgearena/benchmarks/meta_eval/sampling.py
@@ -1,0 +1,86 @@
+"""Deterministic arena battle sampling for judge meta-evaluation."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from judgearena.log import get_logger
+
+logger = get_logger(__name__)
+
+
+class MetaEvalSamplingError(ValueError):
+    """Raised when filtering or sampling yields an unusable battle subset."""
+
+
+def normalize_human_winner(winner: object) -> str:
+    """Collapse the arena's tie labels ("tie", "tie (bothbad)") into "tie"."""
+    text = str(winner)
+    return "tie" if "tie" in text else text
+
+
+def count_battles_per_model(df: pd.DataFrame) -> dict[str, int]:
+    return (
+        pd.concat([df["model_a"], df["model_b"]], ignore_index=True)
+        .value_counts()
+        .to_dict()
+    )
+
+
+def select_top_models(
+    df: pd.DataFrame, *, top_models: int
+) -> tuple[list[str], pd.DataFrame]:
+    """Pick the most-battled models and keep only battles fought among them.
+
+    Restricting to intra-group battles keeps every judged comparison inside a
+    single connected pool, which is what makes the resulting annotations usable
+    for a ranking fit later on.
+    """
+    battle_counts = count_battles_per_model(df)
+    if not battle_counts:
+        raise MetaEvalSamplingError("Cannot select top models from an empty dataframe.")
+
+    top = sorted(battle_counts, key=battle_counts.__getitem__, reverse=True)[
+        :top_models
+    ]
+    top_set = set(top)
+    df_top = df[df["model_a"].isin(top_set) & df["model_b"].isin(top_set)].copy()
+    if df_top.empty:
+        raise MetaEvalSamplingError(
+            f"No battles remain among the top {top_models} models."
+        )
+    return top, df_top
+
+
+def sample_battles_per_model(
+    df_top: pd.DataFrame,
+    top_models: list[str],
+    *,
+    battles_per_model: int,
+    seed: int,
+) -> pd.DataFrame:
+    """Draw up to ``battles_per_model`` battles for each selected model.
+
+    Sampling per model rather than globally keeps thin models represented. A
+    battle between two selected models can be drawn for either of them, so the
+    result may repeat a battle.
+    """
+    per_model_samples: list[pd.DataFrame] = []
+    for model_index, model in enumerate(top_models):
+        df_model = df_top[(df_top["model_a"] == model) | (df_top["model_b"] == model)]
+        if df_model.empty:
+            logger.warning("Model %s has no battles among top models; skipping.", model)
+            continue
+        per_model_samples.append(
+            df_model.sample(
+                n=min(battles_per_model, len(df_model)),
+                replace=False,
+                random_state=seed + model_index,
+            )
+        )
+
+    if not per_model_samples:
+        raise MetaEvalSamplingError(
+            "Sampling produced no battles; reduce top_models or battles_per_model."
+        )
+    return pd.concat(per_model_samples, ignore_index=True)

--- a/judgearena/benchmarks/registry.py
+++ b/judgearena/benchmarks/registry.py
@@ -45,11 +45,13 @@ class ResolvedBenchmark:
 def benchmark_adapters() -> tuple[BenchmarkAdapter, ...]:
     """Return registered benchmark implementations, specific first."""
     from judgearena.benchmarks.elo.runner import run_elo
+    from judgearena.benchmarks.meta_eval.runner import run_meta_eval
     from judgearena.benchmarks.mt_bench.runner import run_mt_bench_benchmark
     from judgearena.benchmarks.pairwise.runner import run_pairwise
 
     return (
         BenchmarkAdapter("elo", frozenset(), run_elo),
+        BenchmarkAdapter("meta_eval", frozenset(), run_meta_eval),
         BenchmarkAdapter("mt_bench", frozenset(), run_mt_bench_benchmark),
         BenchmarkAdapter("pairwise", None, run_pairwise),
     )

--- a/judgearena/config.py
+++ b/judgearena/config.py
@@ -18,7 +18,7 @@ from pydantic_settings import (
 
 from judgearena.benchmarks.pairwise.baselines import native_pairwise_baseline
 from judgearena.tasks.registry import get_packaged_task
-from judgearena.tasks.schema import EloProtocol
+from judgearena.tasks.schema import EloProtocol, MetaEvalProtocol
 
 # Set by build_run_config() for the duration of RunConfig() construction.
 _ACTIVE_CONFIG_PATH: str | None = None
@@ -329,6 +329,28 @@ class EloArgs(BaseModel):
     Defaults to all. Requires ``calibrate_temperature``."""
 
 
+class MetaEvalArgs(BaseModel):
+    """Experiment settings for tasks using the meta-evaluation protocol."""
+
+    model_config = ConfigDict(use_attribute_docstrings=True)
+
+    arena: str | None = None
+    """Arena supplying the human-labeled battles. Derived from the task
+    definition; an explicit value must match it."""
+
+    top_models: int = Field(default=20, gt=0)
+    """Keep the N models with the most battles, then judge only battles fought
+    between two of them."""
+
+    battles_per_model: int = Field(default=50, gt=0)
+    """Battles sampled per selected model. A battle involving two selected
+    models can be drawn for either of them."""
+
+    languages: list[str] | None = None
+    """Restrict battles to these language codes (e.g. ``["en", "fr"]``).
+    Defaults to all languages of the task."""
+
+
 class RunArgs(BaseModel):
     """Run-level settings: seed, output location, caching, and logging."""
 
@@ -382,6 +404,9 @@ class RunConfig(BaseSettings):
     elo: EloArgs | None = None
     """Runtime settings used only by tasks with an ELO protocol."""
 
+    meta_eval: MetaEvalArgs | None = None
+    """Runtime settings used only by tasks with a meta-evaluation protocol."""
+
     run: RunArgs = Field(default_factory=RunArgs)
     """Run-level settings (seed, output, caching, logging)."""
 
@@ -410,7 +435,9 @@ class RunConfig(BaseSettings):
         ):
             self.judge.temperature = task_judge.default_temperature
 
-        baseline = protocol.baseline
+        # Meta-eval judges completions that already exist in the arena, so its
+        # protocol declares no baseline.
+        baseline = getattr(protocol, "baseline", None)
         if (
             self.model.baseline is not None
             and getattr(baseline, "allow_runtime_override", True) is False
@@ -419,6 +446,30 @@ class RunConfig(BaseSettings):
                 f"model.baseline cannot override the baseline defined by "
                 f"task {self.task!r}."
             )
+
+        if isinstance(protocol, MetaEvalProtocol):
+            if self.elo is not None:
+                raise ValueError("elo config is only valid for ELO tasks.")
+            if self.model.name is not None or self.model.baseline is not None:
+                raise ValueError(
+                    "meta-eval tasks judge arena completions; model.name and "
+                    "model.baseline are not used."
+                )
+            if self.meta_eval is None:
+                self.meta_eval = MetaEvalArgs()
+            if (
+                self.meta_eval.arena is not None
+                and self.meta_eval.arena != protocol.arena
+            ):
+                raise ValueError(
+                    f"meta_eval.arena={self.meta_eval.arena!r} does not match task "
+                    f"{self.task!r} ({protocol.arena!r})."
+                )
+            self.meta_eval.arena = protocol.arena
+            return self
+
+        if self.meta_eval is not None:
+            raise ValueError("meta_eval config is only valid for meta-eval tasks.")
 
         is_elo = isinstance(protocol, EloProtocol)
         if is_elo:

--- a/judgearena/datasets/arena_battles.py
+++ b/judgearena/datasets/arena_battles.py
@@ -1,4 +1,4 @@
-"""Dataset adapter for human preference battles used by ELO tasks."""
+"""Dataset adapter for human preference battles used by arena-backed tasks."""
 
 from __future__ import annotations
 
@@ -14,25 +14,28 @@ from judgearena.arenas_utils import (
 from judgearena.tasks.schema import (
     EloProtocol,
     HuggingFaceDatasetSource,
+    MetaEvalProtocol,
     ResolvedTaskSpec,
 )
+
+ArenaProtocol = EloProtocol | MetaEvalProtocol
 
 
 def _task_sources(
     task: ResolvedTaskSpec,
-) -> tuple[EloProtocol, dict[str, HuggingFaceDatasetSource]]:
+) -> tuple[ArenaProtocol, dict[str, HuggingFaceDatasetSource]]:
     protocol = task.spec.protocol
-    if not isinstance(protocol, EloProtocol):
-        raise ValueError(f"Task {task.task!r} does not define an ELO protocol.")
+    if not isinstance(protocol, ArenaProtocol):
+        raise ValueError(f"Task {task.task!r} does not define an arena protocol.")
     if protocol.arena not in {*KNOWN_ARENAS, "LMArena"}:
-        raise ValueError(f"Unsupported ELO arena {protocol.arena!r}.")
+        raise ValueError(f"Unsupported arena {protocol.arena!r}.")
 
     sources: dict[str, HuggingFaceDatasetSource] = {}
     for source in task.spec.dataset.sources.values():
         if not isinstance(source, HuggingFaceDatasetSource):
-            raise ValueError("ELO arena sources must be Hugging Face datasets.")
+            raise ValueError("Arena sources must be Hugging Face datasets.")
         if source.repo_id in sources:
-            raise ValueError(f"Duplicate ELO arena source {source.repo_id!r}.")
+            raise ValueError(f"Duplicate arena source {source.repo_id!r}.")
         sources[source.repo_id] = source
     return protocol, sources
 

--- a/judgearena/tasks/definitions/meta_eval/_base.yaml
+++ b/judgearena/tasks/definitions/meta_eval/_base.yaml
@@ -1,0 +1,17 @@
+schema_version: 1
+task_version: 1
+tags: [meta-eval, arena, judge]
+
+dataset:
+  adapter: arena_battles
+  fields:
+    id: question_id
+    instruction: conversation_a
+    category: lang
+
+protocol:
+  runner: meta_eval
+  judge:
+    default_prompt: default
+    default_swap_mode: fixed
+    allowed_swap_modes: [fixed, both]

--- a/judgearena/tasks/definitions/meta_eval/meta-eval-comparia.yaml
+++ b/judgearena/tasks/definitions/meta_eval/meta-eval-comparia.yaml
@@ -1,0 +1,21 @@
+extends: _base.yaml
+task: meta-eval-comparia
+description: Score a judge against human votes from the ComparIA arena.
+
+variants:
+  selector: language
+  values: [fr, en]
+
+dataset:
+  sources:
+    comparia:
+      type: huggingface_dataset
+      repo_id: ministere-culture/comparia-votes
+      revision: "7a40bce496c1f2aa3be4001da85a49cb4743042b"
+      allow_patterns: [votes.parquet]
+
+protocol:
+  arena: ComparIA
+
+metadata:
+  reference_implementation: https://huggingface.co/datasets/ministere-culture/comparia-votes

--- a/judgearena/tasks/definitions/meta_eval/meta-eval-lmarena-140k.yaml
+++ b/judgearena/tasks/definitions/meta_eval/meta-eval-lmarena-140k.yaml
@@ -1,0 +1,21 @@
+extends: _base.yaml
+task: meta-eval-lmarena-140k
+description: Score a judge against human votes from LMSYS Chatbot Arena 140k.
+
+variants:
+  selector: language
+  values: [en, pl, ru, zh, de, ja, es, fr, ko, pt, fa, it, tr, vi, cs, ar, uk]
+
+dataset:
+  sources:
+    lmarena_140k:
+      type: huggingface_dataset
+      repo_id: lmarena-ai/arena-human-preference-140k
+      revision: "6322995ab34d7c2693e3f47dd13fa5caa0789a74"
+      allow_patterns: [data/*.parquet]
+
+protocol:
+  arena: LMArena-140k
+
+metadata:
+  reference_implementation: https://huggingface.co/datasets/lmarena-ai/arena-human-preference-140k

--- a/judgearena/tasks/registry.py
+++ b/judgearena/tasks/registry.py
@@ -22,6 +22,7 @@ from judgearena.log import get_logger
 from judgearena.prompts.registry import JUDGE_PROMPT_PRESETS
 from judgearena.tasks.schema import (
     EloProtocol,
+    MetaEvalProtocol,
     ResolvedTaskSpec,
     ResourceDigest,
     TaskProvenance,
@@ -247,7 +248,7 @@ def _load_task(root: Traversable, relative_path: str) -> ResolvedTaskSpec:
 class AdapterCatalog:
     """Component IDs that task YAML files may reference."""
 
-    runners: frozenset[str] = frozenset({"elo", "mt_bench", "pairwise"})
+    runners: frozenset[str] = frozenset({"elo", "meta_eval", "mt_bench", "pairwise"})
     instruction_datasets: frozenset[str] = frozenset(
         {"arena_hard", "fluency", "judgearena_tables", "m_arena_hard", "mt_bench"}
     )
@@ -300,16 +301,23 @@ def _discover_tasks(
 def _validate_adapter_ids(resolved: ResolvedTaskSpec, adapters: AdapterCatalog) -> None:
     spec = resolved.spec
     is_elo = isinstance(spec.protocol, EloProtocol)
-    scorer_names = adapters.elo_scorers if is_elo else adapters.pairwise_scorers
+    reads_battles = is_elo or isinstance(spec.protocol, MetaEvalProtocol)
     dataset_names = (
-        adapters.battle_datasets if is_elo else adapters.instruction_datasets
+        adapters.battle_datasets if reads_battles else adapters.instruction_datasets
     )
     references = {
         "runner": (spec.protocol.runner, adapters.runners),
         "dataset adapter": (spec.dataset.adapter, dataset_names),
         "prompt": (spec.protocol.judge.default_prompt, adapters.prompts),
-        "scorer": (spec.protocol.scoring.adapter, scorer_names),
     }
+    # Meta-eval reports agreement with human labels rather than a benchmark
+    # score, so it declares no scoring adapter until its metrics land.
+    scoring = getattr(spec.protocol, "scoring", None)
+    if scoring is not None:
+        references["scorer"] = (
+            scoring.adapter,
+            adapters.elo_scorers if is_elo else adapters.pairwise_scorers,
+        )
     for kind, (adapter_id, available) in references.items():
         if adapter_id not in available:
             raise TaskDefinitionError(

--- a/judgearena/tasks/schema/__init__.py
+++ b/judgearena/tasks/schema/__init__.py
@@ -15,6 +15,7 @@ from judgearena.tasks.schema.baselines import (
 )
 from judgearena.tasks.schema.dataset import DatasetFields, DatasetSpec
 from judgearena.tasks.schema.elo import EloProtocol, EloScoringSpec
+from judgearena.tasks.schema.meta_eval import MetaEvalProtocol
 from judgearena.tasks.schema.mt_bench import (
     MTBenchJudgeSpec,
     MTBenchProtocol,
@@ -58,6 +59,7 @@ __all__ = [
     "HuggingFaceSpaceSource",
     "MTBenchJudgeSpec",
     "MTBenchProtocol",
+    "MetaEvalProtocol",
     "MultiTurnGeneration",
     "NoBaseline",
     "OfficialOutputsBaseline",

--- a/judgearena/tasks/schema/meta_eval.py
+++ b/judgearena/tasks/schema/meta_eval.py
@@ -1,0 +1,23 @@
+"""Schema for judge meta-evaluation against human arena labels."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import Field
+
+from judgearena.tasks.schema.base import StrictFrozenModel
+from judgearena.tasks.schema.pairwise import PairwiseJudgeSpec
+
+
+class MetaEvalProtocol(StrictFrozenModel):
+    """Policy for scoring a judge against human-labeled arena battles.
+
+    Unlike the ELO protocol there is no model under evaluation and no
+    generation step: both completions already exist in the arena, and the
+    judge itself is the subject of the experiment.
+    """
+
+    runner: Literal["meta_eval"]
+    arena: str = Field(min_length=1)
+    judge: PairwiseJudgeSpec

--- a/judgearena/tasks/schema/task.py
+++ b/judgearena/tasks/schema/task.py
@@ -13,11 +13,12 @@ from judgearena.tasks.schema.baselines import (
 )
 from judgearena.tasks.schema.dataset import DatasetSpec
 from judgearena.tasks.schema.elo import EloProtocol
+from judgearena.tasks.schema.meta_eval import MetaEvalProtocol
 from judgearena.tasks.schema.mt_bench import MTBenchProtocol
 from judgearena.tasks.schema.pairwise import PairwiseProtocol
 
 ProtocolSpec = Annotated[
-    PairwiseProtocol | MTBenchProtocol | EloProtocol,
+    PairwiseProtocol | MTBenchProtocol | EloProtocol | MetaEvalProtocol,
     Field(discriminator="runner"),
 ]
 
@@ -77,7 +78,9 @@ class TaskSpec(StrictFrozenModel):
         if len(set(self.tags)) != len(self.tags):
             raise ValueError("tags must not contain duplicates")
         source_names = set(self.dataset.sources)
-        baseline = self.protocol.baseline
+        # Meta-eval judges completions that already exist in the arena, so its
+        # protocol declares no baseline at all.
+        baseline = getattr(self.protocol, "baseline", None)
         if (
             isinstance(baseline, OfficialOutputsBaseline)
             and baseline.source not in source_names

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -118,6 +118,30 @@ def test_elo_config_allows_runtime_scoring_overrides():
     assert cfg.elo.soft_elo_temperature == 0.7
 
 
+def test_meta_eval_config_derives_arena():
+    cfg = RunConfig(task="meta-eval-comparia", judge={"model": "Dummy/j"})
+
+    assert cfg.meta_eval is not None
+    assert cfg.meta_eval.arena == "ComparIA"
+    assert cfg.elo is None
+
+
+def test_meta_eval_rejects_a_model_under_evaluation():
+    with pytest.raises(ValidationError, match="not used"):
+        RunConfig(
+            task="meta-eval-comparia",
+            model={"name": "Dummy/m"},
+            judge={"model": "Dummy/j"},
+        )
+
+
+def test_meta_eval_block_rejected_on_elo_task():
+    data = _base_elo()
+    data["meta_eval"] = {"top_models": 5}
+    with pytest.raises(ValidationError, match="only valid for meta-eval"):
+        RunConfig(**data)
+
+
 def test_elo_requires_model_path():
     data = _base_elo()
     data["model"] = {}

--- a/tests/test_estimate_elo_ratings.py
+++ b/tests/test_estimate_elo_ratings.py
@@ -498,13 +498,13 @@ def test_run_elo_temperature_calibration_builds_judge(monkeypatch, tmp_path):
     assert 0.0 <= result["winrate"] <= 1.0
 
 
-def test_extract_instruction_text_tolerates_moderated_turns():
-    from judgearena.arenas_utils import _extract_instruction_text
+def test_extract_turn_text_tolerates_moderated_turns():
+    from judgearena.arenas_utils import extract_turn_text
 
-    assert _extract_instruction_text({"content": None}) == ""
-    assert _extract_instruction_text({"content": "plain"}) == "plain"
+    assert extract_turn_text({"content": None}) == ""
+    assert extract_turn_text({"content": "plain"}) == "plain"
     assert (
-        _extract_instruction_text(
+        extract_turn_text(
             {"content": [{"type": "text", "text": None}, {"type": "image"}, None]}
         )
         == ""

--- a/tests/test_meta_eval_task_runtime.py
+++ b/tests/test_meta_eval_task_runtime.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import json
+
+import pandas as pd
+import pytest
+
+import judgearena.benchmarks.meta_eval.runner as runner_module
+from judgearena.benchmarks.meta_eval.runner import SAMPLE_FILENAME, run_meta_eval
+from judgearena.benchmarks.meta_eval.sampling import (
+    MetaEvalSamplingError,
+    sample_battles_per_model,
+    select_top_models,
+)
+from judgearena.benchmarks.registry import resolve_benchmark
+from judgearena.config import RunConfig
+from judgearena.tasks.registry import get_packaged_task
+
+
+def _battles() -> pd.DataFrame:
+    models = ["m1", "m2", "m3"]
+    rows = [
+        {
+            "question_id": f"q{i}",
+            "model_a": models[i % 3],
+            "model_b": models[(i + 1) % 3],
+            "winner": "tie (bothbad)" if i % 5 == 0 else "model_a",
+            "lang": "fr" if i % 2 else "en",
+        }
+        for i in range(30)
+    ]
+    rows.append(
+        {
+            "question_id": "q-rare",
+            "model_a": "rare",
+            "model_b": "m1",
+            "winner": "model_b",
+            "lang": "en",
+        }
+    )
+    return pd.DataFrame(rows)
+
+
+def _cfg(tmp_path, **overrides) -> RunConfig:
+    return RunConfig(
+        task="meta-eval-comparia",
+        judge={"model": "Dummy/j"},
+        run={"result_folder": str(tmp_path), "no_log_file": True},
+        **overrides,
+    )
+
+
+def test_meta_eval_task_is_registered_with_the_arena_battle_stack():
+    task = get_packaged_task("meta-eval-lmarena-140k")
+    assert task is not None
+    assert task.spec.protocol.runner == "meta_eval"
+    assert task.spec.protocol.arena == "LMArena-140k"
+    assert task.spec.dataset.adapter == "arena_battles"
+    assert resolve_benchmark("meta-eval-lmarena-140k").adapter.name == "meta_eval"
+
+
+def test_meta_eval_language_variant_selects_one_language():
+    variant = get_packaged_task("meta-eval-comparia-fr")
+    assert variant is not None
+    assert variant.selection is not None
+    assert variant.selection.values == ("fr",)
+
+
+def test_sampling_is_deterministic_and_stays_inside_the_top_models():
+    battles = _battles()
+    top, df_top = select_top_models(battles, top_models=3)
+    assert set(top) == {"m1", "m2", "m3"}
+    assert "q-rare" not in set(df_top["question_id"])
+
+    sample = sample_battles_per_model(df_top, top, battles_per_model=5, seed=0)
+    again = sample_battles_per_model(df_top, top, battles_per_model=5, seed=0)
+
+    assert len(sample) == 15
+    pd.testing.assert_frame_equal(sample, again)
+
+
+def test_sampling_rejects_a_disconnected_top_model_set():
+    battles = pd.DataFrame(
+        [{"question_id": "q", "model_a": "a", "model_b": "b", "winner": "tie"}]
+    )
+    with pytest.raises(MetaEvalSamplingError, match="No battles remain"):
+        select_top_models(battles, top_models=1)
+
+
+def test_runner_writes_a_reproducible_sample_manifest(tmp_path, monkeypatch):
+    monkeypatch.setattr(runner_module, "load_battles", lambda _task: _battles())
+    cfg = _cfg(tmp_path, meta_eval={"top_models": 3, "battles_per_model": 5})
+
+    results = run_meta_eval(cfg, get_packaged_task("meta-eval-comparia"))
+
+    res_dir = tmp_path / "meta-eval-comparia-dummy-j"
+    sample = pd.read_parquet(res_dir / SAMPLE_FILENAME)
+    assert results["n_battles"] == len(sample) == 15
+    assert set(sample["winner"]) <= {"model_a", "model_b", "tie"}
+    assert sorted(sample.columns) == [
+        "lang",
+        "model_a",
+        "model_b",
+        "question_id",
+        "winner",
+    ]
+    assert json.loads((res_dir / "results.json").read_text())["arena"] == "ComparIA"

--- a/tests/test_mt_bench_downloads.py
+++ b/tests/test_mt_bench_downloads.py
@@ -117,6 +117,8 @@ def test_download_all_includes_mt_bench(tmp_path, monkeypatch):
         "fluency",
         "m-arena-hard-v0.1",
         "m-arena-hard-v2.0",
+        "meta-eval-comparia",
+        "meta-eval-lmarena-140k",
         "mt-bench",
     ]
     assert all(path == tables_dir for _, path in hf_datasets)

--- a/tests/test_task_registry.py
+++ b/tests/test_task_registry.py
@@ -88,6 +88,8 @@ def test_packaged_registry_discovers_versioned_tasks():
         "fluency",
         "m-arena-hard-v0.1",
         "m-arena-hard-v2.0",
+        "meta-eval-comparia",
+        "meta-eval-lmarena-140k",
         "mt-bench",
     ]
     assert alpaca.spec.dataset.sources["examples"].revision == (

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -52,6 +52,8 @@ def test_download_all_dispatches_registered_tasks(monkeypatch, tmp_path):
         ("hf", "fluency", tables_dir),
         ("hf", "m-arena-hard-v0.1", tables_dir),
         ("hf", "m-arena-hard-v2.0", tables_dir),
+        ("hf", "meta-eval-comparia", tables_dir),
+        ("hf", "meta-eval-lmarena-140k", tables_dir),
         ("hf", "mt-bench", tables_dir),
     ]
 


### PR DESCRIPTION
# Description

> [!NOTE]
> Packaged meta-eval split from closed PR #76. Meta-eval does not use the unified `do_inference` cache, and the cache stack (#94-#100) does not wire it up either: caching will be added to meta-eval once those PRs are merged.

Adds `meta-eval-lmarena-140k` and `meta-eval-comparia` as packaged YAML tasks on the same arena battle adapter as ELO, plus deterministic top-model / per-model sampling.

There is no generation and no `model.name`. Completions already exist in the arena.

This is stacked on #93.

Stack:

- #101 declare the packaged tasks and sampling
- #102 agreement (accuracy / kappa)
- #103 swap orientation
- #104 ranking adapter
- #105 prompt presets
- #106 held-out Elo gap
- #107 token / OpenRouter reference cost
