### PR TITLE
Meta-eval: (2/7) Score sampled battles with accuracy and Cohen's kappa

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ judgearena \
 | `--meta_eval.n_bootstraps` | `20` | Bootstrap samples for agreement standard errors |
 | `--model.name` | unset | Not used: both completions already exist in the arena |
 
-Results go under `[result_folder]/meta-eval-*-<judge>/` as `sample.parquet`, `annotations.parquet`, `results.json`, `config.yaml`, and `run-metadata.v1.json`. `results.json` reports agreement on all battles and on the subset that drops human ties.
+Results go under `[result_folder]/<task>-<prompt_preset>-<judge>-<swap_mode>/` as `sample.parquet`, `annotations.parquet`, `results.json`, `config.yaml`, and `run-metadata.v1.json`. `results.json` reports agreement on all battles and on the subset that drops human ties.
 
 ## 📈 Estimating ELO Ratings
 

--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ This override applies to all vLLM models in the run. For remote providers (OpenA
 
 ## 📊 Supported Tasks
 
-Task names follow [LMHarness](https://github.com/EleutherAI/lm-evaluation-harness) conventions. Generate+judge tasks produce pairwise preferences between two models; tasks using the ELO protocol estimate a single model's rating against human-annotated arena opponents.
+Task names follow [LMHarness](https://github.com/EleutherAI/lm-evaluation-harness) conventions. Generate+judge tasks produce pairwise preferences between two models; tasks using the ELO protocol estimate a single model's rating against human-annotated arena opponents; meta-eval tasks score a judge against those human votes.
 
 ### Generate + judge (pairwise)
 
@@ -283,6 +283,43 @@ For m-Arena-Hard, baseline completions are tied to the benchmark release:
 | `elo-lmarena-140k`  | Battles sampled from `lmarena-ai/arena-human-preference-140k`      |
 | `elo-lmarena`       | Union of all `LMArena-*` variants                                  |
 | `elo-comparia`      | Battles sampled from the ComparIA arena                            |
+
+### Judge meta-evaluation
+
+| Task                      | Description                                              |
+|---------------------------|----------------------------------------------------------|
+| `meta-eval-lmarena-140k`  | Score a judge against LMSYS Chatbot Arena 140k votes     |
+| `meta-eval-comparia`      | Score a judge against ComparIA human votes               |
+
+Language variants follow the ELO pattern (`meta-eval-lmarena-140k-uk`, `meta-eval-comparia-fr`).
+
+## Judge meta-evaluation
+
+Meta-evaluation scores a judge against **human-labeled arena battles**. It does not generate completions and does not rate a model. Use `elo-*` for that.
+
+The task keeps the most-battled models, samples battles among them, asks the judge to label the stored A/B order, and reports accuracy and Cohen's kappa (with bootstrap SE) against the human vote. PairScore uses temperature `0.5` here; generate+judge keeps `0.3`.
+
+```bash
+judgearena \
+  --task meta-eval-lmarena-140k \
+  --judge.model OpenRouter/deepseek/deepseek-v3.2 \
+  --meta_eval.languages '["en", "es"]' \
+  --meta_eval.top_models 20 \
+  --meta_eval.battles_per_model 50 \
+  --meta_eval.n_bootstraps 20
+```
+
+| Flag | Default | Description |
+|---|---|---|
+| `--task` | *(required)* | `meta-eval-lmarena-140k`, `meta-eval-comparia`, or a language variant |
+| `--judge.model` | *(required)* | Judge under evaluation |
+| `--meta_eval.top_models` | `20` | Keep the N models with the most battles |
+| `--meta_eval.battles_per_model` | `50` | Battles sampled per selected model |
+| `--meta_eval.languages` | all | Restrict to language codes, e.g. `'["en", "es"]'` |
+| `--meta_eval.n_bootstraps` | `20` | Bootstrap samples for agreement standard errors |
+| `--model.name` | unset | Not used: both completions already exist in the arena |
+
+Results go under `[result_folder]/meta-eval-*-<judge>/` as `sample.parquet`, `annotations.parquet`, `results.json`, `config.yaml`, and `run-metadata.v1.json`. `results.json` reports agreement on all battles and on the subset that drops human ties.
 
 ## 📈 Estimating ELO Ratings
 

--- a/judgearena/benchmarks/meta_eval/agreement.py
+++ b/judgearena/benchmarks/meta_eval/agreement.py
@@ -1,0 +1,133 @@
+"""Agreement of a judge with human arena labels."""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+from sklearn.metrics import cohen_kappa_score
+
+WINNER_LABELS = ["model_a", "model_b", "tie"]
+
+
+def _cohen_kappa(y_true: list[str], y_pred: list[str]) -> float:
+    if len(set(y_true) | set(y_pred)) < 2:
+        return float("nan")
+    return float(cohen_kappa_score(y_true, y_pred, labels=WINNER_LABELS))
+
+
+def _finite_std(values: list[float]) -> float:
+    finite = np.asarray([value for value in values if math.isfinite(value)])
+    return float(np.std(finite)) if len(finite) else float("nan")
+
+
+def bootstrap_std(
+    y_true: list[str],
+    y_pred: list[str],
+    *,
+    n_bootstraps: int,
+    seed: int,
+) -> tuple[float, float]:
+    if not y_true:
+        return float("nan"), float("nan")
+    rng = np.random.default_rng(seed)
+    y_true_arr = np.array(y_true)
+    y_pred_arr = np.array(y_pred)
+    acc_samples: list[float] = []
+    kappa_samples: list[float] = []
+    for _ in range(n_bootstraps):
+        idx = rng.choice(len(y_true_arr), size=len(y_true_arr), replace=True)
+        acc_samples.append(float(np.mean(y_true_arr[idx] == y_pred_arr[idx])))
+        kappa_samples.append(
+            _cohen_kappa(y_true_arr[idx].tolist(), y_pred_arr[idx].tolist())
+        )
+    return float(np.std(acc_samples)), _finite_std(kappa_samples)
+
+
+def compute_agreement_metrics(
+    winner_human: list[str],
+    winner_llm: list[str],
+    *,
+    n_bootstraps: int,
+    seed: int,
+) -> dict[str, float | int]:
+    n_all = len(winner_human)
+    nan = float("nan")
+    if n_all == 0:
+        return {
+            "n": 0,
+            "accuracy": nan,
+            "acc_se": nan,
+            "kappa": nan,
+            "kappa_se": nan,
+            "n_nt": 0,
+            "accuracy_nt": nan,
+            "acc_se_nt": nan,
+            "kappa_nt": nan,
+            "kappa_se_nt": nan,
+        }
+
+    acc_all = (
+        sum(h == pred for h, pred in zip(winner_human, winner_llm, strict=True)) / n_all
+    )
+    kappa_all = _cohen_kappa(winner_human, winner_llm)
+    acc_se, kappa_se = bootstrap_std(
+        winner_human, winner_llm, n_bootstraps=n_bootstraps, seed=seed
+    )
+
+    no_tie = [
+        (h, pred)
+        for h, pred in zip(winner_human, winner_llm, strict=True)
+        if h != "tie"
+    ]
+    n_nt = len(no_tie)
+    if n_nt:
+        wh_nt, wl_nt = zip(*no_tie, strict=True)
+        acc_nt = sum(h == pred for h, pred in zip(wh_nt, wl_nt, strict=True)) / n_nt
+        kappa_nt = _cohen_kappa(list(wh_nt), list(wl_nt))
+        acc_se_nt, kappa_se_nt = bootstrap_std(
+            list(wh_nt), list(wl_nt), n_bootstraps=n_bootstraps, seed=seed + 1
+        )
+    else:
+        acc_nt = kappa_nt = acc_se_nt = kappa_se_nt = nan
+
+    return {
+        "n": n_all,
+        "accuracy": acc_all,
+        "acc_se": acc_se,
+        "kappa": kappa_all,
+        "kappa_se": kappa_se,
+        "n_nt": n_nt,
+        "accuracy_nt": acc_nt,
+        "acc_se_nt": acc_se_nt,
+        "kappa_nt": kappa_nt,
+        "kappa_se_nt": kappa_se_nt,
+    }
+
+
+def format_metric(value: float | None, se: float | None, *, digits: int = 3) -> str:
+    if value is None or not math.isfinite(value):
+        return "n/a"
+    if se is None or not math.isfinite(se):
+        return f"{value:.{digits}f}"
+    return f"{value:.{digits}f} ± {se:.{digits}f}"
+
+
+def agreement_view(
+    metrics: dict[str, float | int], *, exclude_human_ties: bool
+) -> dict[str, float | int | str]:
+    suffix = "_nt" if exclude_human_ties else ""
+    n_key = "n_nt" if exclude_human_ties else "n"
+    accuracy = float(metrics[f"accuracy{suffix}"])
+    accuracy_se = float(metrics[f"acc_se{suffix}"])
+    kappa = float(metrics[f"kappa{suffix}"])
+    kappa_se = float(metrics[f"kappa_se{suffix}"])
+    return {
+        "n": int(metrics[n_key]),
+        "accuracy": accuracy,
+        "accuracy_se": accuracy_se,
+        "kappa": kappa,
+        "kappa_se": kappa_se,
+        "accuracy_formatted": format_metric(accuracy, accuracy_se),
+        "kappa_formatted": format_metric(kappa, kappa_se),
+    }

--- a/judgearena/benchmarks/meta_eval/annotate.py
+++ b/judgearena/benchmarks/meta_eval/annotate.py
@@ -1,0 +1,105 @@
+"""Judge a sampled arena battle set in the stored A/B order."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import numpy as np
+import pandas as pd
+
+from judgearena.arenas_utils import extract_turn_text
+from judgearena.evaluate import PairScore, annotate_battles
+
+if TYPE_CHECKING:
+    from judgearena.config import RunConfig
+    from judgearena.prompts.registry import ResolvedJudgePrompt
+
+TIE_EPSILON = 0.01
+# Paper PairScore temperature for meta-eval; generate+judge keeps 0.3.
+META_EVAL_PAIRSCORE_TEMPERATURE = 0.5
+
+
+def serialize_judge_input(judge_input: object) -> str:
+    if judge_input is None:
+        return ""
+    to_string = getattr(judge_input, "to_string", None)
+    if callable(to_string):
+        return to_string()
+    return str(judge_input)
+
+
+def parse_pairscore_pref(
+    judge_completion: str, *, temperature: float = META_EVAL_PAIRSCORE_TEMPERATURE
+) -> float:
+    score = PairScore(temperature=temperature).parse_model_raw(judge_completion)
+    if score is None or np.isnan(score):
+        return 0.5
+    return float(score)
+
+
+def parse_pairscore_winner(
+    judge_completion: str,
+    *,
+    temperature: float = META_EVAL_PAIRSCORE_TEMPERATURE,
+    eps: float = TIE_EPSILON,
+) -> str:
+    score = parse_pairscore_pref(judge_completion, temperature=temperature)
+    if abs(score - 0.5) < eps:
+        return "tie"
+    return "model_b" if score > 0.5 + eps else "model_a"
+
+
+def _battle_texts(df: pd.DataFrame) -> tuple[list[str], list[str], list[str]]:
+    instructions = [extract_turn_text(conv[0]) for conv in df["conversation_a"]]
+    completions_a = [
+        extract_turn_text(conv[1]) if len(conv) > 1 else ""
+        for conv in df["conversation_a"]
+    ]
+    completions_b = [
+        extract_turn_text(conv[1]) if len(conv) > 1 else ""
+        for conv in df["conversation_b"]
+    ]
+    return instructions, completions_a, completions_b
+
+
+def annotate_sample(
+    df_sample: pd.DataFrame,
+    cfg: RunConfig,
+    *,
+    judge_chat_model,
+    resolved_prompt: ResolvedJudgePrompt,
+) -> pd.DataFrame:
+    instructions, completions_a, completions_b = _battle_texts(df_sample)
+    annotations = annotate_battles(
+        judge_chat_model=judge_chat_model,
+        instructions=instructions,
+        completions_A=completions_a,
+        completions_B=completions_b,
+        system_prompt=resolved_prompt.system_prompt,
+        user_prompt_template=resolved_prompt.user_prompt_template,
+        prompt_preset=resolved_prompt.preset_name,
+        truncate_input_chars=cfg.generation.truncate_judge_input_chars,
+        provide_explanation=cfg.judge.provide_explanation,
+        strip_thinking_before_judging=cfg.judge.strip_thinking_before_judging,
+        use_tqdm=cfg.run.use_tqdm,
+    )
+    rows = []
+    for annotation, (_, battle) in zip(annotations, df_sample.iterrows(), strict=True):
+        completion = annotation.judge_completion
+        rows.append(
+            {
+                "question_id": battle["question_id"],
+                "model_a": battle["model_a"],
+                "model_b": battle["model_b"],
+                "winner": battle["winner"],
+                "lang": battle["lang"],
+                "instruction": annotation.instruction,
+                "completion_a": annotation.completion_A,
+                "completion_b": annotation.completion_B,
+                "judge_input": serialize_judge_input(annotation.judge_input),
+                "judge_completion": completion,
+                "winner_llm": parse_pairscore_winner(completion),
+                "pref_llm": parse_pairscore_pref(completion),
+            }
+        )
+    return pd.DataFrame(rows)

--- a/judgearena/benchmarks/meta_eval/annotate.py
+++ b/judgearena/benchmarks/meta_eval/annotate.py
@@ -44,9 +44,9 @@ def parse_pairscore_winner(
     eps: float = TIE_EPSILON,
 ) -> str:
     score = parse_pairscore_pref(judge_completion, temperature=temperature)
-    if abs(score - 0.5) < eps:
+    if abs(score - 0.5) <= eps:
         return "tie"
-    return "model_b" if score > 0.5 + eps else "model_a"
+    return "model_b" if score > 0.5 else "model_a"
 
 
 def _battle_texts(df: pd.DataFrame) -> tuple[list[str], list[str], list[str]]:

--- a/judgearena/benchmarks/meta_eval/runner.py
+++ b/judgearena/benchmarks/meta_eval/runner.py
@@ -49,6 +49,8 @@ class MetaEvalReport(Report):
     """Arena supplying the human votes."""
     judge_model: str
     """Judge under evaluation."""
+    prompt_preset: str
+    """Judge prompt preset the verdicts were parsed under."""
     languages: list[str]
     """Language codes the sample was restricted to (empty means all)."""
     top_models: list[str]
@@ -144,6 +146,7 @@ def run_meta_eval(cfg: RunConfig, task: ResolvedTaskSpec | None = None) -> dict:
         task=cfg.task,
         arena=protocol.arena,
         judge_model=cfg.judge.model,
+        prompt_preset=resolved_prompt.preset_name,
         languages=languages,
         top_models=top_models,
         n_battles=len(sample),
@@ -155,10 +158,14 @@ def run_meta_eval(cfg: RunConfig, task: ResolvedTaskSpec | None = None) -> dict:
     results = report.to_dict()
     report.render()
 
+    # The prompt preset and the swap mode both change the verdicts, so they have
+    # to be part of the folder name: otherwise a second run under a different
+    # preset or swap mode silently overwrites the first run's artifacts.
     res_dir = prepare_run_directory(
         cfg,
         Path(cfg.run.result_folder)
-        / f"{safe_filename(cfg.task)}-{safe_filename(cfg.judge.model)}",
+        / f"{safe_filename(cfg.task)}-{safe_filename(resolved_prompt.preset_name)}-"
+        f"{safe_filename(cfg.judge.model)}-{cfg.judge.swap_mode}",
     )
     result_path = report.save(res_dir / "results.json")
     sample[list(SAMPLE_COLUMNS)].to_parquet(res_dir / SAMPLE_FILENAME, index=False)

--- a/judgearena/benchmarks/meta_eval/runner.py
+++ b/judgearena/benchmarks/meta_eval/runner.py
@@ -1,4 +1,4 @@
-"""Select the human-labeled battles a judge meta-evaluation will score."""
+"""Score a judge against human-labeled arena battles."""
 
 from __future__ import annotations
 
@@ -12,6 +12,12 @@ from judgearena.artifacts import (
     write_run_metadata_safely,
 )
 from judgearena.benchmarks.arena import resolve_task_languages
+from judgearena.benchmarks.execution import build_judge
+from judgearena.benchmarks.meta_eval.agreement import (
+    agreement_view,
+    compute_agreement_metrics,
+)
+from judgearena.benchmarks.meta_eval.annotate import annotate_sample
 from judgearena.benchmarks.meta_eval.sampling import (
     MetaEvalSamplingError,
     normalize_human_winner,
@@ -19,6 +25,7 @@ from judgearena.benchmarks.meta_eval.sampling import (
     select_top_models,
 )
 from judgearena.datasets import load_battles
+from judgearena.evaluate import resolve_run_judge_prompt
 from judgearena.log import get_logger
 from judgearena.tasks.schema import MetaEvalProtocol, ResolvedTaskSpec
 from judgearena.utils.eval import Report
@@ -29,37 +36,52 @@ if TYPE_CHECKING:
 logger = get_logger(__name__)
 
 SAMPLE_FILENAME = "sample.parquet"
-# Identity and label columns only: the conversations stay in the pinned arena
-# snapshot, and question_id joins back to them.
+ANNOTATIONS_FILENAME = "annotations.parquet"
 SAMPLE_COLUMNS = ("question_id", "model_a", "model_b", "winner", "lang")
 
 
-class MetaEvalSampleReport(Report):
-    """The human-labeled battle sample a meta-evaluation run will judge."""
+class MetaEvalReport(Report):
+    """Agreement of one judge with the human votes in a sampled arena slice."""
 
     task: str
     """Task ID that selected the arena and its language variant."""
     arena: str
     """Arena supplying the human votes."""
     judge_model: str
-    """Judge the sample was drawn for."""
+    """Judge under evaluation."""
     languages: list[str]
     """Language codes the sample was restricted to (empty means all)."""
     top_models: list[str]
     """Most-battled models; only battles between two of them are sampled."""
     n_battles: int
     """Sampled battles, counting a battle once per model it was drawn for."""
+    n_annotations: int
+    """Judge passes written to annotations.parquet (one per sampled battle)."""
     battles_per_language: dict[str, int]
     """Sampled battle count per language code."""
     human_winner_counts: dict[str, int]
     """Sampled battle count per human verdict (model_a, model_b, tie)."""
+    agreement: dict[str, dict[str, float | int | str]]
+    """Accuracy and Cohen's kappa on all battles and on the no-human-tie subset."""
 
     def render(self) -> None:
-        print(f"\n=== Meta-eval sample: {self.task} ===")
+        print(f"\n=== Meta-eval: {self.task} ===")
         print(f"Arena: {self.arena}  |  Judge: {self.judge_model}")
         print(f"Models: {len(self.top_models)}  |  Battles: {self.n_battles}")
         print(f"  Languages: {_format_counts(self.battles_per_language)}")
         print(f"  Human votes: {_format_counts(self.human_winner_counts)}")
+        all_view = self.agreement["all"]
+        no_tie = self.agreement["no_human_ties"]
+        print(
+            f"  Agreement (all, n={all_view['n']}): "
+            f"acc {all_view['accuracy_formatted']}  "
+            f"κ {all_view['kappa_formatted']}"
+        )
+        print(
+            f"  Agreement (no human ties, n={no_tie['n']}): "
+            f"acc {no_tie['accuracy_formatted']}  "
+            f"κ {no_tie['kappa_formatted']}"
+        )
 
 
 def _format_counts(counts: dict[str, int]) -> str:
@@ -67,7 +89,7 @@ def _format_counts(counts: dict[str, int]) -> str:
 
 
 def run_meta_eval(cfg: RunConfig, task: ResolvedTaskSpec | None = None) -> dict:
-    """Sample the battles a judge will be scored against."""
+    """Sample arena battles, judge them, and report agreement with human labels."""
     protocol = task.spec.protocol if task is not None else None
     if not isinstance(protocol, MetaEvalProtocol):
         raise ValueError(f"Task {cfg.task!r} does not define a meta-eval protocol.")
@@ -100,15 +122,35 @@ def run_meta_eval(cfg: RunConfig, task: ResolvedTaskSpec | None = None) -> dict:
         "Sampled %d battles among the top %d models.", len(sample), len(top_models)
     )
 
-    report = MetaEvalSampleReport(
+    resolved_prompt = resolve_run_judge_prompt(cfg.task, cfg.judge)
+    annotations = annotate_sample(
+        sample,
+        cfg,
+        judge_chat_model=build_judge(cfg),
+        resolved_prompt=resolved_prompt,
+    )
+    metrics = compute_agreement_metrics(
+        annotations["winner"].tolist(),
+        annotations["winner_llm"].tolist(),
+        n_bootstraps=cfg.meta_eval.n_bootstraps,
+        seed=cfg.run.seed,
+    )
+    agreement = {
+        "all": agreement_view(metrics, exclude_human_ties=False),
+        "no_human_ties": agreement_view(metrics, exclude_human_ties=True),
+    }
+
+    report = MetaEvalReport(
         task=cfg.task,
         arena=protocol.arena,
         judge_model=cfg.judge.model,
         languages=languages,
         top_models=top_models,
         n_battles=len(sample),
+        n_annotations=len(annotations),
         battles_per_language=sample["lang"].value_counts().to_dict(),
         human_winner_counts=sample["winner"].value_counts().to_dict(),
+        agreement=agreement,
     )
     results = report.to_dict()
     report.render()
@@ -120,13 +162,16 @@ def run_meta_eval(cfg: RunConfig, task: ResolvedTaskSpec | None = None) -> dict:
     )
     result_path = report.save(res_dir / "results.json")
     sample[list(SAMPLE_COLUMNS)].to_parquet(res_dir / SAMPLE_FILENAME, index=False)
+    annotations.to_parquet(res_dir / ANNOTATIONS_FILENAME, index=False)
     write_run_metadata_safely(
         output_dir=res_dir,
         entrypoint="judgearena.benchmarks.meta_eval.runner.run_meta_eval",
         run=cfg.model_dump(),
         results=results,
         input_payloads={"question_id": sample["question_id"].astype(str).tolist()},
+        judge_system_prompt=resolved_prompt.system_prompt,
+        judge_user_prompt_template=resolved_prompt.user_prompt_template,
         started_at_utc=run_started_at,
     )
-    logger.info("Meta-eval sample written to %s", res_dir)
+    logger.info("Meta-eval results written to %s", res_dir)
     return {**results, "result_path": str(result_path)}

--- a/judgearena/config.py
+++ b/judgearena/config.py
@@ -346,6 +346,9 @@ class MetaEvalArgs(BaseModel):
     """Battles sampled per selected model. A battle involving two selected
     models can be drawn for either of them."""
 
+    n_bootstraps: int = Field(default=20, gt=0)
+    """Bootstrap resamples used for agreement standard errors."""
+
     languages: list[str] | None = None
     """Restrict battles to these language codes (e.g. ``["en", "fr"]``).
     Defaults to all languages of the task."""

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -123,6 +123,7 @@ def test_meta_eval_config_derives_arena():
 
     assert cfg.meta_eval is not None
     assert cfg.meta_eval.arena == "ComparIA"
+    assert cfg.meta_eval.n_bootstraps == 20
     assert cfg.elo is None
 
 

--- a/tests/test_meta_eval_task_runtime.py
+++ b/tests/test_meta_eval_task_runtime.py
@@ -1,12 +1,24 @@
 from __future__ import annotations
 
 import json
+from types import SimpleNamespace
 
 import pandas as pd
 import pytest
 
+import judgearena.benchmarks.meta_eval.annotate as annotate_module
 import judgearena.benchmarks.meta_eval.runner as runner_module
-from judgearena.benchmarks.meta_eval.runner import SAMPLE_FILENAME, run_meta_eval
+from judgearena.benchmarks.meta_eval.agreement import compute_agreement_metrics
+from judgearena.benchmarks.meta_eval.annotate import (
+    parse_pairscore_pref,
+    parse_pairscore_winner,
+    serialize_judge_input,
+)
+from judgearena.benchmarks.meta_eval.runner import (
+    ANNOTATIONS_FILENAME,
+    SAMPLE_FILENAME,
+    run_meta_eval,
+)
 from judgearena.benchmarks.meta_eval.sampling import (
     MetaEvalSamplingError,
     sample_battles_per_model,
@@ -14,7 +26,15 @@ from judgearena.benchmarks.meta_eval.sampling import (
 )
 from judgearena.benchmarks.registry import resolve_benchmark
 from judgearena.config import RunConfig
+from judgearena.evaluate import JudgeAnnotation
 from judgearena.tasks.registry import get_packaged_task
+
+
+def _turns(answer: str) -> list[dict[str, str]]:
+    return [
+        {"role": "user", "content": "q"},
+        {"role": "assistant", "content": answer},
+    ]
 
 
 def _battles() -> pd.DataFrame:
@@ -26,6 +46,8 @@ def _battles() -> pd.DataFrame:
             "model_b": models[(i + 1) % 3],
             "winner": "tie (bothbad)" if i % 5 == 0 else "model_a",
             "lang": "fr" if i % 2 else "en",
+            "conversation_a": _turns("a"),
+            "conversation_b": _turns("b"),
         }
         for i in range(30)
     ]
@@ -36,6 +58,8 @@ def _battles() -> pd.DataFrame:
             "model_b": "m1",
             "winner": "model_b",
             "lang": "en",
+            "conversation_a": _turns("a"),
+            "conversation_b": _turns("b"),
         }
     )
     return pd.DataFrame(rows)
@@ -48,6 +72,24 @@ def _cfg(tmp_path, **overrides) -> RunConfig:
         run={"result_folder": str(tmp_path), "no_log_file": True},
         **overrides,
     )
+
+
+def _fake_annotations(**kwargs):
+    return [
+        JudgeAnnotation(
+            instruction=instruction,
+            completion_A=completion_a,
+            completion_B=completion_b,
+            judge_completion="score_A: 9\nscore_B: 1",
+            judge_input=SimpleNamespace(to_string=lambda: "prompt"),
+        )
+        for instruction, completion_a, completion_b in zip(
+            kwargs["instructions"],
+            kwargs["completions_A"],
+            kwargs["completions_B"],
+            strict=True,
+        )
+    ]
 
 
 def test_meta_eval_task_is_registered_with_the_arena_battle_stack():
@@ -87,21 +129,52 @@ def test_sampling_rejects_a_disconnected_top_model_set():
         select_top_models(battles, top_models=1)
 
 
-def test_runner_writes_a_reproducible_sample_manifest(tmp_path, monkeypatch):
+def test_pairscore_parses_winners_at_meta_eval_temperature():
+    assert parse_pairscore_winner("score_A: 10\nscore_B: 0") == "model_a"
+    assert parse_pairscore_winner("score_A: 0\nscore_B: 10") == "model_b"
+    assert parse_pairscore_winner("score_A: 5\nscore_B: 5") == "tie"
+    assert parse_pairscore_pref("score_A: 10\nscore_B: 0") < 0.5
+    assert serialize_judge_input(SimpleNamespace(to_string=lambda: "p")) == "p"
+
+
+def test_agreement_metrics_on_fixture():
+    metrics = compute_agreement_metrics(
+        ["model_a", "model_b", "tie", "model_a"],
+        ["model_a", "model_a", "tie", "model_b"],
+        n_bootstraps=10,
+        seed=0,
+    )
+    assert metrics["n"] == 4
+    assert metrics["accuracy"] == 0.5
+    assert metrics["n_nt"] == 3
+
+
+def test_degenerate_agreement_reports_nan_kappa():
+    metrics = compute_agreement_metrics(
+        ["model_a", "model_a"],
+        ["model_a", "model_a"],
+        n_bootstraps=4,
+        seed=0,
+    )
+    assert metrics["accuracy"] == 1.0
+    assert pd.isna(metrics["kappa"])
+
+
+def test_runner_writes_annotations_and_agreement(tmp_path, monkeypatch):
     monkeypatch.setattr(runner_module, "load_battles", lambda _task: _battles())
+    monkeypatch.setattr(runner_module, "build_judge", lambda _cfg: object())
+    monkeypatch.setattr(annotate_module, "annotate_battles", _fake_annotations)
     cfg = _cfg(tmp_path, meta_eval={"top_models": 3, "battles_per_model": 5})
 
     results = run_meta_eval(cfg, get_packaged_task("meta-eval-comparia"))
 
     res_dir = tmp_path / "meta-eval-comparia-dummy-j"
     sample = pd.read_parquet(res_dir / SAMPLE_FILENAME)
-    assert results["n_battles"] == len(sample) == 15
-    assert set(sample["winner"]) <= {"model_a", "model_b", "tie"}
-    assert sorted(sample.columns) == [
-        "lang",
-        "model_a",
-        "model_b",
-        "question_id",
-        "winner",
-    ]
+    annotations = pd.read_parquet(res_dir / ANNOTATIONS_FILENAME)
+    assert results["n_battles"] == results["n_annotations"] == len(sample) == 15
+    assert len(annotations) == 15
+    assert set(annotations["winner_llm"]) == {"model_a"}
+    assert annotations["judge_input"].tolist() == ["prompt"] * 15
+    assert results["agreement"]["all"]["n"] == 15
+    assert results["agreement"]["no_human_ties"]["n"] < 15
     assert json.loads((res_dir / "results.json").read_text())["arena"] == "ComparIA"

--- a/tests/test_meta_eval_task_runtime.py
+++ b/tests/test_meta_eval_task_runtime.py
@@ -168,7 +168,7 @@ def test_runner_writes_annotations_and_agreement(tmp_path, monkeypatch):
 
     results = run_meta_eval(cfg, get_packaged_task("meta-eval-comparia"))
 
-    res_dir = tmp_path / "meta-eval-comparia-dummy-j"
+    res_dir = tmp_path / "meta-eval-comparia-default-dummy-j-fixed"
     sample = pd.read_parquet(res_dir / SAMPLE_FILENAME)
     annotations = pd.read_parquet(res_dir / ANNOTATIONS_FILENAME)
     assert results["n_battles"] == results["n_annotations"] == len(sample) == 15


### PR DESCRIPTION
# Description

> [!NOTE]
> Packaged meta-eval split from closed PR #76. Meta-eval does not use the unified `do_inference` cache, and the cache stack (#94-#100) does not wire it up either: caching will be added to meta-eval once those PRs are merged.

Judges the sampled battles in stored A/B order and reports accuracy and Cohen's kappa with bootstrap SE. Agreement is written for all battles and for the no-human-tie subset.

PairScore temperature is 0.5 here (paper / Figure 4); generate+judge stays 0.3.

This is stacked on #101.
