### PR TITLE
Meta-eval: (3/7) Judge both A/B orders with orientation-normalized rows

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,9 +317,12 @@ judgearena \
 | `--meta_eval.battles_per_model` | `50` | Battles sampled per selected model |
 | `--meta_eval.languages` | all | Restrict to language codes, e.g. `'["en", "es"]'` |
 | `--meta_eval.n_bootstraps` | `20` | Bootstrap samples for agreement standard errors |
+| `--judge.swap_mode` | `fixed` | `fixed`: one A-B pass; `both`: judge each battle in both orders |
 | `--model.name` | unset | Not used: both completions already exist in the arena |
 
 Results go under `[result_folder]/meta-eval-*-<judge>/` as `sample.parquet`, `annotations.parquet`, `results.json`, `config.yaml`, and `run-metadata.v1.json`. `results.json` reports agreement on all battles and on the subset that drops human ties.
+
+With `--judge.swap_mode both`, accuracy and kappa use both orderings (the reversed verdict is inverted back to the stored A/B identity). `annotations.parquet` stores one row per judge pass with an `orientation` column; `winner_llm` and `pref_llm` are always in the original model order.
 
 ## 📈 Estimating ELO Ratings
 

--- a/judgearena/benchmarks/meta_eval/annotate.py
+++ b/judgearena/benchmarks/meta_eval/annotate.py
@@ -1,4 +1,4 @@
-"""Judge a sampled arena battle set in the stored A/B order."""
+"""Judge a sampled arena battle set, optionally in both A/B orders."""
 
 from __future__ import annotations
 
@@ -49,6 +49,14 @@ def parse_pairscore_winner(
     return "model_b" if score > 0.5 + eps else "model_a"
 
 
+def invert_winner(winner: str) -> str:
+    if winner == "model_a":
+        return "model_b"
+    if winner == "model_b":
+        return "model_a"
+    return winner
+
+
 def _battle_texts(df: pd.DataFrame) -> tuple[list[str], list[str], list[str]]:
     instructions = [extract_turn_text(conv[0]) for conv in df["conversation_a"]]
     completions_a = [
@@ -62,14 +70,23 @@ def _battle_texts(df: pd.DataFrame) -> tuple[list[str], list[str], list[str]]:
     return instructions, completions_a, completions_b
 
 
-def annotate_sample(
-    df_sample: pd.DataFrame,
+def _swap_batch(df: pd.DataFrame) -> pd.DataFrame:
+    swapped = df.copy()
+    swapped["conversation_a"] = df["conversation_b"]
+    swapped["conversation_b"] = df["conversation_a"]
+    swapped["model_a"] = df["model_b"]
+    swapped["model_b"] = df["model_a"]
+    return swapped
+
+
+def _judge_pass(
+    df_batch: pd.DataFrame,
     cfg: RunConfig,
     *,
     judge_chat_model,
     resolved_prompt: ResolvedJudgePrompt,
 ) -> pd.DataFrame:
-    instructions, completions_a, completions_b = _battle_texts(df_sample)
+    instructions, completions_a, completions_b = _battle_texts(df_batch)
     annotations = annotate_battles(
         judge_chat_model=judge_chat_model,
         instructions=instructions,
@@ -84,7 +101,7 @@ def annotate_sample(
         use_tqdm=cfg.run.use_tqdm,
     )
     rows = []
-    for annotation, (_, battle) in zip(annotations, df_sample.iterrows(), strict=True):
+    for annotation, (_, battle) in zip(annotations, df_batch.iterrows(), strict=True):
         completion = annotation.judge_completion
         rows.append(
             {
@@ -103,3 +120,61 @@ def annotate_sample(
             }
         )
     return pd.DataFrame(rows)
+
+
+def _normalize_pass(
+    pass_frame: pd.DataFrame, original: pd.DataFrame, *, orientation: str
+) -> pd.DataFrame:
+    """Map a judged pass back onto the arena's stored A/B identity."""
+    normalized = pass_frame.copy()
+    normalized["orientation"] = orientation
+    normalized["presented_model_a"] = pass_frame["model_a"].tolist()
+    normalized["presented_model_b"] = pass_frame["model_b"].tolist()
+    normalized["presented_completion_a"] = pass_frame["completion_a"].tolist()
+    normalized["presented_completion_b"] = pass_frame["completion_b"].tolist()
+    normalized["model_a"] = original["model_a"].tolist()
+    normalized["model_b"] = original["model_b"].tolist()
+    normalized["winner"] = original["winner"].tolist()
+    if orientation == "swapped":
+        normalized["completion_a"] = pass_frame["completion_b"].tolist()
+        normalized["completion_b"] = pass_frame["completion_a"].tolist()
+        normalized["winner_llm"] = [
+            invert_winner(winner) for winner in pass_frame["winner_llm"]
+        ]
+        normalized["pref_llm"] = 1.0 - pass_frame["pref_llm"]
+    return normalized
+
+
+def annotate_sample(
+    df_sample: pd.DataFrame,
+    cfg: RunConfig,
+    *,
+    judge_chat_model,
+    resolved_prompt: ResolvedJudgePrompt,
+) -> pd.DataFrame:
+    parts = [
+        _normalize_pass(
+            _judge_pass(
+                df_sample,
+                cfg,
+                judge_chat_model=judge_chat_model,
+                resolved_prompt=resolved_prompt,
+            ),
+            df_sample,
+            orientation="forward",
+        )
+    ]
+    if cfg.judge.swap_mode == "both":
+        parts.append(
+            _normalize_pass(
+                _judge_pass(
+                    _swap_batch(df_sample),
+                    cfg,
+                    judge_chat_model=judge_chat_model,
+                    resolved_prompt=resolved_prompt,
+                ),
+                df_sample,
+                orientation="swapped",
+            )
+        )
+    return pd.concat(parts, ignore_index=True)

--- a/judgearena/benchmarks/meta_eval/runner.py
+++ b/judgearena/benchmarks/meta_eval/runner.py
@@ -56,7 +56,9 @@ class MetaEvalReport(Report):
     n_battles: int
     """Sampled battles, counting a battle once per model it was drawn for."""
     n_annotations: int
-    """Judge passes written to annotations.parquet (one per sampled battle)."""
+    """Judge passes written to annotations.parquet (one or two per sampled battle)."""
+    swap_mode: str
+    """Position-bias handling used for judging: "fixed" or "both"."""
     battles_per_language: dict[str, int]
     """Sampled battle count per language code."""
     human_winner_counts: dict[str, int]
@@ -67,7 +69,10 @@ class MetaEvalReport(Report):
     def render(self) -> None:
         print(f"\n=== Meta-eval: {self.task} ===")
         print(f"Arena: {self.arena}  |  Judge: {self.judge_model}")
-        print(f"Models: {len(self.top_models)}  |  Battles: {self.n_battles}")
+        print(
+            f"Models: {len(self.top_models)}  |  Battles: {self.n_battles}  |  "
+            f"Judge passes: {self.n_annotations} ({self.swap_mode})"
+        )
         print(f"  Languages: {_format_counts(self.battles_per_language)}")
         print(f"  Human votes: {_format_counts(self.human_winner_counts)}")
         all_view = self.agreement["all"]
@@ -148,6 +153,7 @@ def run_meta_eval(cfg: RunConfig, task: ResolvedTaskSpec | None = None) -> dict:
         top_models=top_models,
         n_battles=len(sample),
         n_annotations=len(annotations),
+        swap_mode=cfg.judge.swap_mode,
         battles_per_language=sample["lang"].value_counts().to_dict(),
         human_winner_counts=sample["winner"].value_counts().to_dict(),
         agreement=agreement,

--- a/tests/test_meta_eval_task_runtime.py
+++ b/tests/test_meta_eval_task_runtime.py
@@ -10,6 +10,7 @@ import judgearena.benchmarks.meta_eval.annotate as annotate_module
 import judgearena.benchmarks.meta_eval.runner as runner_module
 from judgearena.benchmarks.meta_eval.agreement import compute_agreement_metrics
 from judgearena.benchmarks.meta_eval.annotate import (
+    invert_winner,
     parse_pairscore_pref,
     parse_pairscore_winner,
     serialize_judge_input,
@@ -66,12 +67,13 @@ def _battles() -> pd.DataFrame:
 
 
 def _cfg(tmp_path, **overrides) -> RunConfig:
-    return RunConfig(
-        task="meta-eval-comparia",
-        judge={"model": "Dummy/j"},
-        run={"result_folder": str(tmp_path), "no_log_file": True},
-        **overrides,
-    )
+    values = {
+        "task": "meta-eval-comparia",
+        "judge": {"model": "Dummy/j"},
+        "run": {"result_folder": str(tmp_path), "no_log_file": True},
+    }
+    values.update(overrides)
+    return RunConfig(**values)
 
 
 def _fake_annotations(**kwargs):
@@ -135,6 +137,8 @@ def test_pairscore_parses_winners_at_meta_eval_temperature():
     assert parse_pairscore_winner("score_A: 5\nscore_B: 5") == "tie"
     assert parse_pairscore_pref("score_A: 10\nscore_B: 0") < 0.5
     assert serialize_judge_input(SimpleNamespace(to_string=lambda: "p")) == "p"
+    assert invert_winner("model_a") == "model_b"
+    assert invert_winner("tie") == "tie"
 
 
 def test_agreement_metrics_on_fixture():
@@ -173,8 +177,37 @@ def test_runner_writes_annotations_and_agreement(tmp_path, monkeypatch):
     annotations = pd.read_parquet(res_dir / ANNOTATIONS_FILENAME)
     assert results["n_battles"] == results["n_annotations"] == len(sample) == 15
     assert len(annotations) == 15
+    assert set(annotations["orientation"]) == {"forward"}
     assert set(annotations["winner_llm"]) == {"model_a"}
     assert annotations["judge_input"].tolist() == ["prompt"] * 15
     assert results["agreement"]["all"]["n"] == 15
     assert results["agreement"]["no_human_ties"]["n"] < 15
     assert json.loads((res_dir / "results.json").read_text())["arena"] == "ComparIA"
+
+
+def test_swap_mode_both_inverts_the_reversed_pass(tmp_path, monkeypatch):
+    monkeypatch.setattr(runner_module, "load_battles", lambda _task: _battles())
+    monkeypatch.setattr(runner_module, "build_judge", lambda _cfg: object())
+    monkeypatch.setattr(annotate_module, "annotate_battles", _fake_annotations)
+    cfg = _cfg(
+        tmp_path,
+        judge={"model": "Dummy/j", "swap_mode": "both"},
+        meta_eval={"top_models": 3, "battles_per_model": 5},
+    )
+
+    results = run_meta_eval(cfg, get_packaged_task("meta-eval-comparia"))
+
+    annotations = pd.read_parquet(
+        tmp_path / "meta-eval-comparia-dummy-j" / ANNOTATIONS_FILENAME
+    )
+    assert results["n_battles"] == 15
+    assert results["n_annotations"] == results["agreement"]["all"]["n"] == 30
+    assert set(annotations["orientation"]) == {"forward", "swapped"}
+    forward = annotations[annotations["orientation"] == "forward"]
+    swapped = annotations[annotations["orientation"] == "swapped"]
+    assert set(forward["winner_llm"]) == {"model_a"}
+    assert set(swapped["winner_llm"]) == {"model_b"}
+    assert forward["model_a"].tolist() == swapped["model_a"].tolist()
+    assert (
+        forward["presented_model_a"].tolist() == swapped["presented_model_b"].tolist()
+    )


### PR DESCRIPTION
# Description

> [!NOTE]
> Packaged meta-eval split from closed PR #76. Meta-eval does not use the unified `do_inference` cache, and the cache stack (#94-#100) does not wire it up either: caching will be added to meta-eval once those PRs are merged.

`--judge.swap_mode both` judges each sampled battle in both orders. The reversed pass is inverted back onto the stored A/B identity. Overall accuracy and kappa use both passes; ranking later uses one forward-order row per battle.

This is stacked on #102.
