### PR TITLE
Meta-eval: (4/7) Register ranking metrics as the meta-eval scoring adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ Language variants follow the ELO pattern (`meta-eval-lmarena-140k-uk`, `meta-eva
 
 Meta-evaluation scores a judge against **human-labeled arena battles**. It does not generate completions and does not rate a model. Use `elo-*` for that.
 
-The task keeps the most-battled models, samples battles among them, asks the judge to label the stored A/B order, and reports accuracy and Cohen's kappa (with bootstrap SE) against the human vote. PairScore uses temperature `0.5` here; generate+judge keeps `0.3`.
+The task keeps the most-battled models, samples battles among them, asks the judge to label the stored A/B order, and reports accuracy, Cohen's kappa, Spearman correlation of Bradley-Terry ratings, and Elo MAE (with bootstrap SE) against the human vote. PairScore uses temperature `0.5` here; generate+judge keeps `0.3`.
 
 ```bash
 judgearena \
@@ -316,13 +316,14 @@ judgearena \
 | `--meta_eval.top_models` | `20` | Keep the N models with the most battles |
 | `--meta_eval.battles_per_model` | `50` | Battles sampled per selected model |
 | `--meta_eval.languages` | all | Restrict to language codes, e.g. `'["en", "es"]'` |
-| `--meta_eval.n_bootstraps` | `20` | Bootstrap samples for agreement standard errors |
+| `--meta_eval.n_bootstraps` | `20` | Bootstrap samples for agreement and ranking standard errors |
+| `--meta_eval.include_human_ties` | off | Keep human-tie battles in the ranking language splits |
 | `--judge.swap_mode` | `fixed` | `fixed`: one A-B pass; `both`: judge each battle in both orders |
 | `--model.name` | unset | Not used: both completions already exist in the arena |
 
-Results go under `[result_folder]/meta-eval-*-<judge>/` as `sample.parquet`, `annotations.parquet`, `results.json`, `config.yaml`, and `run-metadata.v1.json`. `results.json` reports agreement on all battles and on the subset that drops human ties.
+Results go under `[result_folder]/meta-eval-*-<judge>/` as `sample.parquet`, `annotations.parquet`, `summary.csv`, `results.json`, `config.yaml`, and `run-metadata.v1.json`. `results.json` reports agreement on all battles and on the subset that drops human ties, plus English vs multilingual ranking splits.
 
-With `--judge.swap_mode both`, accuracy and kappa use both orderings (the reversed verdict is inverted back to the stored A/B identity). `annotations.parquet` stores one row per judge pass with an `orientation` column; `winner_llm` and `pref_llm` are always in the original model order.
+With `--judge.swap_mode both`, overall accuracy and kappa use both orderings (the reversed verdict is inverted back to the stored A/B identity). Ranking, language splits, and later Elo-gap analyses keep one forward-order row per sampled battle. `annotations.parquet` stores one row per judge pass with an `orientation` column; `winner_llm` and `pref_llm` are always in the original model order.
 
 ## 📈 Estimating ELO Ratings
 

--- a/judgearena/benchmarks/meta_eval/runner.py
+++ b/judgearena/benchmarks/meta_eval/runner.py
@@ -6,6 +6,8 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+import pandas as pd
+
 from judgearena.artifacts import (
     prepare_run_directory,
     safe_filename,
@@ -24,6 +26,10 @@ from judgearena.benchmarks.meta_eval.sampling import (
     sample_battles_per_model,
     select_top_models,
 )
+from judgearena.benchmarks.meta_eval.scoring import (
+    META_EVAL_SCORERS,
+    ranking_annotations,
+)
 from judgearena.datasets import load_battles
 from judgearena.evaluate import resolve_run_judge_prompt
 from judgearena.log import get_logger
@@ -37,6 +43,7 @@ logger = get_logger(__name__)
 
 SAMPLE_FILENAME = "sample.parquet"
 ANNOTATIONS_FILENAME = "annotations.parquet"
+SUMMARY_FILENAME = "summary.csv"
 SAMPLE_COLUMNS = ("question_id", "model_a", "model_b", "winner", "lang")
 
 
@@ -65,6 +72,8 @@ class MetaEvalReport(Report):
     """Sampled battle count per human verdict (model_a, model_b, tie)."""
     agreement: dict[str, dict[str, float | int | str]]
     """Accuracy and Cohen's kappa on all battles and on the no-human-tie subset."""
+    language_summary: dict[str, dict[str, str | int]]
+    """English vs multilingual ranking agreement, fit on forward-order rows."""
 
     def render(self) -> None:
         print(f"\n=== Meta-eval: {self.task} ===")
@@ -87,6 +96,11 @@ class MetaEvalReport(Report):
             f"acc {no_tie['accuracy_formatted']}  "
             f"κ {no_tie['kappa_formatted']}"
         )
+        for split, metrics in self.language_summary.items():
+            print(
+                f"  {split} (n={metrics['n']}): κ {metrics['kappa']}  "
+                f"ρ {metrics['spearman']}  MAE {metrics['mae_elo']}"
+            )
 
 
 def _format_counts(counts: dict[str, int]) -> str:
@@ -144,6 +158,13 @@ def run_meta_eval(cfg: RunConfig, task: ResolvedTaskSpec | None = None) -> dict:
         "all": agreement_view(metrics, exclude_human_ties=False),
         "no_human_ties": agreement_view(metrics, exclude_human_ties=True),
     }
+    scorer = META_EVAL_SCORERS[protocol.scoring.adapter]
+    language_summary = scorer.language_splits(
+        ranking_annotations(annotations),
+        exclude_human_ties=not cfg.meta_eval.include_human_ties,
+        n_bootstraps=cfg.meta_eval.n_bootstraps,
+        seed=cfg.run.seed,
+    )
 
     report = MetaEvalReport(
         task=cfg.task,
@@ -157,6 +178,7 @@ def run_meta_eval(cfg: RunConfig, task: ResolvedTaskSpec | None = None) -> dict:
         battles_per_language=sample["lang"].value_counts().to_dict(),
         human_winner_counts=sample["winner"].value_counts().to_dict(),
         agreement=agreement,
+        language_summary=language_summary,
     )
     results = report.to_dict()
     report.render()
@@ -169,6 +191,9 @@ def run_meta_eval(cfg: RunConfig, task: ResolvedTaskSpec | None = None) -> dict:
     result_path = report.save(res_dir / "results.json")
     sample[list(SAMPLE_COLUMNS)].to_parquet(res_dir / SAMPLE_FILENAME, index=False)
     annotations.to_parquet(res_dir / ANNOTATIONS_FILENAME, index=False)
+    pd.DataFrame(
+        [{"split": split, **metrics} for split, metrics in language_summary.items()]
+    ).to_csv(res_dir / SUMMARY_FILENAME, index=False)
     write_run_metadata_safely(
         output_dir=res_dir,
         entrypoint="judgearena.benchmarks.meta_eval.runner.run_meta_eval",

--- a/judgearena/benchmarks/meta_eval/scoring.py
+++ b/judgearena/benchmarks/meta_eval/scoring.py
@@ -1,0 +1,191 @@
+"""Ranking a judge against human Bradley-Terry ratings."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Callable
+from dataclasses import dataclass
+
+import numpy as np
+import pandas as pd
+from scipy.stats import spearmanr
+
+from judgearena.benchmarks.elo.rating import fit_bradley_terry
+from judgearena.benchmarks.meta_eval.agreement import (
+    compute_agreement_metrics,
+    format_metric,
+)
+
+LanguageSummary = dict[str, dict[str, str | int]]
+RankingFunction = Callable[..., LanguageSummary]
+
+
+def ranking_annotations(df_ann: pd.DataFrame) -> pd.DataFrame:
+    """Keep one stored-order row per sampled battle.
+
+    swap_mode=both writes a forward row and a swapped row; ranking fits must
+    not count the same battle twice.
+    """
+    if "orientation" in df_ann.columns:
+        return df_ann[df_ann["orientation"] == "forward"].copy()
+    return df_ann.copy()
+
+
+def _hard_bradley_terry(df: pd.DataFrame, winner_col: str) -> dict[str, float]:
+    battles = df[["model_a", "model_b", winner_col]].copy()
+    battles["pref"] = battles[winner_col].map(
+        {"model_a": 0.0, "model_b": 1.0, "tie": 0.5, "tie (bothbad)": 0.5}
+    )
+    return fit_bradley_terry(battles, pref_col="pref")
+
+
+def _bt_ratings(df_sub: pd.DataFrame) -> tuple[dict[str, float], dict[str, float]]:
+    try:
+        human = _hard_bradley_terry(df_sub[["model_a", "model_b", "winner"]], "winner")
+        llm = _hard_bradley_terry(
+            df_sub[["model_a", "model_b", "winner_llm"]].rename(
+                columns={"winner_llm": "winner"}
+            ),
+            "winner",
+        )
+    except ValueError:
+        return {}, {}
+    return human, llm
+
+
+def _bt_ratings_soft(df_sub: pd.DataFrame) -> tuple[dict[str, float], dict[str, float]]:
+    human = _hard_bradley_terry(df_sub[["model_a", "model_b", "winner"]], "winner")
+    llm = fit_bradley_terry(
+        df_sub[["model_a", "model_b", "pref_llm"]], pref_col="pref_llm"
+    )
+    return human, llm
+
+
+def _rating_vectors(
+    df_sub: pd.DataFrame, *, soft: bool
+) -> tuple[np.ndarray, np.ndarray]:
+    human, llm = (_bt_ratings_soft if soft else _bt_ratings)(df_sub)
+    common = sorted(set(human) & set(llm))
+    return (
+        np.array([human[model] for model in common]),
+        np.array([llm[model] for model in common]),
+    )
+
+
+def _bootstrap_rank_metric(
+    hv: np.ndarray,
+    lv: np.ndarray,
+    *,
+    metric: str,
+    n_bootstraps: int,
+    seed: int,
+) -> tuple[float, float]:
+    if len(hv) == 0:
+        return float("nan"), float("nan")
+    rng = np.random.default_rng(seed)
+    samples: list[float] = []
+    for _ in range(n_bootstraps):
+        idx = rng.choice(len(hv), size=len(hv), replace=True)
+        if metric == "spearman":
+            if len(np.unique(hv[idx])) < 2 or len(np.unique(lv[idx])) < 2:
+                continue
+            value = float(spearmanr(hv[idx], lv[idx])[0])
+        else:
+            value = float(np.mean(np.abs(hv[idx] - lv[idx])))
+        if math.isfinite(value):
+            samples.append(value)
+    if not samples:
+        return float("nan"), float("nan")
+    return float(np.mean(samples)), float(np.std(samples))
+
+
+def spearman_with_se(
+    df_sub: pd.DataFrame, *, n_bootstraps: int, seed: int, soft: bool = False
+) -> str:
+    human, llm = _rating_vectors(df_sub, soft=soft)
+    if len(human) == 0 or len(np.unique(human)) < 2 or len(np.unique(llm)) < 2:
+        return "n/a"
+    rho, _ = spearmanr(human, llm)
+    if rho is None or not math.isfinite(float(rho)):
+        return "n/a"
+    _, se = _bootstrap_rank_metric(
+        human, llm, metric="spearman", n_bootstraps=n_bootstraps, seed=seed
+    )
+    return format_metric(float(rho), se)
+
+
+def mae_elo_with_se(
+    df_sub: pd.DataFrame, *, n_bootstraps: int, seed: int, soft: bool = False
+) -> str:
+    human, llm = _rating_vectors(df_sub, soft=soft)
+    if len(human) == 0:
+        return "n/a"
+    mae = float(np.mean(np.abs(human - llm)))
+    _, se = _bootstrap_rank_metric(
+        human, llm, metric="mae", n_bootstraps=n_bootstraps, seed=seed
+    )
+    return format_metric(mae, se, digits=1)
+
+
+def summarize_language_splits(
+    df_ann: pd.DataFrame,
+    *,
+    exclude_human_ties: bool,
+    n_bootstraps: int,
+    seed: int,
+) -> LanguageSummary:
+    rows: LanguageSummary = {}
+    for label, mask in [
+        ("English", df_ann["lang"] == "en"),
+        ("Multilingual", df_ann["lang"] != "en"),
+    ]:
+        df_sub = df_ann[mask]
+        if exclude_human_ties:
+            df_sub = df_sub[df_sub["winner"] != "tie"]
+        metrics = compute_agreement_metrics(
+            df_sub["winner"].tolist(),
+            df_sub["winner_llm"].tolist(),
+            n_bootstraps=n_bootstraps,
+            seed=seed,
+        )
+        entry: dict[str, str | int] = {"n": metrics["n"]}
+        if metrics["n"] == 0:
+            entry.update(
+                {
+                    "kappa": "n/a",
+                    "spearman": "n/a",
+                    "spearman_soft": "n/a",
+                    "mae_elo": "n/a",
+                    "mae_soft_elo": "n/a",
+                }
+            )
+        else:
+            entry["kappa"] = format_metric(
+                float(metrics["kappa"]), float(metrics["kappa_se"])
+            )
+            entry["spearman"] = spearman_with_se(
+                df_sub, n_bootstraps=n_bootstraps, seed=seed + 2, soft=False
+            )
+            entry["spearman_soft"] = spearman_with_se(
+                df_sub, n_bootstraps=n_bootstraps, seed=seed + 3, soft=True
+            )
+            entry["mae_elo"] = mae_elo_with_se(
+                df_sub, n_bootstraps=n_bootstraps, seed=seed + 4, soft=False
+            )
+            entry["mae_soft_elo"] = mae_elo_with_se(
+                df_sub, n_bootstraps=n_bootstraps, seed=seed + 5, soft=True
+            )
+        rows[label] = entry
+    return rows
+
+
+@dataclass(frozen=True)
+class MetaEvalScorer:
+    """Ranking implementation selected by a meta-eval task's scoring adapter."""
+
+    language_splits: RankingFunction
+
+
+META_EVAL_SCORERS = {
+    "ranking": MetaEvalScorer(language_splits=summarize_language_splits),
+}

--- a/judgearena/config.py
+++ b/judgearena/config.py
@@ -347,7 +347,11 @@ class MetaEvalArgs(BaseModel):
     models can be drawn for either of them."""
 
     n_bootstraps: int = Field(default=20, gt=0)
-    """Bootstrap resamples used for agreement standard errors."""
+    """Bootstrap resamples used for agreement and ranking standard errors."""
+
+    include_human_ties: bool = False
+    """If set, ranking language splits keep human-tie battles. Agreement
+    always reports both the full set and the no-tie subset."""
 
     languages: list[str] | None = None
     """Restrict battles to these language codes (e.g. ``["en", "fr"]``).

--- a/judgearena/tasks/definitions/meta_eval/_base.yaml
+++ b/judgearena/tasks/definitions/meta_eval/_base.yaml
@@ -15,3 +15,5 @@ protocol:
     default_prompt: default
     default_swap_mode: fixed
     allowed_swap_modes: [fixed, both]
+  scoring:
+    adapter: ranking

--- a/judgearena/tasks/registry.py
+++ b/judgearena/tasks/registry.py
@@ -17,6 +17,7 @@ import yaml
 from pydantic import ValidationError
 
 from judgearena.benchmarks.elo.scoring import ELO_SCORERS
+from judgearena.benchmarks.meta_eval.scoring import META_EVAL_SCORERS
 from judgearena.benchmarks.pairwise.scoring import PAIRWISE_SCORERS
 from judgearena.log import get_logger
 from judgearena.prompts.registry import JUDGE_PROMPT_PRESETS
@@ -256,6 +257,7 @@ class AdapterCatalog:
     prompts: frozenset[str] = frozenset(JUDGE_PROMPT_PRESETS)
     pairwise_scorers: frozenset[str] = frozenset(PAIRWISE_SCORERS)
     elo_scorers: frozenset[str] = frozenset(ELO_SCORERS)
+    meta_eval_scorers: frozenset[str] = frozenset(META_EVAL_SCORERS)
 
 
 def load_tasks(
@@ -301,23 +303,24 @@ def _discover_tasks(
 def _validate_adapter_ids(resolved: ResolvedTaskSpec, adapters: AdapterCatalog) -> None:
     spec = resolved.spec
     is_elo = isinstance(spec.protocol, EloProtocol)
-    reads_battles = is_elo or isinstance(spec.protocol, MetaEvalProtocol)
+    is_meta_eval = isinstance(spec.protocol, MetaEvalProtocol)
     dataset_names = (
-        adapters.battle_datasets if reads_battles else adapters.instruction_datasets
+        adapters.battle_datasets
+        if is_elo or is_meta_eval
+        else adapters.instruction_datasets
     )
+    if is_elo:
+        scorer_names = adapters.elo_scorers
+    elif is_meta_eval:
+        scorer_names = adapters.meta_eval_scorers
+    else:
+        scorer_names = adapters.pairwise_scorers
     references = {
         "runner": (spec.protocol.runner, adapters.runners),
         "dataset adapter": (spec.dataset.adapter, dataset_names),
         "prompt": (spec.protocol.judge.default_prompt, adapters.prompts),
+        "scorer": (spec.protocol.scoring.adapter, scorer_names),
     }
-    # Meta-eval reports agreement with human labels rather than a benchmark
-    # score, so it declares no scoring adapter until its metrics land.
-    scoring = getattr(spec.protocol, "scoring", None)
-    if scoring is not None:
-        references["scorer"] = (
-            scoring.adapter,
-            adapters.elo_scorers if is_elo else adapters.pairwise_scorers,
-        )
     for kind, (adapter_id, available) in references.items():
         if adapter_id not in available:
             raise TaskDefinitionError(

--- a/judgearena/tasks/schema/meta_eval.py
+++ b/judgearena/tasks/schema/meta_eval.py
@@ -7,7 +7,7 @@ from typing import Literal
 from pydantic import Field
 
 from judgearena.tasks.schema.base import StrictFrozenModel
-from judgearena.tasks.schema.pairwise import PairwiseJudgeSpec
+from judgearena.tasks.schema.pairwise import PairwiseJudgeSpec, ScoringSpec
 
 
 class MetaEvalProtocol(StrictFrozenModel):
@@ -21,3 +21,4 @@ class MetaEvalProtocol(StrictFrozenModel):
     runner: Literal["meta_eval"]
     arena: str = Field(min_length=1)
     judge: PairwiseJudgeSpec
+    scoring: ScoringSpec

--- a/tests/test_meta_eval_task_runtime.py
+++ b/tests/test_meta_eval_task_runtime.py
@@ -18,6 +18,7 @@ from judgearena.benchmarks.meta_eval.annotate import (
 from judgearena.benchmarks.meta_eval.runner import (
     ANNOTATIONS_FILENAME,
     SAMPLE_FILENAME,
+    SUMMARY_FILENAME,
     run_meta_eval,
 )
 from judgearena.benchmarks.meta_eval.sampling import (
@@ -25,6 +26,7 @@ from judgearena.benchmarks.meta_eval.sampling import (
     sample_battles_per_model,
     select_top_models,
 )
+from judgearena.benchmarks.meta_eval.scoring import summarize_language_splits
 from judgearena.benchmarks.registry import resolve_benchmark
 from judgearena.config import RunConfig
 from judgearena.evaluate import JudgeAnnotation
@@ -100,6 +102,7 @@ def test_meta_eval_task_is_registered_with_the_arena_battle_stack():
     assert task.spec.protocol.runner == "meta_eval"
     assert task.spec.protocol.arena == "LMArena-140k"
     assert task.spec.dataset.adapter == "arena_battles"
+    assert task.spec.protocol.scoring.adapter == "ranking"
     assert resolve_benchmark("meta-eval-lmarena-140k").adapter.name == "meta_eval"
 
 
@@ -182,6 +185,9 @@ def test_runner_writes_annotations_and_agreement(tmp_path, monkeypatch):
     assert annotations["judge_input"].tolist() == ["prompt"] * 15
     assert results["agreement"]["all"]["n"] == 15
     assert results["agreement"]["no_human_ties"]["n"] < 15
+    assert set(results["language_summary"]) == {"English", "Multilingual"}
+    summary = pd.read_csv(res_dir / SUMMARY_FILENAME)
+    assert set(summary["split"]) == {"English", "Multilingual"}
     assert json.loads((res_dir / "results.json").read_text())["arena"] == "ComparIA"
 
 
@@ -211,3 +217,32 @@ def test_swap_mode_both_inverts_the_reversed_pass(tmp_path, monkeypatch):
     assert (
         forward["presented_model_a"].tolist() == swapped["presented_model_b"].tolist()
     )
+    ranking_n = sum(split["n"] for split in results["language_summary"].values())
+    assert ranking_n == int((forward["winner"] != "tie").sum())
+    assert ranking_n < results["n_annotations"]
+
+
+def test_empty_language_split_reports_na():
+    df = pd.DataFrame(
+        {
+            "lang": ["fr", "fr"],
+            "model_a": ["a", "a"],
+            "model_b": ["b", "b"],
+            "winner": ["model_a", "model_b"],
+            "winner_llm": ["model_a", "model_a"],
+            "pref_llm": [0.1, 0.2],
+            "orientation": ["forward", "forward"],
+        }
+    )
+    summary = summarize_language_splits(
+        df, exclude_human_ties=True, n_bootstraps=4, seed=0
+    )
+    assert summary["English"] == {
+        "n": 0,
+        "kappa": "n/a",
+        "spearman": "n/a",
+        "spearman_soft": "n/a",
+        "mae_elo": "n/a",
+        "mae_soft_elo": "n/a",
+    }
+    assert summary["Multilingual"]["n"] == 2


### PR DESCRIPTION
# Description

> [!NOTE]
> Packaged meta-eval split from closed PR #76. Meta-eval does not use the unified `do_inference` cache, and the cache stack (#94-#100) does not wire it up either: caching will be added to meta-eval once those PRs are merged.

Adds Bradley-Terry Spearman and Elo MAE, plus English vs multilingual splits, as the packaged `ranking` scoring adapter. Language splits drop human ties by default. Ranking fits use one forward-order row per sampled battle.

This is stacked on #103.
