### PR TITLE
Meta-eval: (5/7) Add Arena-Hard and AlpacaEval judge prompt presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,12 +301,15 @@ The task keeps the most-battled models, samples battles among them, asks the jud
 
 Prompt presets are selected with `--judge.prompt_preset` (the task default is `default`):
 
-| `--judge.prompt_preset` | Parser |
-|---|---|
-| `default` | PairScore |
-| `arena-hard` | Arena-Hard Likert `[[A>>B]]` … `[[B>>A]]` |
-| `alpaca-eval` | AlpacaEval JSON `ordered_models` |
-| `alpaca-eval-pair-score` | AlpacaEval prompt with PairScore output |
+| `--judge.prompt_preset` | Parser | Available to |
+|---|---|---|
+| `default` | PairScore | all tasks |
+| `arena-hard` | Arena-Hard Likert `[[A>>B]]` … `[[B>>A]]` | meta-eval only |
+| `alpaca-eval` | AlpacaEval JSON `ordered_models` | meta-eval only |
+| `alpaca-eval-pair-score` | AlpacaEval prompt with PairScore output | all tasks |
+
+Only meta-eval parses the Likert and JSON verdict formats, so other tasks reject
+those two presets at config time rather than after the judge calls are paid for.
 
 ```bash
 judgearena \

--- a/README.md
+++ b/README.md
@@ -299,6 +299,15 @@ Meta-evaluation scores a judge against **human-labeled arena battles**. It does 
 
 The task keeps the most-battled models, samples battles among them, asks the judge to label the stored A/B order, and reports accuracy, Cohen's kappa, Spearman correlation of Bradley-Terry ratings, and Elo MAE (with bootstrap SE) against the human vote. PairScore uses temperature `0.5` here; generate+judge keeps `0.3`.
 
+Prompt presets are selected with `--judge.prompt_preset` (the task default is `default`):
+
+| `--judge.prompt_preset` | Parser |
+|---|---|
+| `default` | PairScore |
+| `arena-hard` | Arena-Hard Likert `[[A>>B]]` … `[[B>>A]]` |
+| `alpaca-eval` | AlpacaEval JSON `ordered_models` |
+| `alpaca-eval-pair-score` | AlpacaEval prompt with PairScore output |
+
 ```bash
 judgearena \
   --task meta-eval-lmarena-140k \
@@ -313,6 +322,7 @@ judgearena \
 |---|---|---|
 | `--task` | *(required)* | `meta-eval-lmarena-140k`, `meta-eval-comparia`, or a language variant |
 | `--judge.model` | *(required)* | Judge under evaluation |
+| `--judge.prompt_preset` | `default` | `default`, `arena-hard`, `alpaca-eval`, or `alpaca-eval-pair-score` |
 | `--meta_eval.top_models` | `20` | Keep the N models with the most battles |
 | `--meta_eval.battles_per_model` | `50` | Battles sampled per selected model |
 | `--meta_eval.languages` | all | Restrict to language codes, e.g. `'["en", "es"]'` |

--- a/judgearena/benchmarks/meta_eval/annotate.py
+++ b/judgearena/benchmarks/meta_eval/annotate.py
@@ -4,19 +4,15 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import numpy as np
 import pandas as pd
 
 from judgearena.arenas_utils import extract_turn_text
-from judgearena.evaluate import PairScore, annotate_battles
+from judgearena.benchmarks.meta_eval.parsers import parse_pref, parse_winner
+from judgearena.evaluate import annotate_battles
 
 if TYPE_CHECKING:
     from judgearena.config import RunConfig
     from judgearena.prompts.registry import ResolvedJudgePrompt
-
-TIE_EPSILON = 0.01
-# Paper PairScore temperature for meta-eval; generate+judge keeps 0.3.
-META_EVAL_PAIRSCORE_TEMPERATURE = 0.5
 
 
 def serialize_judge_input(judge_input: object) -> str:
@@ -26,27 +22,6 @@ def serialize_judge_input(judge_input: object) -> str:
     if callable(to_string):
         return to_string()
     return str(judge_input)
-
-
-def parse_pairscore_pref(
-    judge_completion: str, *, temperature: float = META_EVAL_PAIRSCORE_TEMPERATURE
-) -> float:
-    score = PairScore(temperature=temperature).parse_model_raw(judge_completion)
-    if score is None or np.isnan(score):
-        return 0.5
-    return float(score)
-
-
-def parse_pairscore_winner(
-    judge_completion: str,
-    *,
-    temperature: float = META_EVAL_PAIRSCORE_TEMPERATURE,
-    eps: float = TIE_EPSILON,
-) -> str:
-    score = parse_pairscore_pref(judge_completion, temperature=temperature)
-    if abs(score - 0.5) < eps:
-        return "tie"
-    return "model_b" if score > 0.5 + eps else "model_a"
 
 
 def invert_winner(winner: str) -> str:
@@ -115,8 +90,8 @@ def _judge_pass(
                 "completion_b": annotation.completion_B,
                 "judge_input": serialize_judge_input(annotation.judge_input),
                 "judge_completion": completion,
-                "winner_llm": parse_pairscore_winner(completion),
-                "pref_llm": parse_pairscore_pref(completion),
+                "winner_llm": parse_winner(completion, resolved_prompt.preset_name),
+                "pref_llm": parse_pref(completion, resolved_prompt.preset_name),
             }
         )
     return pd.DataFrame(rows)

--- a/judgearena/benchmarks/meta_eval/annotate.py
+++ b/judgearena/benchmarks/meta_eval/annotate.py
@@ -90,8 +90,8 @@ def _judge_pass(
                 "completion_b": annotation.completion_B,
                 "judge_input": serialize_judge_input(annotation.judge_input),
                 "judge_completion": completion,
-                "winner_llm": parse_winner(completion, resolved_prompt.preset_name),
-                "pref_llm": parse_pref(completion, resolved_prompt.preset_name),
+                "winner_llm": parse_winner(completion, resolved_prompt.parser_mode),
+                "pref_llm": parse_pref(completion, resolved_prompt.parser_mode),
             }
         )
     return pd.DataFrame(rows)

--- a/judgearena/benchmarks/meta_eval/parsers.py
+++ b/judgearena/benchmarks/meta_eval/parsers.py
@@ -43,9 +43,9 @@ def parse_pairscore_winner(
     eps: float = TIE_EPSILON,
 ) -> str:
     score = parse_pairscore_pref(judge_completion, temperature=temperature)
-    if abs(score - 0.5) < eps:
+    if abs(score - 0.5) <= eps:
         return "tie"
-    return "model_b" if score > 0.5 + eps else "model_a"
+    return "model_b" if score > 0.5 else "model_a"
 
 
 def parse_arena_hard_winner(judge_completion: str) -> str:

--- a/judgearena/benchmarks/meta_eval/parsers.py
+++ b/judgearena/benchmarks/meta_eval/parsers.py
@@ -1,0 +1,114 @@
+"""Winner parsers for meta-eval prompt presets."""
+
+from __future__ import annotations
+
+import json
+import re
+
+import numpy as np
+
+from judgearena.evaluate import PairScore
+
+TIE_EPSILON = 0.01
+META_EVAL_PAIRSCORE_TEMPERATURE = 0.5
+
+_ARENA_HARD_PATTERNS = [
+    re.compile(r"\[\[([AB<>=]+)\]\]"),
+    re.compile(r"\[([AB<>=]+)\]"),
+]
+_ARENA_HARD_LIKERT_TO_WINNER = {
+    "A>>B": "model_a",
+    "A>B": "model_a",
+    "A=B": "tie",
+    "B>A": "model_b",
+    "B>>A": "model_b",
+    "B<<A": "model_a",
+    "B<A": "model_a",
+}
+
+
+def parse_pairscore_pref(
+    judge_completion: str, *, temperature: float = META_EVAL_PAIRSCORE_TEMPERATURE
+) -> float:
+    score = PairScore(temperature=temperature).parse_model_raw(judge_completion)
+    if score is None or np.isnan(score):
+        return 0.5
+    return float(score)
+
+
+def parse_pairscore_winner(
+    judge_completion: str,
+    *,
+    temperature: float = META_EVAL_PAIRSCORE_TEMPERATURE,
+    eps: float = TIE_EPSILON,
+) -> str:
+    score = parse_pairscore_pref(judge_completion, temperature=temperature)
+    if abs(score - 0.5) < eps:
+        return "tie"
+    return "model_b" if score > 0.5 + eps else "model_a"
+
+
+def parse_arena_hard_winner(judge_completion: str) -> str:
+    if not isinstance(judge_completion, str):
+        return "tie"
+    for pattern in _ARENA_HARD_PATTERNS:
+        matches = [
+            match for match in pattern.findall(judge_completion.upper()) if match
+        ]
+        if matches:
+            return _ARENA_HARD_LIKERT_TO_WINNER.get(matches[-1].strip(), "tie")
+    return "tie"
+
+
+def parse_alpaca_eval_winner(judge_completion: str) -> str:
+    if not isinstance(judge_completion, str):
+        return "tie"
+    text = judge_completion
+    fenced = re.search(r"```json\s*(.*?)\s*```", text, re.DOTALL)
+    if fenced:
+        text = fenced.group(1)
+    else:
+        obj_match = re.search(
+            r'\{[^{}]*"ordered_models"[^{}]*\[[^\[\]]*\][^{}]*\}',
+            text,
+            re.DOTALL,
+        )
+        if obj_match:
+            text = obj_match.group(0)
+    try:
+        data = json.loads(text)
+        m_entry = next(
+            (
+                entry
+                for entry in data.get("ordered_models", [])
+                if entry.get("model") == "m"
+            ),
+            None,
+        )
+        if m_entry is None:
+            return "tie"
+        if m_entry["rank"] == 1:
+            return "model_a"
+        if m_entry["rank"] == 2:
+            return "model_b"
+    except (json.JSONDecodeError, KeyError, TypeError):
+        pass
+    return "tie"
+
+
+def winner_to_pref(winner: str) -> float:
+    return {"model_a": 0.0, "model_b": 1.0}.get(winner, 0.5)
+
+
+def parse_winner(judge_completion: str, prompt_preset: str) -> str:
+    if prompt_preset == "arena-hard":
+        return parse_arena_hard_winner(judge_completion)
+    if prompt_preset == "alpaca-eval":
+        return parse_alpaca_eval_winner(judge_completion)
+    return parse_pairscore_winner(judge_completion)
+
+
+def parse_pref(judge_completion: str, prompt_preset: str) -> float:
+    if prompt_preset in ("arena-hard", "alpaca-eval"):
+        return winner_to_pref(parse_winner(judge_completion, prompt_preset))
+    return parse_pairscore_pref(judge_completion)

--- a/judgearena/benchmarks/meta_eval/parsers.py
+++ b/judgearena/benchmarks/meta_eval/parsers.py
@@ -1,4 +1,4 @@
-"""Winner parsers for meta-eval prompt presets."""
+"""Winner parsers for the judge parser modes meta-eval supports."""
 
 from __future__ import annotations
 
@@ -8,6 +8,7 @@ import re
 import numpy as np
 
 from judgearena.evaluate import PairScore
+from judgearena.prompts.registry import JudgeParserMode
 
 TIE_EPSILON = 0.01
 META_EVAL_PAIRSCORE_TEMPERATURE = 0.5
@@ -100,15 +101,16 @@ def winner_to_pref(winner: str) -> float:
     return {"model_a": 0.0, "model_b": 1.0}.get(winner, 0.5)
 
 
-def parse_winner(judge_completion: str, prompt_preset: str) -> str:
-    if prompt_preset == "arena-hard":
+def parse_winner(judge_completion: str, parser_mode: JudgeParserMode) -> str:
+    if parser_mode == "arena_hard_likert":
         return parse_arena_hard_winner(judge_completion)
-    if prompt_preset == "alpaca-eval":
+    if parser_mode == "alpaca_eval_json":
         return parse_alpaca_eval_winner(judge_completion)
     return parse_pairscore_winner(judge_completion)
 
 
-def parse_pref(judge_completion: str, prompt_preset: str) -> float:
-    if prompt_preset in ("arena-hard", "alpaca-eval"):
-        return winner_to_pref(parse_winner(judge_completion, prompt_preset))
-    return parse_pairscore_pref(judge_completion)
+def parse_pref(judge_completion: str, parser_mode: JudgeParserMode) -> float:
+    """Preference in [0, 1]; the categorical modes only yield 0, 0.5 or 1."""
+    if parser_mode == "score":
+        return parse_pairscore_pref(judge_completion)
+    return winner_to_pref(parse_winner(judge_completion, parser_mode))

--- a/judgearena/config.py
+++ b/judgearena/config.py
@@ -17,6 +17,7 @@ from pydantic_settings import (
 )
 
 from judgearena.benchmarks.pairwise.baselines import native_pairwise_baseline
+from judgearena.prompts.registry import PRESETS
 from judgearena.tasks.registry import get_packaged_task
 from judgearena.tasks.schema import EloProtocol, MetaEvalProtocol
 
@@ -477,6 +478,17 @@ class RunConfig(BaseSettings):
 
         if self.meta_eval is not None:
             raise ValueError("meta_eval config is only valid for meta-eval tasks.")
+
+        # Only meta-eval implements the Arena-Hard and AlpacaEval verdict
+        # parsers; elsewhere the judge output would only fail to parse after
+        # every judge call has been paid for.
+        preset = PRESETS.get(self.judge.prompt_preset or task_judge.default_prompt)
+        if preset is not None and preset.parser_mode != "score":
+            raise ValueError(
+                f"judge.prompt_preset={preset.name!r} produces "
+                f"{preset.parser_mode!r} verdicts, which only meta-eval tasks "
+                f"can parse; task {self.task!r} needs a score-based preset."
+            )
 
         is_elo = isinstance(protocol, EloProtocol)
         if is_elo:

--- a/judgearena/prompts/alpaca_eval_pair_score_user.txt
+++ b/judgearena/prompts/alpaca_eval_pair_score_user.txt
@@ -1,0 +1,32 @@
+I require a leaderboard for various large language models. I'll provide you with prompts given to these models and their corresponding responses. Your task is to assess these responses, ranking the models in order of preference from a human perspective.
+
+## Prompt
+
+{{
+    "instruction": "{user_prompt}",
+}}
+
+## Model Outputs
+
+Here are the unordered outputs from the models. Each output is associated with a specific model, identified by a unique model identifier.
+
+{{
+    {{
+        "model": "model A",
+        "output": "{completion_A}"
+    }},
+    {{
+        "model": "model B",
+        "output": "{completion_B}"
+    }}
+}}
+
+## Task
+
+Evaluate and rank the models based on the quality and relevance of their outputs. The ranking should be such that the model with the highest quality output is ranked first.
+
+## Your output, do not repeat the input above
+```
+score_A: <a number between 0 and 10 to indicate the quality of model A's answer>
+score_B: <a number between 0 and 10 to indicate the quality of model B's answer>
+```

--- a/judgearena/prompts/alpaca_eval_system.txt
+++ b/judgearena/prompts/alpaca_eval_system.txt
@@ -1,0 +1,1 @@
+You are a highly efficient assistant, who evaluates and ranks large language models (LLMs) based on the quality of their responses to given prompts. This process will create a leaderboard reflecting the most accurate and human-preferred answers.

--- a/judgearena/prompts/alpaca_eval_user.txt
+++ b/judgearena/prompts/alpaca_eval_user.txt
@@ -1,0 +1,30 @@
+I require a leaderboard for various large language models. I'll provide you with prompts given to these models and their corresponding responses. Your task is to assess these responses, ranking the models in order of preference from a human perspective.
+
+## Prompt
+
+{{
+    "instruction": "{user_prompt}",
+}}
+
+## Model Outputs
+
+Here are the unordered outputs from the models. Each output is associated with a specific model, identified by a unique model identifier.
+
+{{
+    {{
+        "model": "m",
+        "output": "{completion_A}"
+    }},
+    {{
+        "model": "M",
+        "output": "{completion_B}"
+    }}
+}}
+
+## Task
+
+Evaluate and rank the models based on the quality and relevance of their outputs. The ranking should be such that the model with the highest quality output is ranked first.
+
+Output ONLY a JSON object in this exact format (no other text):
+{{"ordered_models": [{{"model": "m", "rank": 1}}, {{"model": "M", "rank": 2}}]}}
+where rank 1 = best. Replace ranks according to your evaluation.

--- a/judgearena/prompts/arena_hard_system.txt
+++ b/judgearena/prompts/arena_hard_system.txt
@@ -1,0 +1,19 @@
+Please act as an impartial judge and evaluate the quality of the responses provided by two AI assistants to the user prompt displayed below. You will be given assistant A's answer and assistant B's answer. Your job is to evaluate which assistant's answer is better.
+
+Begin your evaluation by generating your own answer to the prompt. You must provide your answers before judging any answers.
+
+When evaluating the assistants' answers, compare both assistants' answers with your answer. You must identify and correct any mistakes or inaccurate information.
+
+Then consider if the assistant's answers are helpful, relevant, and concise. Helpful means the answer correctly responds to the prompt or follows the instructions. Note when user prompt has any ambiguity or more than one interpretation, it is more helpful and appropriate to ask for clarifications or more information from the user than providing an answer based on assumptions. Relevant means all parts of the response closely connect or are appropriate to what is being asked. Concise means the response is clear and not verbose or excessive.
+
+Then consider the creativity and novelty of the assistant's answers when needed. Finally, identify any missing important information in the assistants' answers that would be beneficial to include when responding to the user prompt.
+
+After providing your explanation, you must output only one of the following choices as your final verdict with a label:
+
+1. Assistant A is significantly better: [[A>>B]]
+2. Assistant A is slightly better: [[A>B]]
+3. Tie, relatively the same: [[A=B]]
+4. Assistant B is slightly better: [[B>A]]
+5. Assistant B is significantly better: [[B>>A]]
+
+Example output: "My final verdict is tie: [[A=B]]".

--- a/judgearena/prompts/arena_hard_user.txt
+++ b/judgearena/prompts/arena_hard_user.txt
@@ -1,0 +1,10 @@
+<|User Prompt|>
+{user_prompt}
+
+<|The Start of Assistant A's Answer|>
+{completion_A}
+<|The End of Assistant A's Answer|>
+
+<|The Start of Assistant B's Answer|>
+{completion_B}
+<|The End of Assistant B's Answer|>

--- a/judgearena/prompts/registry.py
+++ b/judgearena/prompts/registry.py
@@ -13,6 +13,9 @@ DEFAULT_JUDGE_PROMPT_PRESET = "default"
 DEFAULT_WITH_EXPLANATION_PRESET = "default_with_explanation"
 FLUENCY_JUDGE_PROMPT_PRESET = "fluency"
 FASTCHAT_PAIRWISE_PROMPT_PRESET = "fastchat-pairwise"
+ARENA_HARD_JUDGE_PROMPT_PRESET = "arena-hard"
+ALPACA_EVAL_JUDGE_PROMPT_PRESET = "alpaca-eval"
+ALPACA_EVAL_PAIRSCORE_PROMPT_PRESET = "alpaca-eval-pair-score"
 
 PROMPTS_PACKAGE = "judgearena.prompts"
 _COMPLETION_LABEL_SINGLE = "Answer"
@@ -87,6 +90,21 @@ PRESETS: dict[str, JudgePromptPreset] = {
     FASTCHAT_PAIRWISE_PROMPT_PRESET: JudgePromptPreset(
         name=FASTCHAT_PAIRWISE_PROMPT_PRESET,
         delegated=True,
+    ),
+    ARENA_HARD_JUDGE_PROMPT_PRESET: JudgePromptPreset(
+        name=ARENA_HARD_JUDGE_PROMPT_PRESET,
+        system_file="arena_hard_system.txt",
+        user_file="arena_hard_user.txt",
+    ),
+    ALPACA_EVAL_JUDGE_PROMPT_PRESET: JudgePromptPreset(
+        name=ALPACA_EVAL_JUDGE_PROMPT_PRESET,
+        system_file="alpaca_eval_system.txt",
+        user_file="alpaca_eval_user.txt",
+    ),
+    ALPACA_EVAL_PAIRSCORE_PROMPT_PRESET: JudgePromptPreset(
+        name=ALPACA_EVAL_PAIRSCORE_PROMPT_PRESET,
+        system_file="alpaca_eval_system.txt",
+        user_file="alpaca_eval_pair_score_user.txt",
     ),
 }
 

--- a/judgearena/prompts/registry.py
+++ b/judgearena/prompts/registry.py
@@ -6,7 +6,7 @@ from importlib.resources import files
 from pathlib import Path
 from typing import Literal
 
-JudgeParserMode = Literal["score"]
+JudgeParserMode = Literal["score", "arena_hard_likert", "alpaca_eval_json"]
 PromptSource = Literal["preset", "file", "override", "delegated"]
 
 DEFAULT_JUDGE_PROMPT_PRESET = "default"
@@ -93,11 +93,13 @@ PRESETS: dict[str, JudgePromptPreset] = {
     ),
     ARENA_HARD_JUDGE_PROMPT_PRESET: JudgePromptPreset(
         name=ARENA_HARD_JUDGE_PROMPT_PRESET,
+        parser_mode="arena_hard_likert",
         system_file="arena_hard_system.txt",
         user_file="arena_hard_user.txt",
     ),
     ALPACA_EVAL_JUDGE_PROMPT_PRESET: JudgePromptPreset(
         name=ALPACA_EVAL_JUDGE_PROMPT_PRESET,
+        parser_mode="alpaca_eval_json",
         system_file="alpaca_eval_system.txt",
         user_file="alpaca_eval_user.txt",
     ),

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,6 +6,7 @@ from pydantic import ValidationError
 import judgearena.config as config_module
 from judgearena import cli as cli_module
 from judgearena.config import RunConfig
+from judgearena.prompts.registry import DEFAULT_JUDGE_PROMPT_PRESET
 
 
 def _base_generate() -> dict:
@@ -43,6 +44,7 @@ def _registered_task(
         spec=SimpleNamespace(
             protocol=SimpleNamespace(
                 judge=SimpleNamespace(
+                    default_prompt=DEFAULT_JUDGE_PROMPT_PRESET,
                     default_swap_mode=default_swap_mode,
                     allowed_swap_modes=allowed_swap_modes,
                     default_temperature=default_temperature,

--- a/tests/test_meta_eval_task_runtime.py
+++ b/tests/test_meta_eval_task_runtime.py
@@ -11,9 +11,13 @@ import judgearena.benchmarks.meta_eval.runner as runner_module
 from judgearena.benchmarks.meta_eval.agreement import compute_agreement_metrics
 from judgearena.benchmarks.meta_eval.annotate import (
     invert_winner,
+    serialize_judge_input,
+)
+from judgearena.benchmarks.meta_eval.parsers import (
     parse_pairscore_pref,
     parse_pairscore_winner,
-    serialize_judge_input,
+    parse_pref,
+    parse_winner,
 )
 from judgearena.benchmarks.meta_eval.runner import (
     ANNOTATIONS_FILENAME,
@@ -30,6 +34,7 @@ from judgearena.benchmarks.meta_eval.scoring import summarize_language_splits
 from judgearena.benchmarks.registry import resolve_benchmark
 from judgearena.config import RunConfig
 from judgearena.evaluate import JudgeAnnotation
+from judgearena.prompts.registry import resolve_judge_prompt
 from judgearena.tasks.registry import get_packaged_task
 
 
@@ -142,6 +147,24 @@ def test_pairscore_parses_winners_at_meta_eval_temperature():
     assert serialize_judge_input(SimpleNamespace(to_string=lambda: "p")) == "p"
     assert invert_winner("model_a") == "model_b"
     assert invert_winner("tie") == "tie"
+
+
+def test_prompt_presets_select_their_parsers():
+    assert parse_winner("score_A: 9\nscore_B: 1", "default") == "model_a"
+    assert parse_winner("[[A=B]]", "arena-hard") == "tie"
+    assert parse_winner("[[B>>A]]", "arena-hard") == "model_b"
+    assert (
+        parse_winner(
+            '{"ordered_models": [{"model": "m", "rank": 1}, {"model": "M", "rank": 2}]}',
+            "alpaca-eval",
+        )
+        == "model_a"
+    )
+    assert parse_pref("[[A=B]]", "arena-hard") == 0.5
+    for preset in ("arena-hard", "alpaca-eval", "alpaca-eval-pair-score"):
+        resolved = resolve_judge_prompt(preset=preset)
+        assert resolved.system_prompt
+        assert resolved.user_prompt_template
 
 
 def test_agreement_metrics_on_fixture():

--- a/tests/test_meta_eval_task_runtime.py
+++ b/tests/test_meta_eval_task_runtime.py
@@ -5,6 +5,7 @@ from types import SimpleNamespace
 
 import pandas as pd
 import pytest
+from pydantic import ValidationError
 
 import judgearena.benchmarks.meta_eval.annotate as annotate_module
 import judgearena.benchmarks.meta_eval.runner as runner_module
@@ -153,21 +154,36 @@ def test_pairscore_parses_winners_at_meta_eval_temperature():
 
 
 def test_prompt_presets_select_their_parsers():
-    assert parse_winner("score_A: 9\nscore_B: 1", "default") == "model_a"
-    assert parse_winner("[[A=B]]", "arena-hard") == "tie"
-    assert parse_winner("[[B>>A]]", "arena-hard") == "model_b"
+    assert parse_winner("score_A: 9\nscore_B: 1", "score") == "model_a"
+    assert parse_winner("[[A=B]]", "arena_hard_likert") == "tie"
+    assert parse_winner("[[B>>A]]", "arena_hard_likert") == "model_b"
     assert (
         parse_winner(
             '{"ordered_models": [{"model": "m", "rank": 1}, {"model": "M", "rank": 2}]}',
-            "alpaca-eval",
+            "alpaca_eval_json",
         )
         == "model_a"
     )
-    assert parse_pref("[[A=B]]", "arena-hard") == 0.5
-    for preset in ("arena-hard", "alpaca-eval", "alpaca-eval-pair-score"):
+    assert parse_pref("[[A=B]]", "arena_hard_likert") == 0.5
+    expected_modes = {
+        "arena-hard": "arena_hard_likert",
+        "alpaca-eval": "alpaca_eval_json",
+        "alpaca-eval-pair-score": "score",
+    }
+    for preset, parser_mode in expected_modes.items():
         resolved = resolve_judge_prompt(preset=preset)
         assert resolved.system_prompt
         assert resolved.user_prompt_template
+        assert resolved.parser_mode == parser_mode
+
+
+def test_non_meta_eval_task_rejects_a_preset_it_cannot_parse():
+    with pytest.raises(ValidationError, match="only meta-eval tasks can parse"):
+        RunConfig(
+            task="alpaca-eval",
+            model={"name": "Dummy/m", "baseline": "Dummy/b"},
+            judge={"model": "Dummy/j", "prompt_preset": "arena-hard"},
+        )
 
 
 def test_agreement_metrics_on_fixture():

--- a/tests/test_meta_eval_task_runtime.py
+++ b/tests/test_meta_eval_task_runtime.py
@@ -143,7 +143,10 @@ def test_pairscore_parses_winners_at_meta_eval_temperature():
     assert parse_pairscore_winner("score_A: 10\nscore_B: 0") == "model_a"
     assert parse_pairscore_winner("score_A: 0\nscore_B: 10") == "model_b"
     assert parse_pairscore_winner("score_A: 5\nscore_B: 5") == "tie"
-    assert parse_pairscore_pref("score_A: 10\nscore_B: 0") < 0.5
+    completion = "score_A: 10\nscore_B: 0"
+    preference = parse_pairscore_pref(completion)
+    assert preference < 0.5
+    assert parse_pairscore_winner(completion, eps=abs(preference - 0.5)) == "tie"
     assert serialize_judge_input(SimpleNamespace(to_string=lambda: "p")) == "p"
     assert invert_winner("model_a") == "model_b"
     assert invert_winner("tie") == "tie"


### PR DESCRIPTION
# Description

> [!NOTE]
> Packaged meta-eval split from closed PR #76. Meta-eval does not use the unified `do_inference` cache, and the cache stack (#94-#100) does not wire it up either: caching will be added to meta-eval once those PRs are merged.

Meta-eval selects Arena-Hard and AlpacaEval prompts through `--judge.prompt_preset` rather than a separate `prompt_mode` flag. `arena-hard` parses Likert tags, `alpaca-eval` parses `ordered_models` JSON, and `alpaca-eval-pair-score` keeps the AlpacaEval prompt with PairScore output. The task default remains PairScore.

PairScore preferences exactly on the tie epsilon are classified as ties, matching the original meta-eval parser.

This is stacked on #104.
