### PR TITLE
Meta-eval: (6/7) Measure held-out Elo error against annotation budget

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,7 +297,7 @@ Language variants follow the ELO pattern (`meta-eval-lmarena-140k-uk`, `meta-eva
 
 Meta-evaluation scores a judge against **human-labeled arena battles**. It does not generate completions and does not rate a model. Use `elo-*` for that.
 
-The task keeps the most-battled models, samples battles among them, asks the judge to label the stored A/B order, and reports accuracy, Cohen's kappa, Spearman correlation of Bradley-Terry ratings, and Elo MAE (with bootstrap SE) against the human vote. PairScore uses temperature `0.5` here; generate+judge keeps `0.3`.
+The task keeps the most-battled models, samples battles among them, asks the judge to label the stored A/B order, and reports accuracy, Cohen's kappa, Spearman correlation of Bradley-Terry ratings, Elo MAE (with bootstrap SE), and held-out Elo gap vs annotation budget against the human vote. PairScore uses temperature `0.5` here; generate+judge keeps `0.3`.
 
 Prompt presets are selected with `--judge.prompt_preset` (the task default is `default`):
 
@@ -328,12 +328,14 @@ judgearena \
 | `--meta_eval.languages` | all | Restrict to language codes, e.g. `'["en", "es"]'` |
 | `--meta_eval.n_bootstraps` | `20` | Bootstrap samples for agreement and ranking standard errors |
 | `--meta_eval.include_human_ties` | off | Keep human-tie battles in the ranking language splits |
+| `--meta_eval.elo_gap_battles` | `[10, 20, 30, 40, 50]` | Annotation budgets for held-out Elo MAE |
+| `--meta_eval.elo_gap_seeds` | `10` | Repeats of the held-out Elo-gap sampling at each budget |
 | `--judge.swap_mode` | `fixed` | `fixed`: one A-B pass; `both`: judge each battle in both orders |
 | `--model.name` | unset | Not used: both completions already exist in the arena |
 
-Results go under `[result_folder]/meta-eval-*-<judge>/` as `sample.parquet`, `annotations.parquet`, `summary.csv`, `results.json`, `config.yaml`, and `run-metadata.v1.json`. `results.json` reports agreement on all battles and on the subset that drops human ties, plus English vs multilingual ranking splits.
+Results go under `[result_folder]/meta-eval-*-<judge>/` as `sample.parquet`, `annotations.parquet`, `summary.csv`, `results.json`, `config.yaml`, and `run-metadata.v1.json`. `results.json` reports agreement on all battles and on the subset that drops human ties, English vs multilingual ranking splits, and held-out Elo MAE vs annotation budget (`elo_gap_all` and `elo_gap_exclude_ties`).
 
-With `--judge.swap_mode both`, overall accuracy and kappa use both orderings (the reversed verdict is inverted back to the stored A/B identity). Ranking, language splits, and later Elo-gap analyses keep one forward-order row per sampled battle. `annotations.parquet` stores one row per judge pass with an `orientation` column; `winner_llm` and `pref_llm` are always in the original model order.
+With `--judge.swap_mode both`, overall accuracy and kappa use both orderings (the reversed verdict is inverted back to the stored A/B identity). Ranking, language splits, and Elo-gap analyses keep one forward-order row per sampled battle. `annotations.parquet` stores one row per judge pass with an `orientation` column; `winner_llm` and `pref_llm` are always in the original model order.
 
 ## 📈 Estimating ELO Ratings
 

--- a/judgearena/benchmarks/meta_eval/runner.py
+++ b/judgearena/benchmarks/meta_eval/runner.py
@@ -74,6 +74,10 @@ class MetaEvalReport(Report):
     """Accuracy and Cohen's kappa on all battles and on the no-human-tie subset."""
     language_summary: dict[str, dict[str, str | int]]
     """English vs multilingual ranking agreement, fit on forward-order rows."""
+    elo_gap_all: list[dict[str, float | int | str | bool]]
+    """Held-out Elo MAE vs annotation budget, keeping LLM-predicted ties."""
+    elo_gap_exclude_ties: list[dict[str, float | int | str | bool]]
+    """Held-out Elo MAE vs annotation budget, dropping LLM-predicted ties after sampling."""
 
     def render(self) -> None:
         print(f"\n=== Meta-eval: {self.task} ===")
@@ -159,11 +163,25 @@ def run_meta_eval(cfg: RunConfig, task: ResolvedTaskSpec | None = None) -> dict:
         "no_human_ties": agreement_view(metrics, exclude_human_ties=True),
     }
     scorer = META_EVAL_SCORERS[protocol.scoring.adapter]
+    ranking_ann = ranking_annotations(annotations)
     language_summary = scorer.language_splits(
-        ranking_annotations(annotations),
+        ranking_ann,
         exclude_human_ties=not cfg.meta_eval.include_human_ties,
         n_bootstraps=cfg.meta_eval.n_bootstraps,
         seed=cfg.run.seed,
+    )
+    elo_gap_kwargs = {
+        "df_top": df_top,
+        "df_ann": ranking_ann,
+        "top_models": top_models,
+        "n_battles_list": list(cfg.meta_eval.elo_gap_battles),
+        "n_seeds": cfg.meta_eval.elo_gap_seeds,
+    }
+    elo_gap_all = scorer.elo_gap(
+        **elo_gap_kwargs, seed=cfg.run.seed, exclude_ties=False
+    )
+    elo_gap_no_tie = scorer.elo_gap(
+        **elo_gap_kwargs, seed=cfg.run.seed + 1000, exclude_ties=True
     )
 
     report = MetaEvalReport(
@@ -179,6 +197,8 @@ def run_meta_eval(cfg: RunConfig, task: ResolvedTaskSpec | None = None) -> dict:
         human_winner_counts=sample["winner"].value_counts().to_dict(),
         agreement=agreement,
         language_summary=language_summary,
+        elo_gap_all=elo_gap_all.to_dict(orient="records"),
+        elo_gap_exclude_ties=elo_gap_no_tie.to_dict(orient="records"),
     )
     results = report.to_dict()
     report.render()

--- a/judgearena/benchmarks/meta_eval/scoring.py
+++ b/judgearena/benchmarks/meta_eval/scoring.py
@@ -179,13 +179,90 @@ def summarize_language_splits(
     return rows
 
 
+def compute_elo_gap_summary(
+    df_top: pd.DataFrame,
+    df_ann: pd.DataFrame,
+    top_models: list[str],
+    *,
+    n_battles_list: list[int],
+    n_seeds: int,
+    seed: int,
+    exclude_ties: bool,
+) -> pd.DataFrame:
+    """Measure ELO error by annotation budget.
+
+    Tie predictions are excluded after sampling so ``num_battles`` remains the
+    number of judge annotations purchased, matching the reference experiment.
+    """
+    df_battles = df_top[["model_a", "model_b", "winner"]].copy()
+    human_ratings = _hard_bradley_terry(df_battles, "winner")
+    rows: list[dict[str, float | int | str | bool]] = []
+
+    for num_battles in n_battles_list:
+        for offset in range(n_seeds):
+            rng = np.random.default_rng(seed + offset)
+            gaps: list[float] = []
+            for model in top_models:
+                model_mask_ann = (df_ann["model_a"] == model) | (
+                    df_ann["model_b"] == model
+                )
+                if model_mask_ann.sum() < num_battles:
+                    continue
+                model_mask_top = (df_battles["model_a"] == model) | (
+                    df_battles["model_b"] == model
+                )
+                other_human = df_battles[~model_mask_top].copy()
+                sample = df_ann[model_mask_ann].sample(
+                    n=num_battles,
+                    replace=False,
+                    random_state=int(rng.integers(0, 2**32 - 1)),
+                )
+                if exclude_ties:
+                    sample = sample[sample["winner_llm"] != "tie"]
+                if sample.empty:
+                    continue
+                model_llm = sample[["model_a", "model_b", "winner_llm"]].rename(
+                    columns={"winner_llm": "winner"}
+                )
+                hybrid = pd.concat([other_human, model_llm], ignore_index=True)
+                hybrid_ratings = _hard_bradley_terry(hybrid, "winner")
+                if model in hybrid_ratings and model in human_ratings:
+                    gaps.append(abs(hybrid_ratings[model] - human_ratings[model]))
+            if gaps:
+                rows.append(
+                    {
+                        "num_battles": num_battles,
+                        "seed": offset,
+                        "mean_gap": float(np.mean(gaps)),
+                        "exclude_ties": exclude_ties,
+                    }
+                )
+
+    if not rows:
+        return pd.DataFrame(columns=["num_battles", "mean", "se", "exclude_ties"])
+
+    df_rows = pd.DataFrame(rows)
+    return (
+        df_rows.groupby(["num_battles", "exclude_ties"])["mean_gap"]
+        .agg(mean="mean", se=lambda values: values.std() / np.sqrt(len(values)))
+        .reset_index()
+    )
+
+
+EloGapFunction = Callable[..., pd.DataFrame]
+
+
 @dataclass(frozen=True)
 class MetaEvalScorer:
     """Ranking implementation selected by a meta-eval task's scoring adapter."""
 
     language_splits: RankingFunction
+    elo_gap: EloGapFunction
 
 
 META_EVAL_SCORERS = {
-    "ranking": MetaEvalScorer(language_splits=summarize_language_splits),
+    "ranking": MetaEvalScorer(
+        language_splits=summarize_language_splits,
+        elo_gap=compute_elo_gap_summary,
+    ),
 }

--- a/judgearena/config.py
+++ b/judgearena/config.py
@@ -353,6 +353,12 @@ class MetaEvalArgs(BaseModel):
     """If set, ranking language splits keep human-tie battles. Agreement
     always reports both the full set and the no-tie subset."""
 
+    elo_gap_battles: list[int] = Field(default_factory=lambda: [10, 20, 30, 40, 50])
+    """Annotation budgets at which to measure held-out Elo error."""
+
+    elo_gap_seeds: int = Field(default=10, gt=0)
+    """Repeats of the held-out Elo-gap sampling at each budget."""
+
     languages: list[str] | None = None
     """Restrict battles to these language codes (e.g. ``["en", "fr"]``).
     Defaults to all languages of the task."""

--- a/tests/test_meta_eval_task_runtime.py
+++ b/tests/test_meta_eval_task_runtime.py
@@ -30,7 +30,10 @@ from judgearena.benchmarks.meta_eval.sampling import (
     sample_battles_per_model,
     select_top_models,
 )
-from judgearena.benchmarks.meta_eval.scoring import summarize_language_splits
+from judgearena.benchmarks.meta_eval.scoring import (
+    compute_elo_gap_summary,
+    summarize_language_splits,
+)
 from judgearena.benchmarks.registry import resolve_benchmark
 from judgearena.config import RunConfig
 from judgearena.evaluate import JudgeAnnotation
@@ -194,7 +197,15 @@ def test_runner_writes_annotations_and_agreement(tmp_path, monkeypatch):
     monkeypatch.setattr(runner_module, "load_battles", lambda _task: _battles())
     monkeypatch.setattr(runner_module, "build_judge", lambda _cfg: object())
     monkeypatch.setattr(annotate_module, "annotate_battles", _fake_annotations)
-    cfg = _cfg(tmp_path, meta_eval={"top_models": 3, "battles_per_model": 5})
+    cfg = _cfg(
+        tmp_path,
+        meta_eval={
+            "top_models": 3,
+            "battles_per_model": 5,
+            "elo_gap_battles": [2],
+            "elo_gap_seeds": 1,
+        },
+    )
 
     results = run_meta_eval(cfg, get_packaged_task("meta-eval-comparia"))
 
@@ -209,6 +220,8 @@ def test_runner_writes_annotations_and_agreement(tmp_path, monkeypatch):
     assert results["agreement"]["all"]["n"] == 15
     assert results["agreement"]["no_human_ties"]["n"] < 15
     assert set(results["language_summary"]) == {"English", "Multilingual"}
+    assert results["elo_gap_all"][0]["num_battles"] == 2
+    assert results["elo_gap_exclude_ties"][0]["exclude_ties"] is True
     summary = pd.read_csv(res_dir / SUMMARY_FILENAME)
     assert set(summary["split"]) == {"English", "Multilingual"}
     assert json.loads((res_dir / "results.json").read_text())["arena"] == "ComparIA"
@@ -269,3 +282,20 @@ def test_empty_language_split_reports_na():
         "mae_soft_elo": "n/a",
     }
     assert summary["Multilingual"]["n"] == 2
+
+
+def test_elo_gap_summary_runs():
+    battles = _battles()
+    top, df_top = select_top_models(battles, top_models=3)
+    sample = sample_battles_per_model(df_top, top, battles_per_model=5, seed=0)
+    sample["winner_llm"] = sample["winner"]
+    summary = compute_elo_gap_summary(
+        df_top,
+        sample,
+        top,
+        n_battles_list=[2],
+        n_seeds=2,
+        seed=0,
+        exclude_ties=False,
+    )
+    assert not summary.empty


### PR DESCRIPTION
# Description

> [!NOTE]
> Packaged meta-eval split from closed PR #76. Meta-eval does not use the unified `do_inference` cache, and the cache stack (#94-#100) does not wire it up either: caching will be added to meta-eval once those PRs are merged.

Held-out Elo MAE compares a hybrid Bradley-Terry fit (other models' human battles plus K LLM labels for the held-out model) to full-human BT at each `--meta_eval.elo_gap_battles` budget. Ties are dropped after sampling so the budget stays the number of purchased annotations.

This is stacked on #105.
