### PR TITLE
Meta-Eval (2/2): Report Model Request Usage for Benchmark Runs

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,10 @@ uv run judgearena \
 **Note:** Ensure you have the required LangChain dependencies installed for your chosen provider.
 If you use remote endpoint, you would have to set your credentials.
 
+### Usage reporting
+
+Every benchmark run prints a generation/judging usage summary and stores it in `run-metadata.v1.json`. Token and cost totals come from successful responses returned by completed inference calls. Provider retries or successful responses discarded by a failed call are not observable and are not included. Coverage counts in the metadata distinguish complete, partial, and unavailable fields. Hosted backends are reported when their response metadata exposes usage; local vLLM counts input and output token IDs directly. Cost remains unavailable when the provider does not return it.
+
 ### Chat Templates (vLLM)
 
 When using vLLM, JudgeArena automatically picks the right inference method based on the model:

--- a/judgearena/artifacts/metadata.py
+++ b/judgearena/artifacts/metadata.py
@@ -19,6 +19,8 @@ from importlib import metadata as importlib_metadata
 from pathlib import Path
 from typing import Any
 
+from judgearena.usage import current_run_usage
+
 METADATA_FILENAME = "run-metadata.v1.json"
 METADATA_SCHEMA_VERSION = "judgearena-run-metadata/v1"
 _REQUIREMENT_NAME_RE = re.compile(r"^\s*([A-Za-z0-9][A-Za-z0-9_.-]*)")
@@ -295,6 +297,10 @@ def write_run_metadata(
     task_definition = _task_definition_metadata(run)
     if task_definition is not None:
         metadata["task_definition"] = task_definition
+
+    usage = current_run_usage()
+    if usage is not None:
+        metadata["usage"] = usage.to_dict()
 
     git_hash = _get_git_hash(start_path=Path(__file__).resolve().parent)
     if git_hash:

--- a/judgearena/benchmarks/mt_bench/pairwise_judging.py
+++ b/judgearena/benchmarks/mt_bench/pairwise_judging.py
@@ -96,6 +96,7 @@ def infer_pairwise_judgments_by_prompt_groups(
             chat_model=judge_chat_model,
             inputs=prompt_inputs,
             use_tqdm=use_tqdm,
+            stage="judging",
         )
         for item_index, output, prompt_kwargs in zip(
             idxs, outputs, batch_kwargs, strict=True

--- a/judgearena/benchmarks/runner.py
+++ b/judgearena/benchmarks/runner.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING
 
 from judgearena.benchmarks.registry import resolve_benchmark
 from judgearena.log import get_logger
+from judgearena.usage import track_usage
 
 if TYPE_CHECKING:
     from judgearena.config import RunConfig
@@ -17,4 +18,8 @@ def run_benchmark(cfg: RunConfig) -> object:
     """Run a task through its registered benchmark adapter."""
     resolved = resolve_benchmark(cfg.task)
     logger.info("Using %s benchmark adapter for %s.", resolved.adapter.name, cfg.task)
-    return resolved.adapter.runner(cfg, resolved.task)
+    with track_usage() as usage_tracker:
+        try:
+            return resolved.adapter.runner(cfg, resolved.task)
+        finally:
+            usage_tracker.render_summary()

--- a/judgearena/evaluate.py
+++ b/judgearena/evaluate.py
@@ -233,6 +233,7 @@ def annotate_battles(
         inputs=inputs,
         use_tqdm=use_tqdm,
         return_top_logprobs=collect_top_logprobs,
+        stage="judging",
     )
     if not collect_top_logprobs:
         judge_results = [InferenceResult(text=text) for text in judge_results]

--- a/judgearena/generate.py
+++ b/judgearena/generate.py
@@ -1,7 +1,7 @@
 import pandas as pd
 from langchain_core.prompts import ChatPromptTemplate
 
-from judgearena.models import do_inference, make_model
+from judgearena.models import batch_inference_once, do_inference, make_model
 from judgearena.utils import strip_thinking_tags, truncate
 
 
@@ -37,9 +37,7 @@ def generate_instructions(
     completions = do_inference(
         chat_model=chat_model,
         inputs=inputs,
-        # This path historically used one synchronous batch regardless of the
-        # progress setting; preserve that execution behavior here.
-        use_tqdm=False,
+        use_tqdm=use_tqdm,
         stage="generation",
     )
     df_outputs = pd.DataFrame(
@@ -238,10 +236,10 @@ def generate_base(
         for instruction in instructions
     ]
 
-    completions = do_inference(
-        chat_model=chat_model,
-        inputs=inputs,
-        use_tqdm=use_tqdm,
+    completions = batch_inference_once(
+        chat_model,
+        inputs,
+        max_tokens=max_tokens,
         stage="generation",
     )
 

--- a/judgearena/generate.py
+++ b/judgearena/generate.py
@@ -37,7 +37,10 @@ def generate_instructions(
     completions = do_inference(
         chat_model=chat_model,
         inputs=inputs,
-        use_tqdm=use_tqdm,
+        # This path historically used one synchronous batch regardless of the
+        # progress setting; preserve that execution behavior here.
+        use_tqdm=False,
+        stage="generation",
     )
     df_outputs = pd.DataFrame(
         data={
@@ -88,6 +91,7 @@ def _infer_grouped_by_temperature(
             chat_model=group_model,
             inputs=group_inputs,
             use_tqdm=use_tqdm,
+            stage="generation",
         )
         for i, out in zip(idxs, group_outs, strict=True):
             outputs[i] = out
@@ -152,6 +156,7 @@ def generate_multiturn(
             chat_model=chat_model,
             inputs=turn1_inputs,
             use_tqdm=use_tqdm,
+            stage="generation",
         )
 
     turn2_inputs = []
@@ -206,6 +211,7 @@ def generate_multiturn(
             chat_model=chat_model,
             inputs=turn2_inputs,
             use_tqdm=use_tqdm,
+            stage="generation",
         )
 
     return pd.DataFrame(
@@ -225,18 +231,19 @@ def generate_base(
     use_tqdm: bool = False,
     **engine_kwargs,
 ) -> pd.DataFrame:
-    model = make_model(model, max_tokens=max_tokens, **engine_kwargs)
+    chat_model = make_model(model, max_tokens=max_tokens, **engine_kwargs)
 
     inputs = [
         truncate(instruction, max_len=truncate_input_chars)
         for instruction in instructions
     ]
 
-    completions = model.batch(
+    completions = do_inference(
+        chat_model=chat_model,
         inputs=inputs,
-        max_tokens=max_tokens,
+        use_tqdm=use_tqdm,
+        stage="generation",
     )
-    completions = [x.content if hasattr(x, "content") else x for x in completions]
 
     df_outputs = pd.DataFrame(
         data={

--- a/judgearena/models.py
+++ b/judgearena/models.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 import asyncio
 import json
+import math
 import os
 import time
 import warnings
+from collections.abc import Mapping
 from dataclasses import dataclass, replace
 
 from langchain_community.llms import LlamaCpp
@@ -414,20 +416,47 @@ class ChatVLLM:
         Plain text, or ``InferenceResult`` objects carrying the first token's
         top logprobs when the model was constructed with ``top_logprobs``.
         """
+        usage_stage = invoke_kwargs.pop("usage_stage", None)
         outputs = self._run_raw_batch(inputs)
-        if self._top_logprobs is None:
+        if self._top_logprobs is None and usage_stage is None:
             return [out.outputs[0].text for out in outputs]
         results = []
         for out in outputs:
             generation = out.outputs[0]
             top = None
-            if generation.logprobs:
+            if getattr(generation, "logprobs", None):
                 top = {
                     entry.decoded_token: float(entry.logprob)
                     for entry in generation.logprobs[0].values()
                 }
+            usage = None
+            if usage_stage is not None:
+                prompt_token_ids = getattr(out, "prompt_token_ids", None)
+                output_token_ids = getattr(generation, "token_ids", None)
+                input_tokens = (
+                    len(prompt_token_ids) if prompt_token_ids is not None else None
+                )
+                output_tokens = (
+                    len(output_token_ids) if output_token_ids is not None else None
+                )
+                total_tokens = (
+                    input_tokens + output_tokens
+                    if input_tokens is not None and output_tokens is not None
+                    else None
+                )
+                usage = RequestUsage(
+                    stage=usage_stage,
+                    model=self.model_path,
+                    input_tokens=input_tokens,
+                    output_tokens=output_tokens,
+                    total_tokens=total_tokens,
+                )
             results.append(
-                InferenceResult(text=generation.text, first_token_top_logprobs=top)
+                InferenceResult(
+                    text=generation.text,
+                    first_token_top_logprobs=top,
+                    usage=usage,
+                )
             )
         return results
 
@@ -468,12 +497,31 @@ def _first_token_top_logprobs(response) -> dict[str, float] | None:
 
 
 def _optional_number(value, number_type):
-    if value is None:
+    if value is None or isinstance(value, bool):
         return None
     try:
-        return number_type(value)
-    except (TypeError, ValueError):
+        number = number_type(value)
+    except (TypeError, ValueError, OverflowError):
         return None
+    if not math.isfinite(float(number)) or number < 0:
+        return None
+    return number
+
+
+def _mapping(value) -> Mapping:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _first_present(*values):
+    return next((value for value in values if value is not None), None)
+
+
+def _first_valid_number(number_type, *values):
+    for value in values:
+        number = _optional_number(value, number_type)
+        if number is not None:
+            return number
+    return None
 
 
 def _request_usage(
@@ -482,29 +530,58 @@ def _request_usage(
     stage: str,
     default_model: str | None,
 ) -> RequestUsage:
-    response_metadata = getattr(response, "response_metadata", None) or {}
-    raw_usage = response_metadata.get("token_usage") or {}
-    prompt_details = raw_usage.get("prompt_tokens_details") or {}
-    completion_details = raw_usage.get("completion_tokens_details") or {}
+    response_metadata = _mapping(getattr(response, "response_metadata", None))
+    raw_usage = _mapping(response_metadata.get("token_usage"))
+    standard_usage = _mapping(getattr(response, "usage_metadata", None))
+    prompt_details = _mapping(raw_usage.get("prompt_tokens_details"))
+    completion_details = _mapping(raw_usage.get("completion_tokens_details"))
+    input_details = _mapping(standard_usage.get("input_token_details"))
+    output_details = _mapping(standard_usage.get("output_token_details"))
 
-    input_tokens = _optional_number(raw_usage.get("prompt_tokens"), int)
-    output_tokens = _optional_number(raw_usage.get("completion_tokens"), int)
-    total_tokens = _optional_number(raw_usage.get("total_tokens"), int)
+    input_tokens = _first_valid_number(
+        int,
+        standard_usage.get("input_tokens"),
+        raw_usage.get("prompt_tokens"),
+    )
+    output_tokens = _first_valid_number(
+        int,
+        standard_usage.get("output_tokens"),
+        raw_usage.get("completion_tokens"),
+    )
+    total_tokens = _first_valid_number(
+        int,
+        standard_usage.get("total_tokens"),
+        raw_usage.get("total_tokens"),
+    )
     if total_tokens is None and input_tokens is not None and output_tokens is not None:
         total_tokens = input_tokens + output_tokens
 
-    model = response_metadata.get("model_name") or default_model
+    model = _first_present(
+        response_metadata.get("model_name"),
+        response_metadata.get("model"),
+        default_model,
+    )
     return RequestUsage(
         stage=stage,
         model=str(model) if model is not None else None,
         input_tokens=input_tokens,
         output_tokens=output_tokens,
         total_tokens=total_tokens,
-        reasoning_tokens=_optional_number(
-            completion_details.get("reasoning_tokens"), int
+        reasoning_tokens=_first_valid_number(
+            int,
+            output_details.get("reasoning"),
+            completion_details.get("reasoning_tokens"),
         ),
-        cached_tokens=_optional_number(prompt_details.get("cached_tokens"), int),
-        cost_usd=_optional_number(raw_usage.get("cost"), float),
+        cached_tokens=_first_valid_number(
+            int,
+            input_details.get("cache_read"),
+            prompt_details.get("cached_tokens"),
+        ),
+        cost_usd=_first_valid_number(
+            float,
+            raw_usage.get("cost"),
+            response_metadata.get("cost"),
+        ),
     )
 
 
@@ -545,6 +622,43 @@ def _to_inference_result(
     )
 
 
+def _usage_invoke_kwargs(chat_model, *, stage: str) -> dict[str, str]:
+    return {"usage_stage": stage} if isinstance(chat_model, ChatVLLM) else {}
+
+
+def _collect_inference_results(
+    chat_model, responses, *, stage: str
+) -> list[InferenceResult]:
+    results = [
+        _to_inference_result(
+            response,
+            stage=stage,
+            default_model=_model_name(chat_model),
+        )
+        for response in responses
+    ]
+    request_usage = [result.usage for result in results if result.usage is not None]
+    record_usage(request_usage)
+
+    batch_usage = RunUsage(tuple(request_usage))
+    summary = batch_usage.summary()
+    if summary["requests_with_any_token_usage"] or summary["requests_with_cost"]:
+        logger.info("Model usage (%s): %s.", stage, batch_usage.format_summary())
+    return results
+
+
+def batch_inference_once(
+    chat_model, inputs, *, stage: str = "unspecified", **invoke_kwargs
+) -> list:
+    """Run one native synchronous batch without changing its public outputs."""
+    invoke_kwargs.update(_usage_invoke_kwargs(chat_model, stage=stage))
+    responses = chat_model.batch(inputs=inputs, **invoke_kwargs)
+    results = _collect_inference_results(chat_model, responses, stage=stage)
+    if isinstance(chat_model, ChatVLLM) and chat_model._top_logprobs is not None:
+        return responses
+    return [result.text for result in results]
+
+
 def do_inference(
     chat_model,
     inputs,
@@ -566,6 +680,7 @@ def do_inference(
     invoke_kwargs = {
         # "stop": ["```"],
         # "max_tokens": 100,
+        **_usage_invoke_kwargs(chat_model, stage=stage),
     }
     if use_tqdm:
         # perform inference asynchronously to be able to update tqdm, chat_model.batch does not work as it blocks until
@@ -645,38 +760,12 @@ def do_inference(
 
         res = batch_with_retry(inputs)
 
-    # Langchain chat models return AIMessage objects, barebones models plain
-    # strings, and ChatVLLM with logprobs enabled InferenceResult objects.
-    res = [
-        _to_inference_result(
-            response,
-            stage=stage,
-            default_model=_model_name(chat_model),
-        )
-        for response in res
-    ]
-    request_usage = [result.usage for result in res if result.usage is not None]
-    record_usage(request_usage)
-
-    batch_summary = RunUsage(tuple(request_usage)).summary()
-    if batch_summary["requests_with_token_usage"]:
-        cost = batch_summary["cost_usd"]
-        input_tokens = batch_summary["input_tokens"]
-        output_tokens = batch_summary["output_tokens"]
-        cost_text = (
-            f", ${float(cost):.6f}" if cost is not None else ", cost unavailable"
-        )
-        logger.info(
-            "Model usage (%s): %d request(s), %s input / %s output tokens%s.",
-            stage,
-            batch_summary["requests"],
-            f"{int(input_tokens):,}" if input_tokens is not None else "unknown",
-            f"{int(output_tokens):,}" if output_tokens is not None else "unknown",
-            cost_text,
-        )
+    # LangChain chat models return AIMessage objects, barebones models plain
+    # strings, and ChatVLLM may return structured InferenceResult objects.
+    results = _collect_inference_results(chat_model, res, stage=stage)
     if return_top_logprobs:
-        return res
-    return [r.text for r in res]
+        return results
+    return [result.text for result in results]
 
 
 def _route_sampling_params(

--- a/judgearena/models.py
+++ b/judgearena/models.py
@@ -7,7 +7,7 @@ import json
 import os
 import time
 import warnings
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 
 from langchain_community.llms import LlamaCpp
 from langchain_openai import ChatOpenAI
@@ -16,6 +16,7 @@ from tqdm.contrib.logging import logging_redirect_tqdm
 
 from judgearena.constants import VLLM_REASONING_END_STR, VLLM_REASONING_START_STR
 from judgearena.log import get_logger
+from judgearena.usage import RequestUsage, RunUsage, record_usage
 from judgearena.utils.io import safe_parse_int
 
 logger = get_logger(__name__)
@@ -447,11 +448,11 @@ class ChatVLLM:
 
 @dataclass(frozen=True)
 class InferenceResult:
-    """A text completion with the first generated token's top logprobs, when
-    the backend was asked for (and returned) them."""
+    """A text completion and optional provider response details."""
 
     text: str
     first_token_top_logprobs: dict[str, float] | None = None
+    usage: RequestUsage | None = None
 
 
 def _first_token_top_logprobs(response) -> dict[str, float] | None:
@@ -466,24 +467,97 @@ def _first_token_top_logprobs(response) -> dict[str, float] | None:
     }
 
 
-def _to_inference_result(response) -> InferenceResult:
+def _optional_number(value, number_type):
+    if value is None:
+        return None
+    try:
+        return number_type(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _request_usage(
+    response,
+    *,
+    stage: str,
+    default_model: str | None,
+) -> RequestUsage:
+    response_metadata = getattr(response, "response_metadata", None) or {}
+    raw_usage = response_metadata.get("token_usage") or {}
+    prompt_details = raw_usage.get("prompt_tokens_details") or {}
+    completion_details = raw_usage.get("completion_tokens_details") or {}
+
+    input_tokens = _optional_number(raw_usage.get("prompt_tokens"), int)
+    output_tokens = _optional_number(raw_usage.get("completion_tokens"), int)
+    total_tokens = _optional_number(raw_usage.get("total_tokens"), int)
+    if total_tokens is None and input_tokens is not None and output_tokens is not None:
+        total_tokens = input_tokens + output_tokens
+
+    model = response_metadata.get("model_name") or default_model
+    return RequestUsage(
+        stage=stage,
+        model=str(model) if model is not None else None,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        total_tokens=total_tokens,
+        reasoning_tokens=_optional_number(
+            completion_details.get("reasoning_tokens"), int
+        ),
+        cached_tokens=_optional_number(prompt_details.get("cached_tokens"), int),
+        cost_usd=_optional_number(raw_usage.get("cost"), float),
+    )
+
+
+def _model_name(chat_model) -> str | None:
+    for attribute in ("model_name", "model", "model_path", "name"):
+        value = getattr(chat_model, attribute, None)
+        if isinstance(value, str) and value:
+            return value
+    return None
+
+
+def _to_inference_result(
+    response,
+    *,
+    stage: str,
+    default_model: str | None,
+) -> InferenceResult:
     if isinstance(response, InferenceResult):
-        return response
+        if response.usage is not None:
+            return response
+        return replace(
+            response,
+            usage=RequestUsage(stage=stage, model=default_model),
+        )
     if hasattr(response, "content"):
         return InferenceResult(
             text=response.content,
             first_token_top_logprobs=_first_token_top_logprobs(response),
+            usage=_request_usage(
+                response,
+                stage=stage,
+                default_model=default_model,
+            ),
         )
-    return InferenceResult(text=response)
+    return InferenceResult(
+        text=response,
+        usage=RequestUsage(stage=stage, model=default_model),
+    )
 
 
 def do_inference(
-    chat_model, inputs, use_tqdm: bool = False, return_top_logprobs: bool = False
+    chat_model,
+    inputs,
+    use_tqdm: bool = False,
+    return_top_logprobs: bool = False,
+    *,
+    stage: str = "unspecified",
 ):
     """Run inference over *inputs*, returning a list of text completions.
 
     With ``return_top_logprobs=True``, returns ``InferenceResult`` objects
     carrying the first token's top logprobs where the backend provided them.
+    ``stage`` labels request usage for the run-level summary.
 
     Retries on rate-limit/server errors with exponential backoff. The async
     path (``use_tqdm=True``) retries individual calls; the batch path splits
@@ -573,7 +647,33 @@ def do_inference(
 
     # Langchain chat models return AIMessage objects, barebones models plain
     # strings, and ChatVLLM with logprobs enabled InferenceResult objects.
-    res = [_to_inference_result(x) for x in res]
+    res = [
+        _to_inference_result(
+            response,
+            stage=stage,
+            default_model=_model_name(chat_model),
+        )
+        for response in res
+    ]
+    request_usage = [result.usage for result in res if result.usage is not None]
+    record_usage(request_usage)
+
+    batch_summary = RunUsage(tuple(request_usage)).summary()
+    if batch_summary["usage_reported_requests"]:
+        cost = batch_summary["cost_usd"]
+        input_tokens = batch_summary["input_tokens"]
+        output_tokens = batch_summary["output_tokens"]
+        cost_text = (
+            f", ${float(cost):.6f}" if cost is not None else ", cost unavailable"
+        )
+        logger.info(
+            "Model usage (%s): %d request(s), %s input / %s output tokens%s.",
+            stage,
+            batch_summary["requests"],
+            f"{int(input_tokens):,}" if input_tokens is not None else "unknown",
+            f"{int(output_tokens):,}" if output_tokens is not None else "unknown",
+            cost_text,
+        )
     if return_top_logprobs:
         return res
     return [r.text for r in res]

--- a/judgearena/models.py
+++ b/judgearena/models.py
@@ -659,7 +659,7 @@ def do_inference(
     record_usage(request_usage)
 
     batch_summary = RunUsage(tuple(request_usage)).summary()
-    if batch_summary["usage_reported_requests"]:
+    if batch_summary["requests_with_token_usage"]:
         cost = batch_summary["cost_usd"]
         input_tokens = batch_summary["input_tokens"]
         output_tokens = batch_summary["output_tokens"]

--- a/judgearena/usage.py
+++ b/judgearena/usage.py
@@ -1,0 +1,194 @@
+"""Model request usage collected during one benchmark run."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from contextvars import ContextVar
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class RequestUsage:
+    """Usage record for one model request."""
+
+    stage: str
+    model: str | None = None
+    input_tokens: int | None = None
+    output_tokens: int | None = None
+    total_tokens: int | None = None
+    reasoning_tokens: int | None = None
+    cached_tokens: int | None = None
+    cost_usd: float | None = None
+
+    @property
+    def has_token_usage(self) -> bool:
+        return any(
+            value is not None
+            for value in (self.input_tokens, self.output_tokens, self.total_tokens)
+        )
+
+
+def _coverage_status(reported: int, total: int) -> str:
+    if total == 0:
+        return "no_requests"
+    if reported == 0:
+        return "unavailable"
+    if reported < total:
+        return "partial"
+    return "complete"
+
+
+def _sum_optional(requests: tuple[RequestUsage, ...], field: str) -> int | None:
+    values = [getattr(request, field) for request in requests]
+    reported = [int(value) for value in values if value is not None]
+    return sum(reported) if reported else None
+
+
+def _summarize(requests: tuple[RequestUsage, ...]) -> dict[str, object]:
+    token_reported = sum(request.has_token_usage for request in requests)
+    cost_values = [
+        request.cost_usd for request in requests if request.cost_usd is not None
+    ]
+    cost_reported = len(cost_values)
+    return {
+        "requests": len(requests),
+        "input_tokens": _sum_optional(requests, "input_tokens"),
+        "output_tokens": _sum_optional(requests, "output_tokens"),
+        "total_tokens": _sum_optional(requests, "total_tokens"),
+        "reasoning_tokens": _sum_optional(requests, "reasoning_tokens"),
+        "cached_tokens": _sum_optional(requests, "cached_tokens"),
+        "cost_usd": sum(cost_values) if cost_values else None,
+        "usage_reported_requests": token_reported,
+        "cost_reported_requests": cost_reported,
+        "usage_status": _coverage_status(token_reported, len(requests)),
+        "cost_status": _coverage_status(cost_reported, len(requests)),
+    }
+
+
+@dataclass(frozen=True)
+class RunUsage:
+    """Immutable snapshot of the model requests made during a run."""
+
+    requests: tuple[RequestUsage, ...]
+
+    def summary(self) -> dict[str, object]:
+        return _summarize(self.requests)
+
+    def to_dict(self) -> dict[str, object]:
+        by_stage = {
+            stage: _summarize(
+                tuple(request for request in self.requests if request.stage == stage)
+            )
+            for stage in sorted({request.stage for request in self.requests})
+        }
+        by_model = {
+            model: _summarize(
+                tuple(
+                    request
+                    for request in self.requests
+                    if (request.model or "unknown") == model
+                )
+            )
+            for model in sorted(
+                {request.model or "unknown" for request in self.requests}
+            )
+        }
+        return {
+            "scope": "model_requests_made_during_this_run",
+            "source": "provider_response",
+            "total": self.summary(),
+            "by_stage": by_stage,
+            "by_model": by_model,
+        }
+
+    def render(self) -> None:
+        data = self.to_dict()
+        total = data["total"]
+        assert isinstance(total, dict)
+
+        print("\nModel usage:")
+        if not self.requests:
+            print("  No model requests were made during this run.")
+            return
+
+        by_stage = data["by_stage"]
+        assert isinstance(by_stage, dict)
+        for stage, summary in by_stage.items():
+            assert isinstance(summary, dict)
+            print(f"  {stage.capitalize()}: {_format_summary(summary)}")
+        print(f"  Total: {_format_summary(total)}")
+
+
+def _format_summary(summary: dict[str, object]) -> str:
+    requests = int(summary["requests"])
+    input_tokens = summary["input_tokens"]
+    output_tokens = summary["output_tokens"]
+    cost = summary["cost_usd"]
+    cost_status = str(summary["cost_status"])
+
+    if input_tokens is None or output_tokens is None:
+        tokens = "token usage unavailable"
+    else:
+        tokens = f"{int(input_tokens):,} input / {int(output_tokens):,} output tokens"
+
+    if cost_status == "unavailable":
+        cost_text = "cost unavailable"
+    elif cost_status == "partial":
+        cost_text = f"${float(cost):.6f} reported (partial)"
+    elif cost_status == "no_requests":
+        cost_text = "$0.000000"
+    else:
+        cost_text = f"${float(cost):.6f}"
+    return f"{requests} request(s), {tokens}, {cost_text}"
+
+
+class UsageTracker:
+    """Collect request usage without changing benchmark runner signatures."""
+
+    def __init__(self) -> None:
+        self._requests: list[RequestUsage] = []
+
+    def record(self, usage: RequestUsage) -> None:
+        self._requests.append(usage)
+
+    def record_many(self, usage: list[RequestUsage]) -> None:
+        self._requests.extend(usage)
+
+    def snapshot(self) -> RunUsage:
+        return RunUsage(requests=tuple(self._requests))
+
+    def render_summary(self) -> None:
+        self.snapshot().render()
+
+
+_CURRENT_TRACKER: ContextVar[UsageTracker | None] = ContextVar(
+    "judgearena_usage_tracker", default=None
+)
+
+
+@contextmanager
+def track_usage() -> Iterator[UsageTracker]:
+    """Collect model usage in the current benchmark execution context."""
+    current = _CURRENT_TRACKER.get()
+    if current is not None:
+        yield current
+        return
+
+    tracker = UsageTracker()
+    token = _CURRENT_TRACKER.set(tracker)
+    try:
+        yield tracker
+    finally:
+        _CURRENT_TRACKER.reset(token)
+
+
+def record_usage(requests: list[RequestUsage]) -> None:
+    tracker = _CURRENT_TRACKER.get()
+    if tracker is not None:
+        tracker.record_many(requests)
+
+
+def current_run_usage() -> RunUsage | None:
+    tracker = _CURRENT_TRACKER.get()
+    return tracker.snapshot() if tracker is not None else None

--- a/judgearena/usage.py
+++ b/judgearena/usage.py
@@ -25,7 +25,13 @@ class RequestUsage:
     def has_token_usage(self) -> bool:
         return any(
             value is not None
-            for value in (self.input_tokens, self.output_tokens, self.total_tokens)
+            for value in (
+                self.input_tokens,
+                self.output_tokens,
+                self.total_tokens,
+                self.reasoning_tokens,
+                self.cached_tokens,
+            )
         )
 
 
@@ -36,21 +42,29 @@ def _sum_optional(requests: tuple[RequestUsage, ...], field: str) -> int | None:
 
 
 def _summarize(requests: tuple[RequestUsage, ...]) -> dict[str, object]:
-    token_reported = sum(request.has_token_usage for request in requests)
+    token_fields = (
+        "input_tokens",
+        "output_tokens",
+        "total_tokens",
+        "reasoning_tokens",
+        "cached_tokens",
+    )
+    reported = {
+        field: sum(getattr(request, field) is not None for request in requests)
+        for field in token_fields
+    }
     cost_values = [
         request.cost_usd for request in requests if request.cost_usd is not None
     ]
-    cost_reported = len(cost_values)
     return {
         "requests": len(requests),
-        "input_tokens": _sum_optional(requests, "input_tokens"),
-        "output_tokens": _sum_optional(requests, "output_tokens"),
-        "total_tokens": _sum_optional(requests, "total_tokens"),
-        "reasoning_tokens": _sum_optional(requests, "reasoning_tokens"),
-        "cached_tokens": _sum_optional(requests, "cached_tokens"),
+        **{field: _sum_optional(requests, field) for field in token_fields},
         "cost_usd": sum(cost_values) if cost_values else None,
-        "requests_with_token_usage": token_reported,
-        "requests_with_cost": cost_reported,
+        "requests_with_any_token_usage": sum(
+            request.has_token_usage for request in requests
+        ),
+        **{f"requests_with_{field}": count for field, count in reported.items()},
+        "requests_with_cost": len(cost_values),
     }
 
 
@@ -62,6 +76,9 @@ class RunUsage:
 
     def summary(self) -> dict[str, object]:
         return _summarize(self.requests)
+
+    def format_summary(self) -> str:
+        return _format_summary(self.summary())
 
     def to_dict(self) -> dict[str, object]:
         by_stage = {
@@ -83,8 +100,8 @@ class RunUsage:
             )
         }
         return {
-            "scope": "model_requests_made_during_this_run",
-            "source": "provider_response",
+            "scope": "successful_model_responses_returned_by_completed_inference_calls",
+            "source": "provider_response_metadata_when_available",
             "total": self.summary(),
             "by_stage": by_stage,
             "by_model": by_model,
@@ -105,7 +122,7 @@ class RunUsage:
         for stage, summary in by_stage.items():
             assert isinstance(summary, dict)
             print(f"  {stage.capitalize()}: {_format_summary(summary)}")
-        print(f"  Total: {_format_summary(total)}")
+        print(f"  Total: {self.format_summary()}")
 
 
 def _format_summary(summary: dict[str, object]) -> str:
@@ -113,25 +130,34 @@ def _format_summary(summary: dict[str, object]) -> str:
     input_tokens = summary["input_tokens"]
     output_tokens = summary["output_tokens"]
     cost = summary["cost_usd"]
-    requests_with_tokens = int(summary["requests_with_token_usage"])
-    requests_with_cost = int(summary["requests_with_cost"])
+    input_reported = int(summary["requests_with_input_tokens"])
+    output_reported = int(summary["requests_with_output_tokens"])
+    cost_reported = int(summary["requests_with_cost"])
 
-    if input_tokens is None or output_tokens is None:
+    if input_tokens is None and output_tokens is None:
         tokens = "token usage unavailable"
     else:
-        tokens = f"{int(input_tokens):,} input / {int(output_tokens):,} output tokens"
-        if requests_with_tokens < requests:
-            tokens += " reported (partial)"
+        input_text = f"{int(input_tokens):,}" if input_tokens is not None else "unknown"
+        output_text = (
+            f"{int(output_tokens):,}" if output_tokens is not None else "unknown"
+        )
+        tokens = f"{input_text} input / {output_text} output tokens"
+        if input_reported < requests or output_reported < requests:
+            tokens += (
+                " reported (partial: "
+                f"input {input_reported}/{requests}, "
+                f"output {output_reported}/{requests})"
+            )
 
     if requests == 0:
         cost_text = "$0.000000"
-    elif requests_with_cost == 0:
+    elif cost_reported == 0:
         cost_text = "cost unavailable"
-    elif requests_with_cost < requests:
+    elif cost_reported < requests:
         cost_text = f"${float(cost):.6f} reported (partial)"
     else:
         cost_text = f"${float(cost):.6f}"
-    return f"{requests} request(s), {tokens}, {cost_text}"
+    return f"{requests} successful response(s), {tokens}, {cost_text}"
 
 
 class UsageTracker:
@@ -160,7 +186,7 @@ _CURRENT_TRACKER: ContextVar[UsageTracker | None] = ContextVar(
 
 @contextmanager
 def track_usage() -> Iterator[UsageTracker]:
-    """Collect model usage in the current benchmark execution context."""
+    """Collect usage; nested scopes intentionally share the outer run tracker."""
     current = _CURRENT_TRACKER.get()
     if current is not None:
         yield current

--- a/judgearena/usage.py
+++ b/judgearena/usage.py
@@ -29,16 +29,6 @@ class RequestUsage:
         )
 
 
-def _coverage_status(reported: int, total: int) -> str:
-    if total == 0:
-        return "no_requests"
-    if reported == 0:
-        return "unavailable"
-    if reported < total:
-        return "partial"
-    return "complete"
-
-
 def _sum_optional(requests: tuple[RequestUsage, ...], field: str) -> int | None:
     values = [getattr(request, field) for request in requests]
     reported = [int(value) for value in values if value is not None]
@@ -59,10 +49,8 @@ def _summarize(requests: tuple[RequestUsage, ...]) -> dict[str, object]:
         "reasoning_tokens": _sum_optional(requests, "reasoning_tokens"),
         "cached_tokens": _sum_optional(requests, "cached_tokens"),
         "cost_usd": sum(cost_values) if cost_values else None,
-        "usage_reported_requests": token_reported,
-        "cost_reported_requests": cost_reported,
-        "usage_status": _coverage_status(token_reported, len(requests)),
-        "cost_status": _coverage_status(cost_reported, len(requests)),
+        "requests_with_token_usage": token_reported,
+        "requests_with_cost": cost_reported,
     }
 
 
@@ -125,19 +113,22 @@ def _format_summary(summary: dict[str, object]) -> str:
     input_tokens = summary["input_tokens"]
     output_tokens = summary["output_tokens"]
     cost = summary["cost_usd"]
-    cost_status = str(summary["cost_status"])
+    requests_with_tokens = int(summary["requests_with_token_usage"])
+    requests_with_cost = int(summary["requests_with_cost"])
 
     if input_tokens is None or output_tokens is None:
         tokens = "token usage unavailable"
     else:
         tokens = f"{int(input_tokens):,} input / {int(output_tokens):,} output tokens"
+        if requests_with_tokens < requests:
+            tokens += " reported (partial)"
 
-    if cost_status == "unavailable":
-        cost_text = "cost unavailable"
-    elif cost_status == "partial":
-        cost_text = f"${float(cost):.6f} reported (partial)"
-    elif cost_status == "no_requests":
+    if requests == 0:
         cost_text = "$0.000000"
+    elif requests_with_cost == 0:
+        cost_text = "cost unavailable"
+    elif requests_with_cost < requests:
+        cost_text = f"${float(cost):.6f} reported (partial)"
     else:
         cost_text = f"${float(cost):.6f}"
     return f"{requests} request(s), {tokens}, {cost_text}"

--- a/scripts/annotate_instruction_quality.py
+++ b/scripts/annotate_instruction_quality.py
@@ -74,6 +74,7 @@ judge_completions = do_inference(
     chat_model=judge_chat_model,
     inputs=inputs,
     use_tqdm=False,
+    stage="judging",
 )
 
 print(judge_completions)

--- a/scripts/fluency/generate_fluency.py
+++ b/scripts/fluency/generate_fluency.py
@@ -66,6 +66,7 @@ def generate_contexts(
                     )
                 ],
                 use_tqdm=False,
+                stage="generation",
             )
 
             if len(output[0]) < 10:

--- a/scripts/multilingual_arena_hard/translate_arena_hard.py
+++ b/scripts/multilingual_arena_hard/translate_arena_hard.py
@@ -141,6 +141,7 @@ def generate_translations():
             chat_model=judge_chat_model,
             inputs=inputs,
             use_tqdm=False,
+            stage="generation",
         )
 
         translation_path = f"data/ArenaHard-EU/{language_code}/data.parquet"

--- a/tests/test_chat_vllm.py
+++ b/tests/test_chat_vllm.py
@@ -3,6 +3,7 @@ import sys
 from types import SimpleNamespace
 
 import judgearena.models as models
+from judgearena.usage import track_usage
 
 
 def _install_fake_vllm(monkeypatch):
@@ -33,7 +34,12 @@ def _install_fake_vllm(monkeypatch):
                 "sampling_params": sampling_params,
                 "kwargs": kwargs,
             }
-            return [SimpleNamespace(outputs=[SimpleNamespace(text="ok")])]
+            return [
+                SimpleNamespace(
+                    prompt_token_ids=[1, 2, 3],
+                    outputs=[SimpleNamespace(text="ok", token_ids=[4, 5])],
+                )
+            ]
 
     monkeypatch.setitem(
         sys.modules,
@@ -137,6 +143,28 @@ def test_chat_vllm_passes_disable_thinking_via_chat_template_kwargs(monkeypatch)
     assert captured["chat_call"]["kwargs"]["chat_template_kwargs"] == {
         "enable_thinking": False
     }
+
+
+def test_chat_vllm_reports_exact_local_token_counts(monkeypatch):
+    _captured, _fake_reasoning_config = _install_fake_vllm(monkeypatch)
+    chat_model = models.ChatVLLM(
+        model="Qwen/Qwen3.5-9B",
+        max_tokens=16,
+        gpu_memory_utilization=0.7,
+    )
+
+    with track_usage() as tracker:
+        assert models.do_inference(
+            chat_model,
+            ["hello"],
+            stage="generation",
+        ) == ["ok"]
+        usage = tracker.snapshot().requests[0]
+
+    assert usage.model == "Qwen/Qwen3.5-9B"
+    assert usage.input_tokens == 3
+    assert usage.output_tokens == 2
+    assert usage.total_tokens == 5
 
 
 def test_build_default_judge_model_kwargs_only_defaults_qwen_judges():

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -116,10 +116,8 @@ def test_run_usage_reports_partial_cost_without_presenting_it_as_complete():
         "reasoning_tokens": None,
         "cached_tokens": None,
         "cost_usd": pytest.approx(0.1),
-        "usage_reported_requests": 2,
-        "cost_reported_requests": 1,
-        "usage_status": "complete",
-        "cost_status": "partial",
+        "requests_with_token_usage": 2,
+        "requests_with_cost": 1,
     }
     assert set(usage["by_stage"]) == {"generation", "judging"}
     assert set(usage["by_model"]) == {"candidate", "local-judge"}

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -1,0 +1,182 @@
+import json
+from types import SimpleNamespace
+
+import pytest
+from langchain_core.messages import AIMessage
+
+import judgearena.artifacts.metadata as metadata_module
+import judgearena.benchmarks.runner as benchmark_runner
+from judgearena.models import InferenceResult, do_inference
+from judgearena.usage import (
+    RequestUsage,
+    RunUsage,
+    current_run_usage,
+    record_usage,
+    track_usage,
+)
+
+
+class FakeModel:
+    model_name = "google/test-model"
+
+    def __init__(self, responses):
+        self.responses = responses
+
+    def batch(self, inputs, **kwargs):
+        return self.responses[: len(inputs)]
+
+
+def _provider_message() -> AIMessage:
+    return AIMessage(
+        content="answer",
+        usage_metadata={
+            "input_tokens": 120,
+            "output_tokens": 30,
+            "total_tokens": 150,
+            "input_token_details": {"cache_read": 20},
+            "output_token_details": {"reasoning": 10},
+        },
+        response_metadata={
+            "id": "gen-test",
+            "model_name": "google/test-model",
+            "token_usage": {
+                "prompt_tokens": 120,
+                "completion_tokens": 30,
+                "total_tokens": 150,
+                "prompt_tokens_details": {"cached_tokens": 20},
+                "completion_tokens_details": {"reasoning_tokens": 10},
+                "cost": 0.00125,
+            },
+        },
+    )
+
+
+def test_do_inference_collects_provider_usage_without_changing_text_results():
+    with track_usage() as tracker:
+        outputs = do_inference(
+            FakeModel([_provider_message()]),
+            ["prompt"],
+            stage="judging",
+        )
+        snapshot = tracker.snapshot()
+
+    assert outputs == ["answer"]
+    assert len(snapshot.requests) == 1
+    usage = snapshot.requests[0]
+    assert usage.stage == "judging"
+    assert usage.model == "google/test-model"
+    assert usage.input_tokens == 120
+    assert usage.output_tokens == 30
+    assert usage.reasoning_tokens == 10
+    assert usage.cached_tokens == 20
+    assert usage.cost_usd == pytest.approx(0.00125)
+
+
+def test_do_inference_keeps_usage_on_structured_results():
+    with track_usage():
+        outputs = do_inference(
+            FakeModel([_provider_message()]),
+            ["prompt"],
+            return_top_logprobs=True,
+            stage="judging",
+        )
+
+    assert isinstance(outputs[0], InferenceResult)
+    assert outputs[0].text == "answer"
+    assert outputs[0].usage is not None
+    assert outputs[0].usage.total_tokens == 150
+
+
+def test_run_usage_reports_partial_cost_without_presenting_it_as_complete():
+    usage = RunUsage(
+        requests=(
+            RequestUsage(
+                stage="generation",
+                model="candidate",
+                input_tokens=10,
+                output_tokens=5,
+                total_tokens=15,
+                cost_usd=0.1,
+            ),
+            RequestUsage(
+                stage="judging",
+                model="local-judge",
+                input_tokens=20,
+                output_tokens=2,
+                total_tokens=22,
+            ),
+        )
+    ).to_dict()
+
+    assert usage["total"] == {
+        "requests": 2,
+        "input_tokens": 30,
+        "output_tokens": 7,
+        "total_tokens": 37,
+        "reasoning_tokens": None,
+        "cached_tokens": None,
+        "cost_usd": pytest.approx(0.1),
+        "usage_reported_requests": 2,
+        "cost_reported_requests": 1,
+        "usage_status": "complete",
+        "cost_status": "partial",
+    }
+    assert set(usage["by_stage"]) == {"generation", "judging"}
+    assert set(usage["by_model"]) == {"candidate", "local-judge"}
+
+
+def test_write_run_metadata_includes_active_run_usage(tmp_path, monkeypatch):
+    monkeypatch.setattr(metadata_module, "_get_dependency_versions", lambda **_: {})
+    monkeypatch.setattr(metadata_module, "_get_git_hash", lambda **_: None)
+
+    with track_usage():
+        record_usage(
+            [
+                RequestUsage(
+                    stage="judging",
+                    model="judge",
+                    input_tokens=10,
+                    output_tokens=1,
+                    total_tokens=11,
+                    cost_usd=0.002,
+                )
+            ]
+        )
+        path = metadata_module.write_run_metadata(
+            output_dir=tmp_path,
+            entrypoint="test",
+            run={"task": "unknown"},
+        )
+
+    metadata = json.loads(path.read_text())
+    assert metadata["usage"]["total"]["cost_usd"] == pytest.approx(0.002)
+    assert metadata["usage"]["by_stage"]["judging"]["requests"] == 1
+
+
+def test_run_benchmark_scopes_and_prints_usage(monkeypatch, capsys):
+    def fake_runner(cfg, task):
+        record_usage(
+            [
+                RequestUsage(
+                    stage="judging",
+                    model="judge",
+                    input_tokens=4,
+                    output_tokens=1,
+                    total_tokens=5,
+                    cost_usd=0.0001,
+                )
+            ]
+        )
+        return "done"
+
+    resolved = SimpleNamespace(
+        adapter=SimpleNamespace(name="test", runner=fake_runner),
+        task=None,
+    )
+    monkeypatch.setattr(benchmark_runner, "resolve_benchmark", lambda task: resolved)
+
+    result = benchmark_runner.run_benchmark(SimpleNamespace(task="test"))
+
+    assert result == "done"
+    assert "Model usage:" in capsys.readouterr().out
+    assert current_run_usage() is None

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -1,11 +1,13 @@
 import json
 from types import SimpleNamespace
 
+import pandas as pd
 import pytest
 from langchain_core.messages import AIMessage
 
 import judgearena.artifacts.metadata as metadata_module
 import judgearena.benchmarks.runner as benchmark_runner
+import judgearena.generate as generate_module
 from judgearena.models import InferenceResult, do_inference
 from judgearena.usage import (
     RequestUsage,
@@ -72,6 +74,80 @@ def test_do_inference_collects_provider_usage_without_changing_text_results():
     assert usage.cost_usd == pytest.approx(0.00125)
 
 
+def test_do_inference_collects_canonical_langchain_usage_metadata():
+    message = AIMessage(
+        content="answer",
+        usage_metadata={
+            "input_tokens": 10,
+            "output_tokens": 2,
+            "total_tokens": 12,
+            "input_token_details": {"cache_read": 3},
+            "output_token_details": {"reasoning": 1},
+        },
+        response_metadata={"model_name": "openai/responses-model"},
+    )
+
+    with track_usage() as tracker:
+        do_inference(FakeModel([message]), ["prompt"], stage="judging")
+        usage = tracker.snapshot().requests[0]
+
+    assert usage.input_tokens == 10
+    assert usage.output_tokens == 2
+    assert usage.total_tokens == 12
+    assert usage.cached_tokens == 3
+    assert usage.reasoning_tokens == 1
+
+
+def test_do_inference_ignores_malformed_optional_provider_usage():
+    message = AIMessage(
+        content="answer",
+        response_metadata={"token_usage": "not-a-mapping"},
+    )
+
+    with track_usage() as tracker:
+        assert do_inference(FakeModel([message]), ["prompt"]) == ["answer"]
+        usage = tracker.snapshot().requests[0]
+
+    assert usage.input_tokens is None
+    assert usage.output_tokens is None
+
+
+def test_canonical_usage_survives_malformed_raw_field_values():
+    message = AIMessage(
+        content="answer",
+        usage_metadata={
+            "input_tokens": 101,
+            "output_tokens": 23,
+            "total_tokens": 124,
+            "input_token_details": {"cache_read": 17},
+            "output_token_details": {"reasoning": 9},
+        },
+        response_metadata={
+            "model_name": "openai/responses-model",
+            "cost": 0.125,
+            "token_usage": {
+                "prompt_tokens": "not-a-number",
+                "completion_tokens": -1,
+                "total_tokens": float("nan"),
+                "prompt_tokens_details": {"cached_tokens": True},
+                "completion_tokens_details": {"reasoning_tokens": float("inf")},
+                "cost": "unknown",
+            },
+        },
+    )
+
+    with track_usage() as tracker:
+        do_inference(FakeModel([message]), ["prompt"], stage="judging")
+        usage = tracker.snapshot().requests[0]
+
+    assert usage.input_tokens == 101
+    assert usage.output_tokens == 23
+    assert usage.total_tokens == 124
+    assert usage.cached_tokens == 17
+    assert usage.reasoning_tokens == 9
+    assert usage.cost_usd == pytest.approx(0.125)
+
+
 def test_do_inference_keeps_usage_on_structured_results():
     with track_usage():
         outputs = do_inference(
@@ -116,11 +192,49 @@ def test_run_usage_reports_partial_cost_without_presenting_it_as_complete():
         "reasoning_tokens": None,
         "cached_tokens": None,
         "cost_usd": pytest.approx(0.1),
-        "requests_with_token_usage": 2,
+        "requests_with_any_token_usage": 2,
+        "requests_with_input_tokens": 2,
+        "requests_with_output_tokens": 2,
+        "requests_with_total_tokens": 2,
+        "requests_with_reasoning_tokens": 0,
+        "requests_with_cached_tokens": 0,
         "requests_with_cost": 1,
     }
+    assert usage["scope"] == (
+        "successful_model_responses_returned_by_completed_inference_calls"
+    )
+    assert usage["source"] == "provider_response_metadata_when_available"
     assert set(usage["by_stage"]) == {"generation", "judging"}
     assert set(usage["by_model"]) == {"candidate", "local-judge"}
+
+
+def test_run_usage_reports_per_field_partial_token_coverage():
+    usage = RunUsage(
+        requests=(
+            RequestUsage(stage="generation", input_tokens=10),
+            RequestUsage(stage="generation", output_tokens=5),
+        )
+    )
+    summary = usage.summary()
+
+    assert summary["input_tokens"] == 10
+    assert summary["output_tokens"] == 5
+    assert summary["requests_with_input_tokens"] == 1
+    assert summary["requests_with_output_tokens"] == 1
+    assert "partial: input 1/2, output 1/2" in usage.format_summary()
+
+
+def test_batch_usage_log_marks_missing_responses_as_partial(caplog):
+    caplog.set_level("INFO", logger="judgearena")
+    with track_usage():
+        do_inference(
+            FakeModel([_provider_message(), "no metadata"]),
+            ["one", "two"],
+            stage="judging",
+        )
+
+    assert "partial: input 1/2, output 1/2" in caplog.text
+    assert "$0.001250 reported (partial)" in caplog.text
 
 
 def test_write_run_metadata_includes_active_run_usage(tmp_path, monkeypatch):
@@ -177,4 +291,51 @@ def test_run_benchmark_scopes_and_prints_usage(monkeypatch, capsys):
 
     assert result == "done"
     assert "Model usage:" in capsys.readouterr().out
+    assert current_run_usage() is None
+
+
+class DivergentGenerationModel:
+    model_name = "test/divergent"
+
+    def __init__(self):
+        self.batch_kwargs = None
+
+    def batch(self, *, inputs, **kwargs):
+        self.batch_kwargs = kwargs
+        return ["batch" for _ in inputs]
+
+    async def ainvoke(self, _input, **_kwargs):
+        return "async"
+
+
+def test_generation_paths_preserve_existing_sync_async_behavior(monkeypatch):
+    model = DivergentGenerationModel()
+    monkeypatch.setattr(generate_module, "make_model", lambda *args, **kwargs: model)
+    instructions = pd.Series(["one", "two"])
+
+    instruction_outputs = generate_module.generate_instructions(
+        instructions,
+        "Dummy/model",
+        use_tqdm=True,
+    )
+    assert instruction_outputs["completion"].tolist() == ["async", "async"]
+
+    base_outputs = generate_module.generate_base(
+        instructions,
+        "Dummy/model",
+        max_tokens=123,
+        use_tqdm=True,
+    )
+    assert base_outputs["completion"].tolist() == ["batch", "batch"]
+    assert model.batch_kwargs == {"max_tokens": 123}
+
+
+def test_nested_usage_tracking_explicitly_shares_the_outer_run():
+    with track_usage() as outer:
+        record_usage([RequestUsage(stage="generation", input_tokens=1)])
+        with track_usage() as inner:
+            assert inner is outer
+            record_usage([RequestUsage(stage="judging", output_tokens=1)])
+        assert len(outer.snapshot().requests) == 2
+
     assert current_run_usage() is None

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -21,81 +21,87 @@ from judgearena.usage import (
 class FakeModel:
     model_name = "google/test-model"
 
-    def __init__(self, responses):
+    def __init__(self, responses, *, async_response=None):
         self.responses = responses
+        self.async_response = async_response
+        self.batch_kwargs = None
 
-    def batch(self, inputs, **kwargs):
+    def batch(self, *, inputs, **kwargs):
+        self.batch_kwargs = kwargs
         return self.responses[: len(inputs)]
 
-
-def _provider_message() -> AIMessage:
-    return AIMessage(
-        content="answer",
-        usage_metadata={
-            "input_tokens": 120,
-            "output_tokens": 30,
-            "total_tokens": 150,
-            "input_token_details": {"cache_read": 20},
-            "output_token_details": {"reasoning": 10},
-        },
-        response_metadata={
-            "id": "gen-test",
-            "model_name": "google/test-model",
-            "token_usage": {
-                "prompt_tokens": 120,
-                "completion_tokens": 30,
-                "total_tokens": 150,
-                "prompt_tokens_details": {"cached_tokens": 20},
-                "completion_tokens_details": {"reasoning_tokens": 10},
-                "cost": 0.00125,
-            },
-        },
-    )
+    async def ainvoke(self, _input, **_kwargs):
+        return self.async_response
 
 
-def test_do_inference_collects_provider_usage_without_changing_text_results():
+@pytest.mark.parametrize(
+    ("message", "structured", "expected"),
+    [
+        (
+            AIMessage(
+                content="canonical",
+                usage_metadata={
+                    "input_tokens": 10,
+                    "output_tokens": 2,
+                    "total_tokens": 12,
+                    "input_token_details": {"cache_read": 3},
+                    "output_token_details": {"reasoning": 1},
+                },
+                response_metadata={"model_name": "google/test-model"},
+            ),
+            False,
+            (10, 2, 12, 1, 3, None),
+        ),
+        (
+            AIMessage(
+                content="fallback",
+                response_metadata={
+                    "model_name": "google/test-model",
+                    "token_usage": {
+                        "prompt_tokens": 120,
+                        "completion_tokens": 30,
+                        "total_tokens": 150,
+                        "prompt_tokens_details": {"cached_tokens": 20},
+                        "completion_tokens_details": {"reasoning_tokens": 10},
+                        "cost": 0.00125,
+                    },
+                },
+            ),
+            True,
+            (120, 30, 150, 10, 20, 0.00125),
+        ),
+    ],
+)
+def test_do_inference_collects_canonical_and_fallback_usage(
+    message, structured, expected
+):
     with track_usage() as tracker:
         outputs = do_inference(
-            FakeModel([_provider_message()]),
+            FakeModel([message]),
             ["prompt"],
+            return_top_logprobs=structured,
             stage="judging",
         )
-        snapshot = tracker.snapshot()
-
-    assert outputs == ["answer"]
-    assert len(snapshot.requests) == 1
-    usage = snapshot.requests[0]
-    assert usage.stage == "judging"
-    assert usage.model == "google/test-model"
-    assert usage.input_tokens == 120
-    assert usage.output_tokens == 30
-    assert usage.reasoning_tokens == 10
-    assert usage.cached_tokens == 20
-    assert usage.cost_usd == pytest.approx(0.00125)
-
-
-def test_do_inference_collects_canonical_langchain_usage_metadata():
-    message = AIMessage(
-        content="answer",
-        usage_metadata={
-            "input_tokens": 10,
-            "output_tokens": 2,
-            "total_tokens": 12,
-            "input_token_details": {"cache_read": 3},
-            "output_token_details": {"reasoning": 1},
-        },
-        response_metadata={"model_name": "openai/responses-model"},
-    )
-
-    with track_usage() as tracker:
-        do_inference(FakeModel([message]), ["prompt"], stage="judging")
         usage = tracker.snapshot().requests[0]
 
-    assert usage.input_tokens == 10
-    assert usage.output_tokens == 2
-    assert usage.total_tokens == 12
-    assert usage.cached_tokens == 3
-    assert usage.reasoning_tokens == 1
+    if structured:
+        assert isinstance(outputs[0], InferenceResult)
+        assert outputs[0].text == message.content
+        assert outputs[0].usage == usage
+    else:
+        assert outputs == [message.content]
+    assert (usage.stage, usage.model) == ("judging", "google/test-model")
+    assert (
+        usage.input_tokens,
+        usage.output_tokens,
+        usage.total_tokens,
+        usage.reasoning_tokens,
+        usage.cached_tokens,
+    ) == expected[:5]
+    if expected[5] is None:
+        assert usage.cost_usd is None
+    else:
+        assert usage.cost_usd == pytest.approx(expected[5])
 
 
 def test_do_inference_ignores_malformed_optional_provider_usage():
@@ -112,7 +118,7 @@ def test_do_inference_ignores_malformed_optional_provider_usage():
     assert usage.output_tokens is None
 
 
-def test_canonical_usage_survives_malformed_raw_field_values():
+def test_malformed_raw_usage_does_not_override_canonical_usage():
     message = AIMessage(
         content="answer",
         usage_metadata={
@@ -128,10 +134,8 @@ def test_canonical_usage_survives_malformed_raw_field_values():
             "token_usage": {
                 "prompt_tokens": "not-a-number",
                 "completion_tokens": -1,
-                "total_tokens": float("nan"),
                 "prompt_tokens_details": {"cached_tokens": True},
                 "completion_tokens_details": {"reasoning_tokens": float("inf")},
-                "cost": "unknown",
             },
         },
     )
@@ -140,101 +144,42 @@ def test_canonical_usage_survives_malformed_raw_field_values():
         do_inference(FakeModel([message]), ["prompt"], stage="judging")
         usage = tracker.snapshot().requests[0]
 
-    assert usage.input_tokens == 101
-    assert usage.output_tokens == 23
-    assert usage.total_tokens == 124
-    assert usage.cached_tokens == 17
-    assert usage.reasoning_tokens == 9
-    assert usage.cost_usd == pytest.approx(0.125)
+    assert (
+        usage.input_tokens,
+        usage.output_tokens,
+        usage.total_tokens,
+        usage.cached_tokens,
+        usage.reasoning_tokens,
+        usage.cost_usd,
+    ) == (101, 23, 124, 17, 9, pytest.approx(0.125))
 
 
-def test_do_inference_keeps_usage_on_structured_results():
-    with track_usage():
-        outputs = do_inference(
-            FakeModel([_provider_message()]),
-            ["prompt"],
-            return_top_logprobs=True,
-            stage="judging",
-        )
-
-    assert isinstance(outputs[0], InferenceResult)
-    assert outputs[0].text == "answer"
-    assert outputs[0].usage is not None
-    assert outputs[0].usage.total_tokens == 150
-
-
-def test_run_usage_reports_partial_cost_without_presenting_it_as_complete():
+def test_run_usage_reports_partial_field_coverage():
     usage = RunUsage(
         requests=(
             RequestUsage(
                 stage="generation",
                 model="candidate",
                 input_tokens=10,
-                output_tokens=5,
                 total_tokens=15,
                 cost_usd=0.1,
             ),
-            RequestUsage(
-                stage="judging",
-                model="local-judge",
-                input_tokens=20,
-                output_tokens=2,
-                total_tokens=22,
-            ),
-        )
-    ).to_dict()
-
-    assert usage["total"] == {
-        "requests": 2,
-        "input_tokens": 30,
-        "output_tokens": 7,
-        "total_tokens": 37,
-        "reasoning_tokens": None,
-        "cached_tokens": None,
-        "cost_usd": pytest.approx(0.1),
-        "requests_with_any_token_usage": 2,
-        "requests_with_input_tokens": 2,
-        "requests_with_output_tokens": 2,
-        "requests_with_total_tokens": 2,
-        "requests_with_reasoning_tokens": 0,
-        "requests_with_cached_tokens": 0,
-        "requests_with_cost": 1,
-    }
-    assert usage["scope"] == (
-        "successful_model_responses_returned_by_completed_inference_calls"
-    )
-    assert usage["source"] == "provider_response_metadata_when_available"
-    assert set(usage["by_stage"]) == {"generation", "judging"}
-    assert set(usage["by_model"]) == {"candidate", "local-judge"}
-
-
-def test_run_usage_reports_per_field_partial_token_coverage():
-    usage = RunUsage(
-        requests=(
-            RequestUsage(stage="generation", input_tokens=10),
-            RequestUsage(stage="generation", output_tokens=5),
+            RequestUsage(stage="judging", model="judge", output_tokens=5),
         )
     )
     summary = usage.summary()
+    serialized = usage.to_dict()
 
-    assert summary["input_tokens"] == 10
-    assert summary["output_tokens"] == 5
+    assert (summary["input_tokens"], summary["output_tokens"]) == (10, 5)
     assert summary["requests_with_input_tokens"] == 1
     assert summary["requests_with_output_tokens"] == 1
+    assert summary["requests_with_cost"] == 1
     assert "partial: input 1/2, output 1/2" in usage.format_summary()
-
-
-def test_batch_usage_log_marks_missing_responses_as_partial(caplog):
-    caplog.set_level("INFO", logger="judgearena")
-    with track_usage():
-        do_inference(
-            FakeModel([_provider_message(), "no metadata"]),
-            ["one", "two"],
-            stage="judging",
-        )
-
-    assert "partial: input 1/2, output 1/2" in caplog.text
-    assert "$0.001250 reported (partial)" in caplog.text
+    assert set(serialized["by_stage"]) == {"generation", "judging"}
+    assert set(serialized["by_model"]) == {"candidate", "judge"}
+    assert serialized["scope"] == (
+        "successful_model_responses_returned_by_completed_inference_calls"
+    )
 
 
 def test_write_run_metadata_includes_active_run_usage(tmp_path, monkeypatch):
@@ -242,18 +187,7 @@ def test_write_run_metadata_includes_active_run_usage(tmp_path, monkeypatch):
     monkeypatch.setattr(metadata_module, "_get_git_hash", lambda **_: None)
 
     with track_usage():
-        record_usage(
-            [
-                RequestUsage(
-                    stage="judging",
-                    model="judge",
-                    input_tokens=10,
-                    output_tokens=1,
-                    total_tokens=11,
-                    cost_usd=0.002,
-                )
-            ]
-        )
+        record_usage([RequestUsage(stage="judging", cost_usd=0.002)])
         path = metadata_module.write_run_metadata(
             output_dir=tmp_path,
             entrypoint="test",
@@ -267,18 +201,7 @@ def test_write_run_metadata_includes_active_run_usage(tmp_path, monkeypatch):
 
 def test_run_benchmark_scopes_and_prints_usage(monkeypatch, capsys):
     def fake_runner(cfg, task):
-        record_usage(
-            [
-                RequestUsage(
-                    stage="judging",
-                    model="judge",
-                    input_tokens=4,
-                    output_tokens=1,
-                    total_tokens=5,
-                    cost_usd=0.0001,
-                )
-            ]
-        )
+        record_usage([RequestUsage(stage="judging", cost_usd=0.0001)])
         return "done"
 
     resolved = SimpleNamespace(
@@ -287,29 +210,13 @@ def test_run_benchmark_scopes_and_prints_usage(monkeypatch, capsys):
     )
     monkeypatch.setattr(benchmark_runner, "resolve_benchmark", lambda task: resolved)
 
-    result = benchmark_runner.run_benchmark(SimpleNamespace(task="test"))
-
-    assert result == "done"
+    assert benchmark_runner.run_benchmark(SimpleNamespace(task="test")) == "done"
     assert "Model usage:" in capsys.readouterr().out
     assert current_run_usage() is None
 
 
-class DivergentGenerationModel:
-    model_name = "test/divergent"
-
-    def __init__(self):
-        self.batch_kwargs = None
-
-    def batch(self, *, inputs, **kwargs):
-        self.batch_kwargs = kwargs
-        return ["batch" for _ in inputs]
-
-    async def ainvoke(self, _input, **_kwargs):
-        return "async"
-
-
 def test_generation_paths_preserve_existing_sync_async_behavior(monkeypatch):
-    model = DivergentGenerationModel()
+    model = FakeModel(["batch", "batch"], async_response="async")
     monkeypatch.setattr(generate_module, "make_model", lambda *args, **kwargs: model)
     instructions = pd.Series(["one", "two"])
 
@@ -327,7 +234,7 @@ def test_generation_paths_preserve_existing_sync_async_behavior(monkeypatch):
         use_tqdm=True,
     )
     assert base_outputs["completion"].tolist() == ["batch", "batch"]
-    assert model.batch_kwargs == {"max_tokens": 123}
+    assert model.batch_kwargs["max_tokens"] == 123
 
 
 def test_nested_usage_tracking_explicitly_shares_the_outer_run():


### PR DESCRIPTION
This PR replicates #107 however implements according to OpenRouters official API.
## Problem

JudgeArena currently discards token and cost information returned by model providers. Users can see benchmark results, but they cannot tell how many model requests were made or how much reported usage came from generation and judging.

This PR collects provider-reported usage through the shared inference path and attaches one summary to the run metadata. It works for every benchmark using `do_inference()`, including pairwise, ELO, MT-Bench, fluency, and meta-evaluation.

## Before and after

| Area | Before | After |
| --- | --- | --- |
| Inference result | Returned text and optional top logprobs | Also carries provider-reported request usage |
| Run summary | No token or cost overview | Reports totals by stage and model |
| Saved metadata | Usage information was discarded | `run-metadata.v1.json` includes a `usage` section |
| Partial data | Missing provider fields were not visible | Partial token and cost coverage is reported clearly |

## How it works

```text
benchmark runner
    -> starts one run usage tracker
    -> generation and judging call do_inference()
    -> provider usage is normalized per request
    -> requests are grouped by stage and model
    -> metadata writer saves the current summary
    -> terminal prints the final summary
```

Generation requests use the `generation` stage and judge requests use the `judging` stage. Meta-evaluation only reports judging because it evaluates stored completions and does not generate model answers.

The summary includes request count, input tokens, output tokens, total tokens, reasoning tokens, cached tokens, and cost when the provider returns those fields.

This PR does not estimate missing prices or token counts. If a backend does not report cost, the result says that cost is unavailable. If only some requests contain usage, the totals are marked as partial.

## Example

```bash
judgearena \
  --task meta-eval-lmarena-100k \
  --judge.model OpenRouter/deepseek/deepseek-v3.2 \
  --meta_eval.top_models 5 \
  --meta_eval.battles_per_model 10
```

The terminal prints a summary such as:

```text
Model usage:
  Judging: 50 request(s), 120,000 input / 5,000 output tokens, $0.420000
  Total: 50 request(s), 120,000 input / 5,000 output tokens, $0.420000
```

The same information is stored under `usage.total`, `usage.by_stage`, and `usage.by_model` in `run-metadata.v1.json`.

## Change composition and task scope

Unique stacked diff against `feat/meta-eval-integration` at `e68f3bbc`; parent PR changes are excluded. **Changed LoC = added + removed lines.**

| Change type | Files | Changed LoC | Added | Removed |
|---|---:|---:|---:|---:|
| Core implementation | 10 | 463 | +442 | -21 |
| Tests | 2 | 278 | +277 | -1 |
| Static files | 0 | 0 | +0 | -0 |
| Docs/packaging and other | 1 | 4 | +4 | -0 |
| **Total** | **13** | **745** | **+723** | **-22** |

- **Core capability areas:** provider usage extraction, run-level aggregation/metadata, and exact local vLLM token accounting.
- **Task scope:** Framework-wide request-usage reporting for generation and judging; no benchmark scoring policy is intentionally changed.

## Tests

The tests cover provider response parsing, structured inference results, partial cost reporting, metadata output, benchmark-run scoping, and meta-evaluation integration.

## Notes
~180 lines are for the tests, thus this PR is minimal and optional (although definitely recommended)


## Example
Mergin everything, we can finally report
```bash
============================================================
                  🏆 MODEL BATTLE RESULTS 🏆
📊 Task: arena-hard-v2.0-official
🤖 Competitors: Model A: deepseek-r1 vs Model B: gemini-2.0-flash-001+o3-mini-2025-01-31
⚖️ Judge: OpenRouter/openai/gpt-4.1
📈 Results Summary:
   Total Battles: 154 (2×77 — each instruction judged in both orders to detect positional bias)
   Win Rate (A): 57.8%
   ✅ Wins:   86
   ❌ Losses: 62
   🤝 Ties:   6

Per-Category Breakdown:
  Category       | Win Rate(A) | Wins | Losses | Ties
  ---------------+-------------+------+--------+-----
  creative_writing |       93.3% |   56 |      4 |    0
  hard_prompt    |       35.1% |   30 |     58 |    6
📁 Results: parity-results/arena-hard-v2-gpt41-smoke/arena-hard-v2.0-official-deepseek-r1-gemini-2.0-flash-001+o3-mini-2025-01-31-OpenRouter_openai_gpt-4.1-both-20260820_103526
============================================================


Model usage:
  Judging: 100 request(s), 241,932 input / 89,919 output tokens, $1.200336
  Total: 100 request(s), 241,932 input / 89,919 output tokens, $1.200336
```
Comparison to the official results (https://github.com/lmarena/arena-hard-auto/blob/main/show_result.py)
```bash
   Category            JudgeArena    Official, same 50    Difference
  ━━━━━━━━━━━━━━━━━━  ━━━━━━━━━━━━  ━━━━━━━━━━━━━━━━━━━  ━━━━━━━━━━━━
   hard_prompt              35.1%                30.6%       +4.5 pp
  ──────────────────  ────────────  ───────────────────  ────────────
   creative_writing         93.3%                95.5%       −2.2 pp
```