### PR TITLE
[feat]: Adding Meta-Eval pipeline into the framework

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,27 +287,11 @@ For m-Arena-Hard, baseline completions are tied to the benchmark release:
 | `elo-lmarena`       | Union of all `LMArena-*` variants                                  |
 | `elo-comparia`      | Battles sampled from the ComparIA arena                            |
 
-### Judge meta-evaluation
-
-| Task                     | Description                                          |
-|--------------------------|------------------------------------------------------|
-| `meta-eval-lmarena-100k` | Score a judge against LMSYS Chatbot Arena 100k votes |
-| `meta-eval-lmarena-140k` | Score a judge against LMSYS Chatbot Arena 140k votes |
-| `meta-eval-comparia`     | Score a judge against ComparIA human votes           |
-
-Language suffixes are supported, for example `meta-eval-lmarena-100k-en` and `meta-eval-comparia-fr`.
-
 ## Meta-evaluating a judge
 
-Meta-evaluation uses existing human-labeled arena battles. It does not generate completions or rate a candidate model. The runner selects the most-battled models, builds a deterministic connected sample, and asks the configured judge to compare the stored responses.
+Meta-evaluation scores a judge against existing human-labeled arena battles. It samples a connected set of battles and reports agreement, hard and soft ranking similarity, and held-out Elo error.
 
-The task definitions configure three metrics:
-
-- `meta_eval_agreement` reports coverage, attempted accuracy, complete-only accuracy, and complete-only Cohen's kappa. It reports bootstrap standard errors for both accuracies and kappa. Incomplete judgments count as incorrect in attempted accuracy.
-- `meta_eval_ranking` compares human, hard-judge, and soft-judge Bradley-Terry ratings using Spearman correlation and Elo MAE. Bootstrap draws resample battles within matchup strata.
-- `meta_eval_elo_gap` measures the mean focal-model rating gap at budgets of attempted incident battles per focal model. It reports hard, soft, and hard-without-judge-ties methods on the same nested sampling schedules. These values are not run-wide annotation counts.
-
-The default prompt is `meta-eval-pair-score`. It requires integer scores from 0 to 10 for both responses and converts them to a continuous preference with temperature `0.5`.
+Packaged tasks are `meta-eval-lmarena-100k`, `meta-eval-lmarena-140k`, and `meta-eval-comparia`. Language suffixes such as `-en` and `-fr` are supported.
 
 ```bash
 judgearena \
@@ -318,11 +302,7 @@ judgearena \
   --meta_eval.battles_per_model 50
 ```
 
-Runtime sampling defaults to 20 models and 50 sampled incident battles per model. The task YAML owns metric parameters: the packaged tasks use 1,000 agreement and ranking bootstrap draws, Elo-gap budgets `[10, 20, 30, 40, 50]`, and 10 Elo-gap sampling replicates. The largest Elo-gap budget cannot exceed `--meta_eval.battles_per_model`.
-
-Do not set `--model.name` or `--model.baseline`; meta-evaluation rejects both fields because the arena responses already exist. `judge.swap_mode=random` is also unsupported. With `both`, a physical battle gets a preference only if both passes parse. If only one pass parses, its evidence remains in `annotations.parquet`, while the battle preference is null. Ranking and Elo-gap use only battles with a non-null judge preference. Attempted agreement retains all sampled battles and treats a null preference as incorrect.
-
-A successful run writes `config.yaml`, `sample.parquet`, `annotations.parquet`, `battles.parquet`, and `results.json` to a timestamped directory. `annotations.parquet` contains one lean evidence row per judge pass. `battles.parquet` contains the full selected top-model pool, including unsampled rows, with numeric human references and a nullable complete judge preference. `run-metadata.v1.json` is written on a best-effort basis.
+Runs save the selected sample, judge evidence, metric battles, configuration, and results under `--run.result_folder`.
 
 ## 📈 Estimating ELO Ratings
 

--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ The task definitions configure three metrics:
 
 - `meta_eval_agreement` reports coverage, attempted accuracy, complete-only accuracy, and complete-only Cohen's kappa. It reports bootstrap standard errors for both accuracies and kappa. Incomplete judgments count as incorrect in attempted accuracy.
 - `meta_eval_ranking` compares human, hard-judge, and soft-judge Bradley-Terry ratings using Spearman correlation and Elo MAE. Bootstrap draws resample battles within matchup strata.
-- `meta_eval_elo_gap` measures the mean focal-model rating gap at budgets of attempted incident battles per focal model. These values are not run-wide annotation counts.
+- `meta_eval_elo_gap` measures the mean focal-model rating gap at budgets of attempted incident battles per focal model. It reports hard, soft, and hard-without-judge-ties methods on the same nested sampling schedules. These values are not run-wide annotation counts.
 
 The default prompt is `meta-eval-pair-score`. It requires integer scores from 0 to 10 for both responses and converts them to a continuous preference with temperature `0.5`.
 

--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ Meta-evaluation uses existing human-labeled arena battles. It does not generate 
 
 The task definitions configure three metrics:
 
-- `meta_eval_agreement` reports coverage, attempted accuracy, complete-only accuracy, and complete-only Cohen's kappa. It reports bootstrap standard errors for both accuracies and kappa. Missing or partial judgments count as incorrect in attempted accuracy.
+- `meta_eval_agreement` reports coverage, attempted accuracy, complete-only accuracy, and complete-only Cohen's kappa. It reports bootstrap standard errors for both accuracies and kappa. Incomplete judgments count as incorrect in attempted accuracy.
 - `meta_eval_ranking` compares human, hard-judge, and soft-judge Bradley-Terry ratings using Spearman correlation and Elo MAE. Bootstrap draws resample battles within matchup strata.
 - `meta_eval_elo_gap` measures the mean focal-model rating gap at budgets of attempted incident battles per focal model. These values are not run-wide annotation counts.
 
@@ -315,15 +315,14 @@ judgearena \
   --judge.model OpenRouter/deepseek/deepseek-v3.2 \
   --meta_eval.languages '["en", "es"]' \
   --meta_eval.top_models 20 \
-  --meta_eval.battles_per_model 50 \
-  --meta_eval.n_bootstraps 20
+  --meta_eval.battles_per_model 50
 ```
 
-Runtime sampling defaults to 20 models and 50 sampled incident battles per model. The task definitions use 1,000 agreement and ranking bootstrap draws, Elo-gap budgets `[10, 20, 30, 40, 50]`, and 10 Elo-gap sampling replicates. Runtime flags under `--meta_eval` can override these values. The largest Elo-gap budget cannot exceed `--meta_eval.battles_per_model`.
+Runtime sampling defaults to 20 models and 50 sampled incident battles per model. The task YAML owns metric parameters: the packaged tasks use 1,000 agreement and ranking bootstrap draws, Elo-gap budgets `[10, 20, 30, 40, 50]`, and 10 Elo-gap sampling replicates. The largest Elo-gap budget cannot exceed `--meta_eval.battles_per_model`.
 
-Do not set `--model.name` or `--model.baseline`; meta-evaluation rejects both fields because the arena responses already exist. `judge.swap_mode=random` is also unsupported. With `both`, the runner normalizes each scalar preference to the stored model order, and a battle is complete only if both passes parse. Ranking and Elo-gap use complete battles. Attempted agreement retains partial and missing battles and treats them as incorrect.
+Do not set `--model.name` or `--model.baseline`; meta-evaluation rejects both fields because the arena responses already exist. `judge.swap_mode=random` is also unsupported. With `both`, a physical battle gets a preference only if both passes parse. If only one pass parses, its evidence remains in `annotations.parquet`, while the battle preference is null. Ranking and Elo-gap use only battles with a non-null judge preference. Attempted agreement retains all sampled battles and treats a null preference as incorrect.
 
-A successful run writes `config.yaml`, `sample.parquet`, `annotations.parquet`, `battles.parquet`, and `results.json` to a timestamped directory. `annotations.parquet` contains one row per judge pass. `battles.parquet` contains one row per battle in the selected top-model pool, including unsampled rows, numeric human references, and judge parse state. `run-metadata.v1.json` is written on a best-effort basis.
+A successful run writes `config.yaml`, `sample.parquet`, `annotations.parquet`, `battles.parquet`, and `results.json` to a timestamped directory. `annotations.parquet` contains one lean evidence row per judge pass. `battles.parquet` contains the full selected top-model pool, including unsampled rows, with numeric human references and a nullable complete judge preference. `run-metadata.v1.json` is written on a best-effort basis.
 
 ## 📈 Estimating ELO Ratings
 

--- a/README.md
+++ b/README.md
@@ -240,7 +240,7 @@ This override applies to all vLLM models in the run. For remote providers (OpenA
 
 ## 📊 Supported Tasks
 
-Task names follow [LMHarness](https://github.com/EleutherAI/lm-evaluation-harness) conventions. Generate+judge tasks produce pairwise preferences between two models; tasks using the ELO protocol estimate a single model's rating against human-annotated arena opponents.
+Generate+judge tasks produce pairwise preferences between two models. Elo tasks estimate a single model's rating against human-annotated arena opponents. Meta-evaluation tasks score a judge against human arena votes.
 
 ### Generate + judge (pairwise)
 
@@ -286,6 +286,44 @@ For m-Arena-Hard, baseline completions are tied to the benchmark release:
 | `elo-lmarena-140k`  | Battles sampled from `lmarena-ai/arena-human-preference-140k`      |
 | `elo-lmarena`       | Union of all `LMArena-*` variants                                  |
 | `elo-comparia`      | Battles sampled from the ComparIA arena                            |
+
+### Judge meta-evaluation
+
+| Task                     | Description                                          |
+|--------------------------|------------------------------------------------------|
+| `meta-eval-lmarena-100k` | Score a judge against LMSYS Chatbot Arena 100k votes |
+| `meta-eval-lmarena-140k` | Score a judge against LMSYS Chatbot Arena 140k votes |
+| `meta-eval-comparia`     | Score a judge against ComparIA human votes           |
+
+Language suffixes are supported, for example `meta-eval-lmarena-100k-en` and `meta-eval-comparia-fr`.
+
+## Meta-evaluating a judge
+
+Meta-evaluation uses existing human-labeled arena battles. It does not generate completions or rate a candidate model. The runner selects the most-battled models, builds a deterministic connected sample, and asks the configured judge to compare the stored responses.
+
+The task definitions configure three metrics:
+
+- `meta_eval_agreement` reports coverage, attempted accuracy, complete-only accuracy, and complete-only Cohen's kappa. It reports bootstrap standard errors for both accuracies and kappa. Missing or partial judgments count as incorrect in attempted accuracy.
+- `meta_eval_ranking` compares human, hard-judge, and soft-judge Bradley-Terry ratings using Spearman correlation and Elo MAE. Bootstrap draws resample battles within matchup strata.
+- `meta_eval_elo_gap` measures the mean focal-model rating gap at budgets of attempted incident battles per focal model. These values are not run-wide annotation counts.
+
+The default prompt is `meta-eval-pair-score`. It requires integer scores from 0 to 10 for both responses and converts them to a continuous preference with temperature `0.5`.
+
+```bash
+judgearena \
+  --task meta-eval-lmarena-140k \
+  --judge.model OpenRouter/deepseek/deepseek-v3.2 \
+  --meta_eval.languages '["en", "es"]' \
+  --meta_eval.top_models 20 \
+  --meta_eval.battles_per_model 50 \
+  --meta_eval.n_bootstraps 20
+```
+
+Runtime sampling defaults to 20 models and 50 sampled incident battles per model. The task definitions use 1,000 agreement and ranking bootstrap draws, Elo-gap budgets `[10, 20, 30, 40, 50]`, and 10 Elo-gap sampling replicates. Runtime flags under `--meta_eval` can override these values. The largest Elo-gap budget cannot exceed `--meta_eval.battles_per_model`.
+
+Do not set `--model.name` or `--model.baseline`; meta-evaluation rejects both fields because the arena responses already exist. `judge.swap_mode=random` is also unsupported. With `both`, the runner normalizes each scalar preference to the stored model order, and a battle is complete only if both passes parse. Ranking and Elo-gap use complete battles. Attempted agreement retains partial and missing battles and treats them as incorrect.
+
+A successful run writes `config.yaml`, `sample.parquet`, `annotations.parquet`, `battles.parquet`, and `results.json` to a timestamped directory. `annotations.parquet` contains one row per judge pass. `battles.parquet` contains one row per battle in the selected top-model pool, including unsampled rows, numeric human references, and judge parse state. `run-metadata.v1.json` is written on a best-effort basis.
 
 ## 📈 Estimating ELO Ratings
 

--- a/judgearena/arenas_utils.py
+++ b/judgearena/arenas_utils.py
@@ -34,8 +34,8 @@ def _download_arena_dataset(
     )
 
 
-def _extract_instruction_text(turn: dict) -> str:
-    """Extract plain instruction text from a conversation turn.
+def extract_turn_text(turn: dict) -> str:
+    """Extract plain text from a conversation turn.
 
     Handles both the 100k schema (content is a plain string) and the 140k
     schema (content is an array of {type, text, ...} objects). Moderated or
@@ -170,7 +170,7 @@ def _load_arena_dataframe(
         df["question_id"] = df["id"]
 
     df["lang"] = df["conversation_a"].apply(
-        lambda conv: detect_language(_extract_instruction_text(conv[0])).lower()
+        lambda conv: detect_language(extract_turn_text(conv[0])).lower()
     )
 
     cols = [

--- a/judgearena/benchmarks/arena.py
+++ b/judgearena/benchmarks/arena.py
@@ -1,0 +1,25 @@
+"""Helpers shared by runners that read human arena battles."""
+
+from __future__ import annotations
+
+from judgearena.tasks.schema import ResolvedTaskSpec
+
+
+def resolve_task_languages(
+    task: ResolvedTaskSpec, requested: list[str] | None, *, setting: str
+) -> list[str]:
+    """Narrow an optional runtime filter within a task language variant."""
+    selected = list(requested or [])
+    if task.selection is None:
+        return selected
+
+    variant_languages = list(task.selection.values)
+    if not selected:
+        return variant_languages
+    narrowed = [language for language in selected if language in set(variant_languages)]
+    if not narrowed:
+        raise ValueError(
+            f"{setting} {requested} has no overlap with the languages of task "
+            f"{task.task!r} ({variant_languages})."
+        )
+    return narrowed

--- a/judgearena/benchmarks/arena.py
+++ b/judgearena/benchmarks/arena.py
@@ -16,7 +16,7 @@ def resolve_task_languages(
     variant_languages = list(task.selection.values)
     if not selected:
         return variant_languages
-    narrowed = [language for language in selected if language in set(variant_languages)]
+    narrowed = [language for language in selected if language in variant_languages]
     if not narrowed:
         raise ValueError(
             f"{setting} {requested} has no overlap with the languages of task "

--- a/judgearena/benchmarks/elo/calibration.py
+++ b/judgearena/benchmarks/elo/calibration.py
@@ -8,7 +8,7 @@ import numpy as np
 import pandas as pd
 from scipy.optimize import minimize_scalar
 
-from judgearena.arenas_utils import _extract_instruction_text
+from judgearena.arenas_utils import extract_turn_text
 from judgearena.benchmarks.elo.rating import winner_to_pref
 from judgearena.evaluate import judge_and_parse_prefs
 from judgearena.log import get_logger
@@ -91,15 +91,15 @@ def calibrate_pairscore_temperature(
         random_state=int(rng.integers(0, 2**31)),
     )
     instructions = [
-        _extract_instruction_text(source_battles.loc[index, "conversation_a"][0])
+        extract_turn_text(source_battles.loc[index, "conversation_a"][0])
         for index in calibration_battles.index
     ]
     completions_a = [
-        _extract_instruction_text(source_battles.loc[index, "conversation_a"][1])
+        extract_turn_text(source_battles.loc[index, "conversation_a"][1])
         for index in calibration_battles.index
     ]
     completions_b = [
-        _extract_instruction_text(source_battles.loc[index, "conversation_b"][1])
+        extract_turn_text(source_battles.loc[index, "conversation_b"][1])
         for index in calibration_battles.index
     ]
 

--- a/judgearena/benchmarks/elo/runner.py
+++ b/judgearena/benchmarks/elo/runner.py
@@ -14,6 +14,7 @@ from judgearena.artifacts import (
     write_run_metadata_safely,
 )
 from judgearena.battles import Leaderboard, RatingEntry, write_battles
+from judgearena.benchmarks.arena import resolve_task_languages
 from judgearena.benchmarks.elo.calibration import calibrate_pairscore_temperature
 from judgearena.benchmarks.elo.rating import (
     arena_anchor_battles,
@@ -58,22 +59,10 @@ def run_elo(cfg: "RunConfig", task: ResolvedTaskSpec | None = None) -> dict:
     logger.info("Step 1: Loading battles from %s", arena)
     df_arena_all = load_battles(task)
 
-    # Filter by language: a task variant (e.g. elo-lmarena-140k-en) preselects
-    # languages; elo.languages narrows further within that selection.
-    selected_languages = list(cfg.elo.languages or [])
-    if task.selection is not None:
-        variant_languages = list(task.selection.values)
-        if selected_languages:
-            selected_languages = [
-                lang for lang in selected_languages if lang in set(variant_languages)
-            ]
-            if not selected_languages:
-                raise ValueError(
-                    f"elo.languages {cfg.elo.languages} has no overlap with the "
-                    f"languages of task {cfg.task!r} ({variant_languages})."
-                )
-        else:
-            selected_languages = variant_languages
+    # A task variant preselects languages; elo.languages may narrow it further.
+    selected_languages = resolve_task_languages(
+        task, cfg.elo.languages, setting="elo.languages"
+    )
 
     df_battles = df_arena_all
     if selected_languages:

--- a/judgearena/benchmarks/elo/runner.py
+++ b/judgearena/benchmarks/elo/runner.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 import numpy as np
 import pandas as pd
 
-from judgearena.arenas_utils import _extract_instruction_text
+from judgearena.arenas_utils import extract_turn_text
 from judgearena.artifacts import (
     prepare_run_directory,
     safe_filename,
@@ -115,7 +115,7 @@ def run_elo(cfg: "RunConfig", task: ResolvedTaskSpec | None = None) -> dict:
     # Extract user instructions (first turn of conversation_a)
     instructions = pd.Series(
         [
-            _extract_instruction_text(row["conversation_a"][0])
+            extract_turn_text(row["conversation_a"][0])
             for _, row in df_battles.iterrows()
         ],
         name="instruction",
@@ -188,9 +188,9 @@ def run_elo(cfg: "RunConfig", task: ResolvedTaskSpec | None = None) -> dict:
 
     opponent_completions = [
         (
-            _extract_instruction_text(row["conversation_a"][1])
+            extract_turn_text(row["conversation_a"][1])
             if use_model_a_as_opponent[i]
-            else _extract_instruction_text(row["conversation_b"][1])
+            else extract_turn_text(row["conversation_b"][1])
         )
         for i, (_, row) in enumerate(df_battles.iterrows())
     ]

--- a/judgearena/benchmarks/meta_eval/__init__.py
+++ b/judgearena/benchmarks/meta_eval/__init__.py
@@ -1,0 +1,1 @@
+"""Meta-evaluation of a judge against human arena votes."""

--- a/judgearena/benchmarks/meta_eval/annotate.py
+++ b/judgearena/benchmarks/meta_eval/annotate.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 from typing import TYPE_CHECKING
 
+import numpy as np
 import pandas as pd
 
 from judgearena.arenas_utils import extract_turn_text
@@ -32,7 +33,10 @@ def _battle_texts(df: pd.DataFrame) -> tuple[list[str], list[str], list[str]]:
         conversations = []
         for column in ("conversation_a", "conversation_b"):
             conversation = battle[column]
-            if not isinstance(conversation, (list, tuple)) or len(conversation) < 2:
+            if (
+                not isinstance(conversation, (list, tuple, np.ndarray))
+                or len(conversation) < 2
+            ):
                 raise ValueError(
                     f"Battle {battle_id!r} requires user and assistant turns in "
                     f"{column}."

--- a/judgearena/benchmarks/meta_eval/annotate.py
+++ b/judgearena/benchmarks/meta_eval/annotate.py
@@ -115,14 +115,16 @@ def aggregate_battle_preferences(
     annotations: pd.DataFrame, *, swap_mode: str
 ) -> pd.DataFrame:
     """Combine canonical judge passes into one row per physical battle."""
-    expected_passes = 2 if swap_mode == "both" else 1
     expected_orientations = (
         {"direct", "reversed"} if swap_mode == "both" else {"single"}
     )
     rows = []
     for battle_id, passes in annotations.groupby("battle_id", sort=False):
         orientations = set(passes["orientation"])
-        if len(passes) != expected_passes or orientations != expected_orientations:
+        if (
+            len(passes) != len(expected_orientations)
+            or orientations != expected_orientations
+        ):
             raise ValueError(
                 f"Battle {battle_id!r} has {len(passes)} passes and orientations "
                 f"{sorted(orientations)}; expected {sorted(expected_orientations)}."

--- a/judgearena/benchmarks/meta_eval/annotate.py
+++ b/judgearena/benchmarks/meta_eval/annotate.py
@@ -24,22 +24,12 @@ def serialize_judge_input(judge_input: object) -> str:
     return str(judge_input)
 
 
-def preference_to_hard(preference: float | None) -> float:
-    """Apply the shared pairwise hard-preference contract exactly."""
-    if preference is None or pd.isna(preference):
-        return float("nan")
-    if preference < 0.5:
-        return 0.0
-    if preference > 0.5:
-        return 1.0
-    return 0.5
-
-
-def validate_battle_conversations(df: pd.DataFrame) -> None:
-    """Require matching user/assistant conversation pairs."""
+def _battle_texts(df: pd.DataFrame) -> tuple[list[str], list[str], list[str]]:
+    """Validate each conversation pair and return the text sent to the judge."""
+    instructions, completions_a, completions_b = [], [], []
     for _, battle in df.iterrows():
         battle_id = battle.get("battle_id", battle.get("question_id", "unknown"))
-        prompts: list[str] = []
+        conversations = []
         for column in ("conversation_a", "conversation_b"):
             conversation = battle[column]
             if not isinstance(conversation, (list, tuple)) or len(conversation) < 2:
@@ -59,22 +49,20 @@ def validate_battle_conversations(df: pd.DataFrame) -> None:
                     f"{column}."
                 )
             try:
-                prompts.append(extract_turn_text(user_turn))
-                extract_turn_text(assistant_turn)
+                conversations.append(
+                    (extract_turn_text(user_turn), extract_turn_text(assistant_turn))
+                )
             except (AttributeError, TypeError, ValueError) as exc:
                 raise ValueError(
                     f"Battle {battle_id!r} has invalid turn content in {column}."
                 ) from exc
-        if prompts[0] != prompts[1]:
+        if conversations[0][0] != conversations[1][0]:
             raise ValueError(
                 f"Battle {battle_id!r} has different user prompts across conversations."
             )
-
-
-def _battle_texts(df: pd.DataFrame) -> tuple[list[str], list[str], list[str]]:
-    instructions = [extract_turn_text(conv[0]) for conv in df["conversation_a"]]
-    completions_a = [extract_turn_text(conv[1]) for conv in df["conversation_a"]]
-    completions_b = [extract_turn_text(conv[1]) for conv in df["conversation_b"]]
+        instructions.append(conversations[0][0])
+        completions_a.append(conversations[0][1])
+        completions_b.append(conversations[1][1])
     return instructions, completions_a, completions_b
 
 
@@ -87,60 +75,26 @@ def _serialize_mapping(value: dict[str, object] | None) -> str | None:
 def _annotation_frame(
     original: pd.DataFrame,
     annotations: list[JudgeAnnotation],
+    preferences: pd.Series,
     *,
     orientation: str,
-    parser_name: str,
 ) -> pd.DataFrame:
-    """Attach one judge pass to the arena's stored A/B identity."""
-    reversed_pass = orientation == "reversed"
+    """Store one judge pass with preferences in the arena's A/B orientation."""
     rows = []
-    for annotation, (_, battle) in zip(annotations, original.iterrows(), strict=True):
+    for annotation, battle_id, preference in zip(
+        annotations, original["battle_id"], preferences, strict=True
+    ):
         parsed = annotation.parsed
-        judge_input_preference = (
-            float("nan") if parsed is None else float(parsed.preference)
-        )
-        preference = (
-            1.0 - judge_input_preference
-            if reversed_pass and parsed is not None
-            else judge_input_preference
-        )
         rows.append(
             {
-                "battle_id": battle["battle_id"],
-                "question_id": battle["question_id"],
-                "model_a": battle["model_a"],
-                "model_b": battle["model_b"],
-                "winner": battle["winner"],
-                "lang": battle["lang"],
-                "instruction": annotation.instruction,
-                "completion_a": (
-                    annotation.completion_B
-                    if reversed_pass
-                    else annotation.completion_A
-                ),
-                "completion_b": (
-                    annotation.completion_A
-                    if reversed_pass
-                    else annotation.completion_B
-                ),
+                "battle_id": battle_id,
+                "orientation": orientation,
+                "pref": preference,
                 "judge_input": serialize_judge_input(annotation.judge_input),
                 "judge_completion": annotation.judge_completion,
-                "judge_parser": parser_name,
                 "judge_top_logprobs_json": _serialize_mapping(
                     annotation.judge_top_logprobs
                 ),
-                "parse_ok": parsed is not None,
-                "pref_judge_input": judge_input_preference,
-                "pref": preference,
-                "orientation": orientation,
-                "judge_input_model_a": (
-                    battle["model_b"] if reversed_pass else battle["model_a"]
-                ),
-                "judge_input_model_b": (
-                    battle["model_a"] if reversed_pass else battle["model_b"]
-                ),
-                "judge_input_completion_a": annotation.completion_A,
-                "judge_input_completion_b": annotation.completion_B,
                 "parsed_label": None if parsed is None else parsed.label,
                 "parsed_scores_json": (
                     None if parsed is None else _serialize_mapping(parsed.scores)
@@ -157,79 +111,25 @@ def aggregate_battle_preferences(
     annotations: pd.DataFrame, *, swap_mode: str
 ) -> pd.DataFrame:
     """Combine canonical judge passes into one row per physical battle."""
-    if swap_mode not in {"fixed", "both"}:
-        raise ValueError(
-            "Meta-evaluation aggregation supports fixed or both swap modes."
-        )
-    metadata_columns = (
-        "battle_id",
-        "question_id",
-        "model_a",
-        "model_b",
-        "winner",
-        "lang",
-    )
-    missing = sorted(set(metadata_columns) - set(annotations.columns))
-    if missing:
-        raise ValueError(f"Meta-evaluation annotations are missing columns: {missing}.")
-    if annotations[list(metadata_columns)].isna().any().any():
-        raise ValueError(
-            "Meta-evaluation physical-battle metadata must not be missing."
-        )
-
     expected_passes = 2 if swap_mode == "both" else 1
     expected_orientations = (
         {"direct", "reversed"} if swap_mode == "both" else {"single"}
     )
     rows = []
     for battle_id, passes in annotations.groupby("battle_id", sort=False):
-        conflicting = [
-            column
-            for column in metadata_columns[1:]
-            if passes[column].nunique(dropna=False) != 1
-        ]
-        if conflicting:
-            raise ValueError(
-                f"Battle {battle_id!r} has conflicting metadata: {conflicting}."
-            )
         orientations = set(passes["orientation"])
         if len(passes) != expected_passes or orientations != expected_orientations:
             raise ValueError(
                 f"Battle {battle_id!r} has {len(passes)} passes and orientations "
                 f"{sorted(orientations)}; expected {sorted(expected_orientations)}."
             )
-        valid = passes.loc[passes["parse_ok"] & passes["pref"].notna(), "pref"]
-        parsed = len(valid)
-        preference = float(valid.mean()) if parsed else float("nan")
-        first = passes.iloc[0]
-        rows.append(
-            {
-                "battle_id": battle_id,
-                "question_id": first["question_id"],
-                "model_a": first["model_a"],
-                "model_b": first["model_b"],
-                "winner": first["winner"],
-                "lang": first["lang"],
-                "parse_ok": parsed > 0,
-                "pref": preference,
-                "pref_hard": preference_to_hard(preference),
-                "n_passes_expected": expected_passes,
-                "n_passes_parsed": parsed,
-                "parse_status": (
-                    "complete"
-                    if parsed == expected_passes
-                    else "partial"
-                    if parsed
-                    else "missing"
-                ),
-            }
+        preference = (
+            float(passes["pref"].mean())
+            if passes["pref"].notna().all()
+            else float("nan")
         )
-    aggregated = pd.DataFrame(rows)
-    if aggregated["battle_id"].duplicated().any():
-        raise ValueError(
-            "Aggregated meta-eval battles must have unique battle_id values."
-        )
-    return aggregated
+        rows.append({"battle_id": battle_id, "pref": preference})
+    return pd.DataFrame(rows, columns=["battle_id", "pref"])
 
 
 def annotate_sample(
@@ -239,25 +139,10 @@ def annotate_sample(
     judge_chat_model,
     resolved_prompt: ResolvedJudgePrompt,
 ) -> pd.DataFrame:
-    if cfg.judge.swap_mode not in {"fixed", "both"}:
-        raise ValueError(
-            "Meta-evaluation annotation supports fixed or both swap modes."
-        )
     parser = resolved_prompt.parser
-    if parser is None:
-        raise ValueError(
-            f"Prompt preset {resolved_prompt.preset_name!r} has no judge parser."
-        )
-
-    df_sample = df_sample.copy()
-    if "battle_id" not in df_sample:
-        raise ValueError("annotate_sample requires stable battle_id values.")
-    if df_sample["battle_id"].isna().any() or df_sample["battle_id"].duplicated().any():
-        raise ValueError("annotate_sample requires unique, non-null battle_id values.")
-    validate_battle_conversations(df_sample)
-
+    assert parser is not None
     instructions, completions_a, completions_b = _battle_texts(df_sample)
-    annotations, reversed_annotations, _combined_preferences = judge_and_parse_prefs(
+    annotations, reversed_annotations, preferences = judge_and_parse_prefs(
         judge_chat_model=judge_chat_model,
         instructions=instructions,
         completions_A=completions_a,
@@ -272,26 +157,13 @@ def annotate_sample(
         use_tqdm=cfg.run.use_tqdm,
     )
 
-    both = cfg.judge.swap_mode == "both"
-    if len(annotations) != len(df_sample):
-        raise ValueError(
-            "Meta-evaluation judging returned an unexpected number of direct passes."
-        )
-    if both and (
-        reversed_annotations is None or len(reversed_annotations) != len(df_sample)
-    ):
-        raise ValueError(
-            "Meta-evaluation judging returned an unexpected number of reversed passes."
-        )
-    if not both and reversed_annotations is not None:
-        raise ValueError("Fixed meta-evaluation judging returned reversed passes.")
-
+    n_battles = len(df_sample)
     parts = [
         _annotation_frame(
             df_sample,
             annotations,
-            orientation="direct" if both else "single",
-            parser_name=parser.name,
+            preferences.iloc[:n_battles],
+            orientation="direct" if reversed_annotations is not None else "single",
         )
     ]
     if reversed_annotations is not None:
@@ -299,8 +171,8 @@ def annotate_sample(
             _annotation_frame(
                 df_sample,
                 reversed_annotations,
+                preferences.iloc[n_battles:],
                 orientation="reversed",
-                parser_name=parser.name,
             )
         )
     return pd.concat(parts, ignore_index=True)

--- a/judgearena/benchmarks/meta_eval/annotate.py
+++ b/judgearena/benchmarks/meta_eval/annotate.py
@@ -1,0 +1,306 @@
+"""Judge sampled arena battles and produce canonical physical-battle rows."""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+import pandas as pd
+
+from judgearena.arenas_utils import extract_turn_text
+from judgearena.evaluate import JudgeAnnotation, judge_and_parse_prefs
+
+if TYPE_CHECKING:
+    from judgearena.config import RunConfig
+    from judgearena.prompts.registry import ResolvedJudgePrompt
+
+
+def serialize_judge_input(judge_input: object) -> str:
+    if judge_input is None:
+        return ""
+    to_string = getattr(judge_input, "to_string", None)
+    if callable(to_string):
+        return to_string()
+    return str(judge_input)
+
+
+def preference_to_hard(preference: float | None) -> float:
+    """Apply the shared pairwise hard-preference contract exactly."""
+    if preference is None or pd.isna(preference):
+        return float("nan")
+    if preference < 0.5:
+        return 0.0
+    if preference > 0.5:
+        return 1.0
+    return 0.5
+
+
+def validate_battle_conversations(df: pd.DataFrame) -> None:
+    """Require matching user/assistant conversation pairs."""
+    for _, battle in df.iterrows():
+        battle_id = battle.get("battle_id", battle.get("question_id", "unknown"))
+        prompts: list[str] = []
+        for column in ("conversation_a", "conversation_b"):
+            conversation = battle[column]
+            if not isinstance(conversation, (list, tuple)) or len(conversation) < 2:
+                raise ValueError(
+                    f"Battle {battle_id!r} requires user and assistant turns in "
+                    f"{column}."
+                )
+            user_turn, assistant_turn = conversation[:2]
+            if (
+                not isinstance(user_turn, dict)
+                or not isinstance(assistant_turn, dict)
+                or user_turn.get("role") != "user"
+                or assistant_turn.get("role") != "assistant"
+            ):
+                raise ValueError(
+                    f"Battle {battle_id!r} requires user and assistant turns in "
+                    f"{column}."
+                )
+            try:
+                prompts.append(extract_turn_text(user_turn))
+                extract_turn_text(assistant_turn)
+            except (AttributeError, TypeError, ValueError) as exc:
+                raise ValueError(
+                    f"Battle {battle_id!r} has invalid turn content in {column}."
+                ) from exc
+        if prompts[0] != prompts[1]:
+            raise ValueError(
+                f"Battle {battle_id!r} has different user prompts across conversations."
+            )
+
+
+def _battle_texts(df: pd.DataFrame) -> tuple[list[str], list[str], list[str]]:
+    instructions = [extract_turn_text(conv[0]) for conv in df["conversation_a"]]
+    completions_a = [extract_turn_text(conv[1]) for conv in df["conversation_a"]]
+    completions_b = [extract_turn_text(conv[1]) for conv in df["conversation_b"]]
+    return instructions, completions_a, completions_b
+
+
+def _serialize_mapping(value: dict[str, object] | None) -> str | None:
+    if value is None:
+        return None
+    return json.dumps(value, ensure_ascii=False, sort_keys=True)
+
+
+def _annotation_frame(
+    original: pd.DataFrame,
+    annotations: list[JudgeAnnotation],
+    *,
+    orientation: str,
+    parser_name: str,
+) -> pd.DataFrame:
+    """Attach one judge pass to the arena's stored A/B identity."""
+    reversed_pass = orientation == "reversed"
+    rows = []
+    for annotation, (_, battle) in zip(annotations, original.iterrows(), strict=True):
+        parsed = annotation.parsed
+        judge_input_preference = (
+            float("nan") if parsed is None else float(parsed.preference)
+        )
+        preference = (
+            1.0 - judge_input_preference
+            if reversed_pass and parsed is not None
+            else judge_input_preference
+        )
+        rows.append(
+            {
+                "battle_id": battle["battle_id"],
+                "question_id": battle["question_id"],
+                "model_a": battle["model_a"],
+                "model_b": battle["model_b"],
+                "winner": battle["winner"],
+                "lang": battle["lang"],
+                "instruction": annotation.instruction,
+                "completion_a": (
+                    annotation.completion_B
+                    if reversed_pass
+                    else annotation.completion_A
+                ),
+                "completion_b": (
+                    annotation.completion_A
+                    if reversed_pass
+                    else annotation.completion_B
+                ),
+                "judge_input": serialize_judge_input(annotation.judge_input),
+                "judge_completion": annotation.judge_completion,
+                "judge_parser": parser_name,
+                "judge_top_logprobs_json": _serialize_mapping(
+                    annotation.judge_top_logprobs
+                ),
+                "parse_ok": parsed is not None,
+                "pref_judge_input": judge_input_preference,
+                "pref": preference,
+                "orientation": orientation,
+                "judge_input_model_a": (
+                    battle["model_b"] if reversed_pass else battle["model_a"]
+                ),
+                "judge_input_model_b": (
+                    battle["model_a"] if reversed_pass else battle["model_b"]
+                ),
+                "judge_input_completion_a": annotation.completion_A,
+                "judge_input_completion_b": annotation.completion_B,
+                "parsed_label": None if parsed is None else parsed.label,
+                "parsed_scores_json": (
+                    None if parsed is None else _serialize_mapping(parsed.scores)
+                ),
+                "parsed_details_json": (
+                    None if parsed is None else _serialize_mapping(parsed.details)
+                ),
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+def aggregate_battle_preferences(
+    annotations: pd.DataFrame, *, swap_mode: str
+) -> pd.DataFrame:
+    """Combine canonical judge passes into one row per physical battle."""
+    if swap_mode not in {"fixed", "both"}:
+        raise ValueError(
+            "Meta-evaluation aggregation supports fixed or both swap modes."
+        )
+    metadata_columns = (
+        "battle_id",
+        "question_id",
+        "model_a",
+        "model_b",
+        "winner",
+        "lang",
+    )
+    missing = sorted(set(metadata_columns) - set(annotations.columns))
+    if missing:
+        raise ValueError(f"Meta-evaluation annotations are missing columns: {missing}.")
+    if annotations[list(metadata_columns)].isna().any().any():
+        raise ValueError(
+            "Meta-evaluation physical-battle metadata must not be missing."
+        )
+
+    expected_passes = 2 if swap_mode == "both" else 1
+    expected_orientations = (
+        {"direct", "reversed"} if swap_mode == "both" else {"single"}
+    )
+    rows = []
+    for battle_id, passes in annotations.groupby("battle_id", sort=False):
+        conflicting = [
+            column
+            for column in metadata_columns[1:]
+            if passes[column].nunique(dropna=False) != 1
+        ]
+        if conflicting:
+            raise ValueError(
+                f"Battle {battle_id!r} has conflicting metadata: {conflicting}."
+            )
+        orientations = set(passes["orientation"])
+        if len(passes) != expected_passes or orientations != expected_orientations:
+            raise ValueError(
+                f"Battle {battle_id!r} has {len(passes)} passes and orientations "
+                f"{sorted(orientations)}; expected {sorted(expected_orientations)}."
+            )
+        valid = passes.loc[passes["parse_ok"] & passes["pref"].notna(), "pref"]
+        parsed = len(valid)
+        preference = float(valid.mean()) if parsed else float("nan")
+        first = passes.iloc[0]
+        rows.append(
+            {
+                "battle_id": battle_id,
+                "question_id": first["question_id"],
+                "model_a": first["model_a"],
+                "model_b": first["model_b"],
+                "winner": first["winner"],
+                "lang": first["lang"],
+                "parse_ok": parsed > 0,
+                "pref": preference,
+                "pref_hard": preference_to_hard(preference),
+                "n_passes_expected": expected_passes,
+                "n_passes_parsed": parsed,
+                "parse_status": (
+                    "complete"
+                    if parsed == expected_passes
+                    else "partial"
+                    if parsed
+                    else "missing"
+                ),
+            }
+        )
+    aggregated = pd.DataFrame(rows)
+    if aggregated["battle_id"].duplicated().any():
+        raise ValueError(
+            "Aggregated meta-eval battles must have unique battle_id values."
+        )
+    return aggregated
+
+
+def annotate_sample(
+    df_sample: pd.DataFrame,
+    cfg: RunConfig,
+    *,
+    judge_chat_model,
+    resolved_prompt: ResolvedJudgePrompt,
+) -> pd.DataFrame:
+    if cfg.judge.swap_mode not in {"fixed", "both"}:
+        raise ValueError(
+            "Meta-evaluation annotation supports fixed or both swap modes."
+        )
+    parser = resolved_prompt.parser
+    if parser is None:
+        raise ValueError(
+            f"Prompt preset {resolved_prompt.preset_name!r} has no judge parser."
+        )
+
+    df_sample = df_sample.copy()
+    if "battle_id" not in df_sample:
+        raise ValueError("annotate_sample requires stable battle_id values.")
+    if df_sample["battle_id"].isna().any() or df_sample["battle_id"].duplicated().any():
+        raise ValueError("annotate_sample requires unique, non-null battle_id values.")
+    validate_battle_conversations(df_sample)
+
+    instructions, completions_a, completions_b = _battle_texts(df_sample)
+    annotations, reversed_annotations, _combined_preferences = judge_and_parse_prefs(
+        judge_chat_model=judge_chat_model,
+        instructions=instructions,
+        completions_A=completions_a,
+        completions_B=completions_b,
+        swap_mode=cfg.judge.swap_mode,
+        strip_thinking_before_judging=cfg.judge.strip_thinking_before_judging,
+        system_prompt=resolved_prompt.system_prompt,
+        user_prompt_template=resolved_prompt.user_prompt_template,
+        prompt_preset=resolved_prompt.preset_name,
+        parse=parser,
+        truncate_input_chars=cfg.generation.truncate_judge_input_chars,
+        use_tqdm=cfg.run.use_tqdm,
+    )
+
+    both = cfg.judge.swap_mode == "both"
+    if len(annotations) != len(df_sample):
+        raise ValueError(
+            "Meta-evaluation judging returned an unexpected number of direct passes."
+        )
+    if both and (
+        reversed_annotations is None or len(reversed_annotations) != len(df_sample)
+    ):
+        raise ValueError(
+            "Meta-evaluation judging returned an unexpected number of reversed passes."
+        )
+    if not both and reversed_annotations is not None:
+        raise ValueError("Fixed meta-evaluation judging returned reversed passes.")
+
+    parts = [
+        _annotation_frame(
+            df_sample,
+            annotations,
+            orientation="direct" if both else "single",
+            parser_name=parser.name,
+        )
+    ]
+    if reversed_annotations is not None:
+        parts.append(
+            _annotation_frame(
+                df_sample,
+                reversed_annotations,
+                orientation="reversed",
+                parser_name=parser.name,
+            )
+        )
+    return pd.concat(parts, ignore_index=True)

--- a/judgearena/benchmarks/meta_eval/runner.py
+++ b/judgearena/benchmarks/meta_eval/runner.py
@@ -125,15 +125,6 @@ def run_meta_eval(
         task, cfg.meta_eval.languages, setting="meta_eval.languages"
     )
     metrics = build_metrics(protocol.scoring.metrics)
-    for request, metric in metrics:
-        if request.metric == "meta_eval_elo_gap":
-            maximum = max(metric.battle_counts)
-            if maximum > cfg.meta_eval.battles_per_model:
-                raise ValueError(
-                    "The maximum meta_eval_elo_gap battle budget "
-                    f"({maximum}) exceeds meta_eval.battles_per_model "
-                    f"({cfg.meta_eval.battles_per_model})."
-                )
 
     logger.info("Loading human battles from %s", protocol.arena)
     arena_battles = _prepare_arena_battles(

--- a/judgearena/benchmarks/meta_eval/runner.py
+++ b/judgearena/benchmarks/meta_eval/runner.py
@@ -1,0 +1,299 @@
+"""Score a judge against human-labeled arena battles."""
+
+from __future__ import annotations
+
+import hashlib
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import numpy as np
+import pandas as pd
+
+from judgearena.artifacts import (
+    prepare_run_directory,
+    safe_filename,
+    write_run_metadata_safely,
+)
+from judgearena.benchmarks.arena import resolve_task_languages
+from judgearena.benchmarks.execution import build_judge
+from judgearena.benchmarks.meta_eval.annotate import (
+    aggregate_battle_preferences,
+    annotate_sample,
+    validate_battle_conversations,
+)
+from judgearena.benchmarks.meta_eval.sampling import (
+    MetaEvalSamplingError,
+    sample_battles_per_model,
+    select_top_models,
+)
+from judgearena.benchmarks.scoring import build_metrics, calculate_metrics
+from judgearena.datasets import load_battles
+from judgearena.evaluate import resolve_run_judge_prompt
+from judgearena.log import get_logger
+from judgearena.reports import MetaEvalReport
+from judgearena.tasks.schema import MetaEvalProtocol, ResolvedTaskSpec
+
+if TYPE_CHECKING:
+    from judgearena.config import MetaEvalArgs, RunConfig
+
+logger = get_logger(__name__)
+
+_WINNER_PREFERENCES = {
+    "model_a": 0.0,
+    "model_b": 1.0,
+    "tie": 0.5,
+    "tie (bothbad)": 0.5,
+}
+_REQUIRED_COLUMNS = {
+    "question_id",
+    "model_a",
+    "model_b",
+    "winner",
+    "lang",
+    "conversation_a",
+    "conversation_b",
+}
+
+
+def _prepare_arena_battles(
+    battles: pd.DataFrame, *, task: str, arena: str, languages: list[str]
+) -> pd.DataFrame:
+    """Validate arena identity fields and add the metric reference preference."""
+    missing = sorted(_REQUIRED_COLUMNS - set(battles.columns))
+    if missing:
+        raise MetaEvalSamplingError(
+            f"Task {task!r} is missing required battle columns: {missing}."
+        )
+
+    battles = battles.copy()
+    identity_columns = ("question_id", "model_a", "model_b", "winner", "lang")
+    for column in identity_columns:
+        if battles[column].isna().any():
+            raise MetaEvalSamplingError(
+                f"Task {task!r} contains null values in {column}."
+            )
+    for column in ("model_a", "model_b"):
+        valid = battles[column].map(
+            lambda value: isinstance(value, str) and bool(value)
+        )
+        if not valid.all():
+            raise MetaEvalSamplingError(
+                f"Task {task!r} contains invalid model identifiers in {column}."
+            )
+
+    battles["battle_id"] = arena + ":" + battles["question_id"].astype(str)
+    if battles["battle_id"].duplicated().any():
+        raise MetaEvalSamplingError(
+            f"Task {task!r} contains duplicate physical battle IDs."
+        )
+
+    battles["reference_pref"] = battles["winner"].map(_WINNER_PREFERENCES)
+    invalid_winners = sorted(
+        {
+            str(value)
+            for value in battles.loc[battles["reference_pref"].isna(), "winner"]
+        }
+    )
+    if invalid_winners:
+        raise MetaEvalSamplingError(
+            f"Task {task!r} contains invalid human winners: {invalid_winners}."
+        )
+
+    if languages:
+        battles = battles.loc[battles["lang"].isin(languages)].copy()
+    if battles.empty:
+        raise MetaEvalSamplingError(
+            f"Task {task!r} has no battles in languages {languages}."
+        )
+    return battles.reset_index(drop=True)
+
+
+def _metric_overrides(meta_eval: MetaEvalArgs) -> dict[str, dict[str, object]]:
+    overrides: dict[str, dict[str, object]] = {}
+    if meta_eval.n_bootstraps is not None:
+        for name in ("meta_eval_agreement", "meta_eval_ranking"):
+            overrides.setdefault(name, {})["n_bootstraps"] = meta_eval.n_bootstraps
+    if meta_eval.include_human_ties is not None:
+        overrides.setdefault("meta_eval_ranking", {})["include_human_ties"] = (
+            meta_eval.include_human_ties
+        )
+    if meta_eval.elo_gap_battles is not None:
+        overrides.setdefault("meta_eval_elo_gap", {})["battle_counts"] = (
+            meta_eval.elo_gap_battles
+        )
+    if meta_eval.elo_gap_seeds is not None:
+        overrides.setdefault("meta_eval_elo_gap", {})["n_seeds"] = (
+            meta_eval.elo_gap_seeds
+        )
+    return overrides
+
+
+def _metric_rng(seed: int, metric_name: str) -> np.random.Generator:
+    payload = f"{seed}\0{metric_name}".encode()
+    metric_seed = int.from_bytes(hashlib.sha256(payload).digest()[:8], "big")
+    return np.random.default_rng(metric_seed)
+
+
+def _build_metric_battles(
+    top_pool: pd.DataFrame,
+    sample: pd.DataFrame,
+    judged_battles: pd.DataFrame,
+) -> pd.DataFrame:
+    """Attach sampled judge outcomes to the complete top-model human pool."""
+    metric_battles = top_pool.loc[
+        :, ("battle_id", "question_id", "model_a", "model_b", "reference_pref", "lang")
+    ].copy()
+    sampled_ids = set(sample["battle_id"])
+    metric_battles["sampled"] = metric_battles["battle_id"].isin(sampled_ids)
+    metric_battles["language_group"] = np.where(
+        metric_battles["lang"].eq("en"), "English", "Multilingual"
+    )
+    judge_columns = (
+        "battle_id",
+        "pref",
+        "pref_hard",
+        "parse_ok",
+        "n_passes_expected",
+        "n_passes_parsed",
+        "parse_status",
+    )
+    metric_battles = metric_battles.merge(
+        judged_battles.loc[:, judge_columns],
+        on="battle_id",
+        how="left",
+        validate="one_to_one",
+    )
+    return metric_battles.sort_values(
+        ["language_group", "battle_id"], kind="stable"
+    ).reset_index(drop=True)
+
+
+def run_meta_eval(
+    cfg: RunConfig, task: ResolvedTaskSpec | None = None
+) -> dict[str, object]:
+    """Sample arena battles, judge them, and run configured meta metrics."""
+    protocol = task.spec.protocol if task is not None else None
+    if not isinstance(protocol, MetaEvalProtocol):
+        raise ValueError(f"Task {cfg.task!r} does not define a meta-eval protocol.")
+    if cfg.meta_eval is None:
+        raise ValueError(f"Task {cfg.task!r} requires meta-eval runtime settings.")
+
+    run_started_at = datetime.now(UTC)
+    languages = resolve_task_languages(
+        task, cfg.meta_eval.languages, setting="meta_eval.languages"
+    )
+    metrics = build_metrics(
+        protocol.scoring.metrics,
+        parameter_overrides_by_metric=_metric_overrides(cfg.meta_eval),
+    )
+    for request, metric in metrics:
+        if request.metric == "meta_eval_elo_gap":
+            maximum = max(metric.battle_counts)
+            if maximum > cfg.meta_eval.battles_per_model:
+                raise ValueError(
+                    "The maximum meta_eval_elo_gap battle budget "
+                    f"({maximum}) exceeds meta_eval.battles_per_model "
+                    f"({cfg.meta_eval.battles_per_model})."
+                )
+
+    logger.info("Loading human battles from %s", protocol.arena)
+    arena_battles = _prepare_arena_battles(
+        load_battles(task), task=cfg.task, arena=protocol.arena, languages=languages
+    )
+    top_models, top_pool = select_top_models(
+        arena_battles, top_models=cfg.meta_eval.top_models
+    )
+    sample = sample_battles_per_model(
+        top_pool,
+        top_models,
+        battles_per_model=cfg.meta_eval.battles_per_model,
+        seed=cfg.run.seed,
+    )
+    validate_battle_conversations(sample)
+    resolved_prompt = resolve_run_judge_prompt(cfg.task, cfg.judge)
+    if resolved_prompt.delegated:
+        raise ValueError(
+            "Meta-evaluation cannot use delegated prompt preset "
+            f"{resolved_prompt.preset_name!r}."
+        )
+    if resolved_prompt.parser is None:
+        raise ValueError(
+            f"Prompt preset {resolved_prompt.preset_name!r} has no judge parser."
+        )
+
+    logger.info(
+        "Sampled %d battles among the top %d models.", len(sample), len(top_models)
+    )
+    timestamp = run_started_at.strftime("%Y%m%d_%H%M%S")
+    result_name = (
+        f"{safe_filename(cfg.task)}-{safe_filename(cfg.judge.model)}-"
+        f"{cfg.judge.swap_mode}-{timestamp}"
+    )
+    result_dir = prepare_run_directory(cfg, Path(cfg.run.result_folder) / result_name)
+    sample.loc[
+        :, ("battle_id", "question_id", "model_a", "model_b", "winner", "lang")
+    ].to_parquet(result_dir / "sample.parquet", index=False)
+
+    annotations = annotate_sample(
+        sample,
+        cfg,
+        judge_chat_model=build_judge(cfg),
+        resolved_prompt=resolved_prompt,
+    )
+    annotations.to_parquet(result_dir / "annotations.parquet", index=False)
+    judged_battles = aggregate_battle_preferences(
+        annotations, swap_mode=cfg.judge.swap_mode
+    )
+    metric_battles = _build_metric_battles(top_pool, sample, judged_battles)
+    metric_battles.to_parquet(result_dir / "battles.parquet", index=False)
+    runtime_by_metric = {
+        request.metric: {"rng": _metric_rng(cfg.run.seed, request.metric)}
+        for request, _metric in metrics
+    }
+    metric_results = calculate_metrics(
+        metric_battles, metrics, runtime_by_metric=runtime_by_metric
+    )
+    report = MetaEvalReport(
+        task=cfg.task,
+        arena=protocol.arena,
+        judge_model=cfg.judge.model,
+        prompt_preset=resolved_prompt.preset_name,
+        languages=languages,
+        top_models=top_models,
+        n_battles=len(sample),
+        n_annotations=len(annotations),
+        n_parsed_annotations=int(annotations["parse_ok"].sum()),
+        n_scored_battles=int(judged_battles["parse_status"].eq("complete").sum()),
+        battle_parse_status={
+            str(key): int(value)
+            for key, value in judged_battles["parse_status"].value_counts().items()
+        },
+        swap_mode=cfg.judge.swap_mode,
+        battles_per_language={
+            str(key): int(value) for key, value in sample["lang"].value_counts().items()
+        },
+        human_winner_counts={
+            str(key): int(value)
+            for key, value in sample["winner"].value_counts().items()
+        },
+        metrics=metric_results,
+    )
+    results = report.to_dict()
+    report.render()
+    result_path = report.save(result_dir / "results.json")
+    write_run_metadata_safely(
+        output_dir=result_dir,
+        entrypoint="judgearena.benchmarks.meta_eval.runner.run_meta_eval",
+        run=cfg.model_dump(),
+        results=results,
+        input_payloads={
+            "battle_id": sample["battle_id"].astype(str).tolist(),
+            "question_id": sample["question_id"].astype(str).tolist(),
+        },
+        judge_system_prompt=resolved_prompt.system_prompt,
+        judge_user_prompt_template=resolved_prompt.user_prompt_template,
+        started_at_utc=run_started_at,
+    )
+    logger.info("Meta-eval results written to %s", result_dir)
+    return {**results, "result_path": str(result_path)}

--- a/judgearena/benchmarks/meta_eval/runner.py
+++ b/judgearena/benchmarks/meta_eval/runner.py
@@ -96,6 +96,7 @@ def _prepare_arena_battles(
 
     if languages:
         battles = battles.loc[battles["lang"].isin(languages)].copy()
+    battles = battles.loc[battles["model_a"] != battles["model_b"]].copy()
     if battles.empty:
         raise MetaEvalSamplingError(
             f"Task {task!r} has no battles in languages {languages}."

--- a/judgearena/benchmarks/meta_eval/runner.py
+++ b/judgearena/benchmarks/meta_eval/runner.py
@@ -16,6 +16,7 @@ from judgearena.artifacts import (
     write_run_metadata_safely,
 )
 from judgearena.benchmarks.arena import resolve_task_languages
+from judgearena.benchmarks.elo.rating import winner_to_pref
 from judgearena.benchmarks.execution import build_judge
 from judgearena.benchmarks.meta_eval.annotate import (
     aggregate_battle_preferences,
@@ -38,12 +39,6 @@ if TYPE_CHECKING:
 
 logger = get_logger(__name__)
 
-_WINNER_PREFERENCES = {
-    "model_a": 0.0,
-    "model_b": 1.0,
-    "tie": 0.5,
-    "tie (bothbad)": 0.5,
-}
 _REQUIRED_COLUMNS = {
     "question_id",
     "model_a",
@@ -87,7 +82,7 @@ def _prepare_arena_battles(
             f"Task {task!r} contains duplicate physical battle IDs."
         )
 
-    battles["reference_pref"] = battles["winner"].map(_WINNER_PREFERENCES)
+    battles["reference_pref"] = battles["winner"].map(winner_to_pref)
     invalid_winners = sorted(
         {
             str(value)

--- a/judgearena/benchmarks/meta_eval/runner.py
+++ b/judgearena/benchmarks/meta_eval/runner.py
@@ -95,8 +95,8 @@ def _prepare_arena_battles(
         )
 
     if languages:
-        battles = battles.loc[battles["lang"].isin(languages)].copy()
-    battles = battles.loc[battles["model_a"] != battles["model_b"]].copy()
+        battles = battles.loc[battles["lang"].isin(languages)]
+    battles = battles.loc[battles["model_a"] != battles["model_b"]]
     if battles.empty:
         raise MetaEvalSamplingError(
             f"Task {task!r} has no battles in languages {languages}."

--- a/judgearena/benchmarks/meta_eval/runner.py
+++ b/judgearena/benchmarks/meta_eval/runner.py
@@ -20,7 +20,6 @@ from judgearena.benchmarks.execution import build_judge
 from judgearena.benchmarks.meta_eval.annotate import (
     aggregate_battle_preferences,
     annotate_sample,
-    validate_battle_conversations,
 )
 from judgearena.benchmarks.meta_eval.sampling import (
     MetaEvalSamplingError,
@@ -35,7 +34,7 @@ from judgearena.reports import MetaEvalReport
 from judgearena.tasks.schema import MetaEvalProtocol, ResolvedTaskSpec
 
 if TYPE_CHECKING:
-    from judgearena.config import MetaEvalArgs, RunConfig
+    from judgearena.config import RunConfig
 
 logger = get_logger(__name__)
 
@@ -109,64 +108,10 @@ def _prepare_arena_battles(
     return battles.reset_index(drop=True)
 
 
-def _metric_overrides(meta_eval: MetaEvalArgs) -> dict[str, dict[str, object]]:
-    overrides: dict[str, dict[str, object]] = {}
-    if meta_eval.n_bootstraps is not None:
-        for name in ("meta_eval_agreement", "meta_eval_ranking"):
-            overrides.setdefault(name, {})["n_bootstraps"] = meta_eval.n_bootstraps
-    if meta_eval.include_human_ties is not None:
-        overrides.setdefault("meta_eval_ranking", {})["include_human_ties"] = (
-            meta_eval.include_human_ties
-        )
-    if meta_eval.elo_gap_battles is not None:
-        overrides.setdefault("meta_eval_elo_gap", {})["battle_counts"] = (
-            meta_eval.elo_gap_battles
-        )
-    if meta_eval.elo_gap_seeds is not None:
-        overrides.setdefault("meta_eval_elo_gap", {})["n_seeds"] = (
-            meta_eval.elo_gap_seeds
-        )
-    return overrides
-
-
 def _metric_rng(seed: int, metric_name: str) -> np.random.Generator:
     payload = f"{seed}\0{metric_name}".encode()
     metric_seed = int.from_bytes(hashlib.sha256(payload).digest()[:8], "big")
     return np.random.default_rng(metric_seed)
-
-
-def _build_metric_battles(
-    top_pool: pd.DataFrame,
-    sample: pd.DataFrame,
-    judged_battles: pd.DataFrame,
-) -> pd.DataFrame:
-    """Attach sampled judge outcomes to the complete top-model human pool."""
-    metric_battles = top_pool.loc[
-        :, ("battle_id", "question_id", "model_a", "model_b", "reference_pref", "lang")
-    ].copy()
-    sampled_ids = set(sample["battle_id"])
-    metric_battles["sampled"] = metric_battles["battle_id"].isin(sampled_ids)
-    metric_battles["language_group"] = np.where(
-        metric_battles["lang"].eq("en"), "English", "Multilingual"
-    )
-    judge_columns = (
-        "battle_id",
-        "pref",
-        "pref_hard",
-        "parse_ok",
-        "n_passes_expected",
-        "n_passes_parsed",
-        "parse_status",
-    )
-    metric_battles = metric_battles.merge(
-        judged_battles.loc[:, judge_columns],
-        on="battle_id",
-        how="left",
-        validate="one_to_one",
-    )
-    return metric_battles.sort_values(
-        ["language_group", "battle_id"], kind="stable"
-    ).reset_index(drop=True)
 
 
 def run_meta_eval(
@@ -183,10 +128,7 @@ def run_meta_eval(
     languages = resolve_task_languages(
         task, cfg.meta_eval.languages, setting="meta_eval.languages"
     )
-    metrics = build_metrics(
-        protocol.scoring.metrics,
-        parameter_overrides_by_metric=_metric_overrides(cfg.meta_eval),
-    )
+    metrics = build_metrics(protocol.scoring.metrics)
     for request, metric in metrics:
         if request.metric == "meta_eval_elo_gap":
             maximum = max(metric.battle_counts)
@@ -210,7 +152,6 @@ def run_meta_eval(
         battles_per_model=cfg.meta_eval.battles_per_model,
         seed=cfg.run.seed,
     )
-    validate_battle_conversations(sample)
     resolved_prompt = resolve_run_judge_prompt(cfg.task, cfg.judge)
     if resolved_prompt.delegated:
         raise ValueError(
@@ -221,7 +162,6 @@ def run_meta_eval(
         raise ValueError(
             f"Prompt preset {resolved_prompt.preset_name!r} has no judge parser."
         )
-
     logger.info(
         "Sampled %d battles among the top %d models.", len(sample), len(top_models)
     )
@@ -245,7 +185,15 @@ def run_meta_eval(
     judged_battles = aggregate_battle_preferences(
         annotations, swap_mode=cfg.judge.swap_mode
     )
-    metric_battles = _build_metric_battles(top_pool, sample, judged_battles)
+    metric_battles = top_pool.loc[
+        :, ("battle_id", "model_a", "model_b", "reference_pref")
+    ].copy()
+    metric_battles["sampled"] = metric_battles["battle_id"].isin(
+        judged_battles["battle_id"]
+    )
+    metric_battles = metric_battles.merge(
+        judged_battles, on="battle_id", how="left"
+    ).sort_values("battle_id", kind="stable", ignore_index=True)
     metric_battles.to_parquet(result_dir / "battles.parquet", index=False)
     runtime_by_metric = {
         request.metric: {"rng": _metric_rng(cfg.run.seed, request.metric)}
@@ -261,22 +209,8 @@ def run_meta_eval(
         prompt_preset=resolved_prompt.preset_name,
         languages=languages,
         top_models=top_models,
-        n_battles=len(sample),
-        n_annotations=len(annotations),
-        n_parsed_annotations=int(annotations["parse_ok"].sum()),
-        n_scored_battles=int(judged_battles["parse_status"].eq("complete").sum()),
-        battle_parse_status={
-            str(key): int(value)
-            for key, value in judged_battles["parse_status"].value_counts().items()
-        },
+        n_sampled_battles=len(sample),
         swap_mode=cfg.judge.swap_mode,
-        battles_per_language={
-            str(key): int(value) for key, value in sample["lang"].value_counts().items()
-        },
-        human_winner_counts={
-            str(key): int(value)
-            for key, value in sample["winner"].value_counts().items()
-        },
         metrics=metric_results,
     )
     results = report.to_dict()
@@ -287,10 +221,7 @@ def run_meta_eval(
         entrypoint="judgearena.benchmarks.meta_eval.runner.run_meta_eval",
         run=cfg.model_dump(),
         results=results,
-        input_payloads={
-            "battle_id": sample["battle_id"].astype(str).tolist(),
-            "question_id": sample["question_id"].astype(str).tolist(),
-        },
+        input_payloads={"battle_id": sample["battle_id"].astype(str).tolist()},
         judge_system_prompt=resolved_prompt.system_prompt,
         judge_user_prompt_template=resolved_prompt.user_prompt_template,
         started_at_utc=run_started_at,

--- a/judgearena/benchmarks/meta_eval/sampling.py
+++ b/judgearena/benchmarks/meta_eval/sampling.py
@@ -48,7 +48,7 @@ def comparison_components(
             stack.extend(adjacency[model] - component)
         unseen -= component
         components.append(frozenset(component))
-    return sorted(components, key=lambda component: sorted(component))
+    return components
 
 
 def require_connected_pool(
@@ -80,8 +80,7 @@ def select_top_models(
         raise MetaEvalSamplingError(
             f"Requested {top_models} top models, but only {len(top)} are available."
         )
-    top_set = set(top)
-    df_top = df[df["model_a"].isin(top_set) & df["model_b"].isin(top_set)].copy()
+    df_top = df[df["model_a"].isin(top) & df["model_b"].isin(top)].copy()
     require_connected_pool(df_top, top, context="Top-model")
     return top, df_top
 
@@ -136,8 +135,8 @@ def sample_battles_per_model(
         lambda battle_id: _stable_priority(battle_id, seed=seed)
     )
     working = working.sort_values(
-        ["_sample_priority", "battle_id"], kind="stable"
-    ).reset_index(drop=True)
+        ["_sample_priority", "battle_id"], kind="stable", ignore_index=True
+    )
     available_counts = count_battles_per_model(working)
     shortfalls = {
         model: available_counts.get(model, 0)
@@ -160,6 +159,6 @@ def sample_battles_per_model(
         if needed:
             selected_ids.update(candidates.head(needed)["battle_id"].tolist())
 
-    sample = working[working["battle_id"].isin(selected_ids)].copy()
+    sample = working[working["battle_id"].isin(selected_ids)]
 
     return sample.drop(columns="_sample_priority").reset_index(drop=True)

--- a/judgearena/benchmarks/meta_eval/sampling.py
+++ b/judgearena/benchmarks/meta_eval/sampling.py
@@ -1,0 +1,206 @@
+"""Deterministic arena battle sampling for judge meta-evaluation."""
+
+from __future__ import annotations
+
+import hashlib
+from collections.abc import Iterable
+
+import pandas as pd
+
+
+class MetaEvalSamplingError(ValueError):
+    """Raised when filtering or sampling yields an unusable battle subset."""
+
+
+def count_battles_per_model(df: pd.DataFrame) -> dict[str, int]:
+    """Count unique physical rows incident to each model."""
+    model_a_counts = df["model_a"].value_counts()
+    model_b_counts = df["model_b"].value_counts()
+    self_counts = df.loc[df["model_a"] == df["model_b"], "model_a"].value_counts()
+    return (
+        model_a_counts.add(model_b_counts, fill_value=0)
+        .sub(self_counts, fill_value=0)
+        .astype(int)
+        .to_dict()
+    )
+
+
+def comparison_components(
+    df: pd.DataFrame, models: Iterable[str] | None = None
+) -> list[frozenset[str]]:
+    """Return connected components of the model comparison graph."""
+    model_set = set(models or ())
+    model_set.update(df["model_a"].dropna().astype(str))
+    model_set.update(df["model_b"].dropna().astype(str))
+    adjacency = {model: set() for model in model_set}
+    for model_a, model_b in df[["model_a", "model_b"]].itertuples(
+        index=False, name=None
+    ):
+        model_a, model_b = str(model_a), str(model_b)
+        adjacency[model_a].add(model_b)
+        adjacency[model_b].add(model_a)
+
+    components: list[frozenset[str]] = []
+    unseen = set(adjacency)
+    while unseen:
+        start = min(unseen)
+        stack = [start]
+        component = set()
+        while stack:
+            model = stack.pop()
+            if model in component:
+                continue
+            component.add(model)
+            stack.extend(adjacency[model] - component)
+        unseen -= component
+        components.append(frozenset(component))
+    return sorted(components, key=lambda component: sorted(component))
+
+
+def require_connected_pool(
+    df: pd.DataFrame, models: Iterable[str], *, context: str
+) -> None:
+    """Reject comparison pools whose Bradley-Terry offsets are unidentified."""
+    components = comparison_components(df, models)
+    if len(components) != 1:
+        rendered = [sorted(component) for component in components]
+        raise MetaEvalSamplingError(
+            f"{context} comparison graph is disconnected: {rendered}."
+        )
+
+
+def select_top_models(
+    df: pd.DataFrame, *, top_models: int
+) -> tuple[list[str], pd.DataFrame]:
+    """Pick the most-battled models and require one connected induced pool."""
+    if (df["model_a"] == df["model_b"]).any():
+        raise MetaEvalSamplingError("Meta-evaluation does not allow self-comparisons.")
+    battle_counts = count_battles_per_model(df)
+    if not battle_counts:
+        raise MetaEvalSamplingError("Cannot select top models from an empty dataframe.")
+
+    top = sorted(battle_counts, key=lambda model: (-battle_counts[model], str(model)))[
+        :top_models
+    ]
+    if len(top) != top_models:
+        raise MetaEvalSamplingError(
+            f"Requested {top_models} top models, but only {len(top)} are available."
+        )
+    top_set = set(top)
+    df_top = df[df["model_a"].isin(top_set) & df["model_b"].isin(top_set)].copy()
+    if df_top.empty:
+        raise MetaEvalSamplingError(
+            f"No battles remain among the top {top_models} models."
+        )
+    require_connected_pool(df_top, top, context="Top-model")
+    return top, df_top
+
+
+def _with_unique_battle_ids(df: pd.DataFrame) -> pd.DataFrame:
+    working = df.copy()
+    if "battle_id" not in working:
+        raise MetaEvalSamplingError(
+            "Stable battle_id values are required for deterministic sampling."
+        )
+    if working["battle_id"].isna().any() or working["battle_id"].duplicated().any():
+        raise MetaEvalSamplingError(
+            "Physical battle_id values must be present and unique."
+        )
+    return working
+
+
+def _stable_priority(battle_id: object, *, seed: int) -> str:
+    payload = f"{seed}\0{battle_id}".encode()
+    return hashlib.sha256(payload).hexdigest()
+
+
+def _spanning_battle_ids(df: pd.DataFrame, top_models: list[str]) -> set[object]:
+    """Choose a stable-priority spanning tree before filling quotas."""
+    parent = {model: model for model in top_models}
+
+    def find(model: str) -> str:
+        while parent[model] != model:
+            parent[model] = parent[parent[model]]
+            model = parent[model]
+        return model
+
+    def union(model_a: str, model_b: str) -> bool:
+        root_a, root_b = find(model_a), find(model_b)
+        if root_a == root_b:
+            return False
+        parent[root_b] = root_a
+        return True
+
+    selected: set[object] = set()
+    for row in df.itertuples(index=False):
+        if union(str(row.model_a), str(row.model_b)):
+            selected.add(row.battle_id)
+            if len(selected) == len(top_models) - 1:
+                break
+    return selected
+
+
+def sample_battles_per_model(
+    df_top: pd.DataFrame,
+    top_models: list[str],
+    *,
+    battles_per_model: int,
+    seed: int,
+) -> pd.DataFrame:
+    """Build one connected panel with no repeated physical battles.
+
+    A spanning tree guarantees connectivity. Already-selected battles count
+    toward both endpoint quotas; remaining unseen battles fill each model's
+    target deterministically. Connectivity can make some models exceed the
+    target, which is preferable to an unidentified ranking graph.
+    """
+    working = _with_unique_battle_ids(df_top)
+    if (working["model_a"] == working["model_b"]).any():
+        raise MetaEvalSamplingError("Meta-evaluation does not allow self-comparisons.")
+    working["_sample_priority"] = working["battle_id"].map(
+        lambda battle_id: _stable_priority(battle_id, seed=seed)
+    )
+    working = working.sort_values(
+        ["_sample_priority", "battle_id"], kind="stable"
+    ).reset_index(drop=True)
+    require_connected_pool(working, top_models, context="Candidate")
+    available_counts = count_battles_per_model(working)
+    shortfalls = {
+        model: available_counts.get(model, 0)
+        for model in top_models
+        if available_counts.get(model, 0) < battles_per_model
+    }
+    if shortfalls:
+        raise MetaEvalSamplingError(
+            "Insufficient unique battles for the requested per-model quota: "
+            f"{shortfalls}."
+        )
+    selected_ids = _spanning_battle_ids(working, top_models)
+
+    for model in top_models:
+        incident = (working["model_a"] == model) | (working["model_b"] == model)
+        already_selected = working["battle_id"].isin(selected_ids)
+        current = int((incident & already_selected).sum())
+        needed = max(0, battles_per_model - current)
+        candidates = working[incident & ~already_selected]
+        if needed:
+            selected_ids.update(candidates.head(needed)["battle_id"].tolist())
+
+    if not selected_ids:
+        raise MetaEvalSamplingError(
+            "Sampling produced no battles; reduce top_models or battles_per_model."
+        )
+    sample = working[working["battle_id"].isin(selected_ids)].copy()
+    require_connected_pool(sample, top_models, context="Sampled")
+    sampled_counts = count_battles_per_model(sample)
+    final_shortfalls = {
+        model: sampled_counts.get(model, 0)
+        for model in top_models
+        if sampled_counts.get(model, 0) < battles_per_model
+    }
+    if final_shortfalls:
+        raise MetaEvalSamplingError(
+            f"Sampling failed to meet the unique per-model quota: {final_shortfalls}."
+        )
+
+    return sample.drop(columns="_sample_priority").reset_index(drop=True)

--- a/judgearena/benchmarks/meta_eval/sampling.py
+++ b/judgearena/benchmarks/meta_eval/sampling.py
@@ -16,13 +16,7 @@ def count_battles_per_model(df: pd.DataFrame) -> dict[str, int]:
     """Count unique physical rows incident to each model."""
     model_a_counts = df["model_a"].value_counts()
     model_b_counts = df["model_b"].value_counts()
-    self_counts = df.loc[df["model_a"] == df["model_b"], "model_a"].value_counts()
-    return (
-        model_a_counts.add(model_b_counts, fill_value=0)
-        .sub(self_counts, fill_value=0)
-        .astype(int)
-        .to_dict()
-    )
+    return model_a_counts.add(model_b_counts, fill_value=0).astype(int).to_dict()
 
 
 def comparison_components(
@@ -88,25 +82,8 @@ def select_top_models(
         )
     top_set = set(top)
     df_top = df[df["model_a"].isin(top_set) & df["model_b"].isin(top_set)].copy()
-    if df_top.empty:
-        raise MetaEvalSamplingError(
-            f"No battles remain among the top {top_models} models."
-        )
     require_connected_pool(df_top, top, context="Top-model")
     return top, df_top
-
-
-def _with_unique_battle_ids(df: pd.DataFrame) -> pd.DataFrame:
-    working = df.copy()
-    if "battle_id" not in working:
-        raise MetaEvalSamplingError(
-            "Stable battle_id values are required for deterministic sampling."
-        )
-    if working["battle_id"].isna().any() or working["battle_id"].duplicated().any():
-        raise MetaEvalSamplingError(
-            "Physical battle_id values must be present and unique."
-        )
-    return working
 
 
 def _stable_priority(battle_id: object, *, seed: int) -> str:
@@ -154,16 +131,13 @@ def sample_battles_per_model(
     target deterministically. Connectivity can make some models exceed the
     target, which is preferable to an unidentified ranking graph.
     """
-    working = _with_unique_battle_ids(df_top)
-    if (working["model_a"] == working["model_b"]).any():
-        raise MetaEvalSamplingError("Meta-evaluation does not allow self-comparisons.")
+    working = df_top.copy()
     working["_sample_priority"] = working["battle_id"].map(
         lambda battle_id: _stable_priority(battle_id, seed=seed)
     )
     working = working.sort_values(
         ["_sample_priority", "battle_id"], kind="stable"
     ).reset_index(drop=True)
-    require_connected_pool(working, top_models, context="Candidate")
     available_counts = count_battles_per_model(working)
     shortfalls = {
         model: available_counts.get(model, 0)
@@ -186,21 +160,6 @@ def sample_battles_per_model(
         if needed:
             selected_ids.update(candidates.head(needed)["battle_id"].tolist())
 
-    if not selected_ids:
-        raise MetaEvalSamplingError(
-            "Sampling produced no battles; reduce top_models or battles_per_model."
-        )
     sample = working[working["battle_id"].isin(selected_ids)].copy()
-    require_connected_pool(sample, top_models, context="Sampled")
-    sampled_counts = count_battles_per_model(sample)
-    final_shortfalls = {
-        model: sampled_counts.get(model, 0)
-        for model in top_models
-        if sampled_counts.get(model, 0) < battles_per_model
-    }
-    if final_shortfalls:
-        raise MetaEvalSamplingError(
-            f"Sampling failed to meet the unique per-model quota: {final_shortfalls}."
-        )
 
     return sample.drop(columns="_sample_priority").reset_index(drop=True)

--- a/judgearena/benchmarks/meta_eval/scoring.py
+++ b/judgearena/benchmarks/meta_eval/scoring.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import math
 from dataclasses import dataclass
 from numbers import Real
@@ -435,4 +436,229 @@ class MetaEvalRankingMetric:
                 ranking["elo_mae"], ranking["elo_mae_se"], digits=1
             )
             lines.append(f"  {name}: spearman={spearman}, elo_mae={elo_mae}")
+        return "\n".join(lines)
+
+
+_ELO_GAP_VARIANTS = ("hard", "soft", "hard_no_judge_ties")
+
+
+def _validate_elo_gap_configuration(
+    battle_counts: object, n_seeds: int, tie_tolerance: float
+) -> tuple[int, ...]:
+    _validate_configuration(0, tie_tolerance)
+    if not isinstance(battle_counts, (list, tuple)) or not battle_counts:
+        raise ValueError("battle_counts must be a non-empty ordered sequence")
+    if any(type(count) is not int or count <= 0 for count in battle_counts):
+        raise ValueError("battle_counts values must be positive integers")
+    counts = tuple(battle_counts)
+    if any(left >= right for left, right in zip(counts, counts[1:], strict=False)):
+        raise ValueError("battle_counts values must be unique and ordered ascending")
+    if type(n_seeds) is not int or n_seeds <= 0:
+        raise ValueError("n_seeds must be a positive integer")
+    return counts
+
+
+def _elo_gap_priority(
+    schedule_seed: int, replicate: int, focal_model: str, battle_id: object
+) -> bytes:
+    battle_type, battle_value = _battle_sort_key(battle_id)
+    payload = (
+        f"{schedule_seed}\0{replicate}\0{focal_model}\0{battle_type}\0{battle_value}"
+    )
+    return hashlib.sha256(payload.encode()).digest()
+
+
+def _elo_gap_vector(rows: pd.DataFrame, models: list[str]) -> np.ndarray | None:
+    if comparison_components(rows, models) != [frozenset(models)]:
+        return None
+    try:
+        ratings = fit_bradley_terry(rows, pref_col="pref")
+    except (TypeError, ValueError):
+        return None
+    return _centered_vector(ratings, models)
+
+
+def _elo_gap_rows(
+    *,
+    models: list[str],
+    battles: pd.DataFrame,
+    schedules: dict[tuple[int, str], list[object]],
+    reference: np.ndarray | None,
+    battle_counts: tuple[int, ...],
+    n_seeds: int,
+    tie_tolerance: float,
+) -> dict[str, list[dict[str, float | int]]]:
+    results: dict[str, list[dict[str, float | int]]] = {
+        variant: [] for variant in _ELO_GAP_VARIANTS
+    }
+    by_id = battles.set_index("battle_id", drop=False)
+    human_by_model = {}
+    for focal_model in models:
+        incident = battles["model_a"].eq(focal_model) | battles["model_b"].eq(
+            focal_model
+        )
+        human_by_model[focal_model] = battles.loc[
+            ~incident, ["model_a", "model_b", "reference_pref"]
+        ].rename(columns={"reference_pref": "pref"})
+
+    for battle_count in battle_counts:
+        replicate_gaps = {variant: [] for variant in _ELO_GAP_VARIANTS}
+        parsed_counts: list[int] = []
+        used_counts = {variant: [] for variant in _ELO_GAP_VARIANTS}
+
+        for replicate in range(n_seeds):
+            gaps = {variant: [] for variant in _ELO_GAP_VARIANTS}
+            for focal_index, focal_model in enumerate(models):
+                selected_ids = schedules[replicate, focal_model][:battle_count]
+                selected = by_id.loc[selected_ids]
+                parsed = selected.loc[selected["parse_status"].eq("complete")].copy()
+                hard_prefs = _hard_preferences(parsed["pref"], tie_tolerance) / 2.0
+                parsed_counts.append(len(parsed))
+                human = human_by_model[focal_model]
+
+                for variant in _ELO_GAP_VARIANTS:
+                    judge = parsed[["model_a", "model_b"]].copy()
+                    judge["pref"] = (
+                        parsed["pref"].to_numpy(dtype=float)
+                        if variant == "soft"
+                        else hard_prefs
+                    )
+                    if variant == "hard_no_judge_ties":
+                        judge = judge.loc[judge["pref"].ne(0.5)]
+                    used_counts[variant].append(len(judge))
+
+                    hybrid = pd.concat([human, judge], ignore_index=True)
+                    fitted = _elo_gap_vector(hybrid, models)
+                    if reference is not None and fitted is not None:
+                        gaps[variant].append(
+                            abs(fitted[focal_index] - reference[focal_index])
+                        )
+
+            for variant in _ELO_GAP_VARIANTS:
+                if len(gaps[variant]) == len(models) and models:
+                    replicate_gaps[variant].append(float(np.mean(gaps[variant])))
+
+        for variant in _ELO_GAP_VARIANTS:
+            valid = replicate_gaps[variant]
+            mean_gap = float(np.mean(valid)) if valid else float("nan")
+            sampling_se = (
+                float(np.std(valid, ddof=1) / np.sqrt(len(valid)))
+                if len(valid) >= 2
+                else float("nan")
+            )
+            results[variant].append(
+                {
+                    "attempted_battles_per_model": battle_count,
+                    "mean_gap": mean_gap,
+                    "sampling_se": sampling_se,
+                    "n_seeds_valid": len(valid),
+                    "n_seeds_failed": n_seeds - len(valid),
+                    "n_models": len(models),
+                    "mean_parsed_per_model": float(np.mean(parsed_counts))
+                    if parsed_counts
+                    else float("nan"),
+                    "mean_used_per_model": float(np.mean(used_counts[variant]))
+                    if used_counts[variant]
+                    else float("nan"),
+                }
+            )
+    return results
+
+
+@dataclass(frozen=True, kw_only=True)
+class MetaEvalEloGapMetric:
+    """Held-out focal-model Elo error at fixed annotation budgets."""
+
+    battle_counts: tuple[int, ...] = (10, 20, 30, 40, 50)
+    n_seeds: int = 10
+    tie_tolerance: float = 0.01
+
+    def __post_init__(self) -> None:
+        counts = _validate_elo_gap_configuration(
+            self.battle_counts, self.n_seeds, self.tie_tolerance
+        )
+        object.__setattr__(self, "battle_counts", counts)
+
+    def calculate(
+        self,
+        battles: pd.DataFrame,
+        *,
+        rng: np.random.Generator | None = None,
+    ) -> dict[str, object]:
+        """Calculate hard, soft, and judge-tie-excluded Elo gaps."""
+        _validate_battles(battles)
+        if rng is None:
+            raise ValueError("Meta-evaluation Elo gap requires an RNG.")
+
+        models = sorted(set(battles["model_a"]) | set(battles["model_b"]))
+        attempted = battles.loc[battles["sampled"]]
+        maximum = max(self.battle_counts)
+        attempted_ids_by_model = {}
+        shortfalls = {}
+        for model in models:
+            incident = attempted["model_a"].eq(model) | attempted["model_b"].eq(model)
+            battle_ids = attempted.loc[incident, "battle_id"].tolist()
+            attempted_ids_by_model[model] = battle_ids
+            if len(battle_ids) < maximum:
+                shortfalls[model] = len(battle_ids)
+        if shortfalls:
+            raise ValueError(
+                f"Every model needs at least {maximum} attempted incident battles; "
+                f"available counts: {shortfalls}."
+            )
+
+        schedule_seed = int(rng.integers(0, 2**63))
+        schedules: dict[tuple[int, str], list[object]] = {}
+        for replicate in range(self.n_seeds):
+            for focal_model in models:
+                schedules[replicate, focal_model] = sorted(
+                    attempted_ids_by_model[focal_model],
+                    key=lambda battle_id: (
+                        _elo_gap_priority(
+                            schedule_seed, replicate, focal_model, battle_id
+                        ),
+                        _battle_sort_key(battle_id),
+                    ),
+                )
+
+        human = battles[["model_a", "model_b", "reference_pref"]].rename(
+            columns={"reference_pref": "pref"}
+        )
+        reference = _elo_gap_vector(human, models)
+        variants = _elo_gap_rows(
+            models=models,
+            battles=battles,
+            schedules=schedules,
+            reference=reference,
+            battle_counts=self.battle_counts,
+            n_seeds=self.n_seeds,
+            tie_tolerance=self.tie_tolerance,
+        )
+        return {
+            "schedule_seed": schedule_seed,
+            "battle_counts_requested": list(self.battle_counts),
+            "n_seeds_requested": self.n_seeds,
+            **variants,
+        }
+
+    @staticmethod
+    def render(values: dict[str, object]) -> str:
+        """Render Elo gaps and their sampling standard errors."""
+        lines = [
+            "meta_eval_elo_gap: "
+            f"{values['n_seeds_requested']} sampling seeds "
+            f"(schedule seed {values['schedule_seed']})"
+        ]
+        for variant in _ELO_GAP_VARIANTS:
+            lines.append(f"  {variant}:")
+            for row in values[variant]:
+                gap = _format_estimate(row["mean_gap"], row["sampling_se"], digits=1)
+                lines.append(
+                    f"    {row['attempted_battles_per_model']} attempted battles/focal: "
+                    f"mean_gap={gap} (sampling SE; "
+                    f"valid seeds {row['n_seeds_valid']}/"
+                    f"{values['n_seeds_requested']}, "
+                    f"parsed/model={row['mean_parsed_per_model']:.1f}, "
+                    f"used/model={row['mean_used_per_model']:.1f})"
+                )
         return "\n".join(lines)

--- a/judgearena/benchmarks/meta_eval/scoring.py
+++ b/judgearena/benchmarks/meta_eval/scoring.py
@@ -14,6 +14,9 @@ from sklearn.metrics import cohen_kappa_score
 
 from judgearena.benchmarks.elo.rating import fit_bradley_terry
 from judgearena.benchmarks.meta_eval.sampling import comparison_components
+from judgearena.log import get_logger
+
+logger = get_logger(__name__)
 
 _REQUIRED_COLUMNS = {
     "battle_id",
@@ -561,10 +564,13 @@ class MetaEvalEloGapMetric:
             if len(battle_ids) < maximum:
                 shortfalls[model] = len(battle_ids)
         if shortfalls:
-            raise ValueError(
-                f"Every model needs at least {maximum} attempted incident battles; "
-                f"available counts: {shortfalls}."
+            logger.warning(
+                "Skipping meta_eval_elo_gap: every model needs at least %s "
+                "attempted incident battles; available counts: %s.",
+                maximum,
+                shortfalls,
             )
+            return {}
 
         schedule_seed = int(rng.integers(0, 2**63))
         schedules: dict[tuple[int, str], list[object]] = {}

--- a/judgearena/benchmarks/meta_eval/scoring.py
+++ b/judgearena/benchmarks/meta_eval/scoring.py
@@ -20,9 +20,7 @@ _REQUIRED_COLUMNS = {
     "reference_pref",
     "pref",
     "sampled",
-    "parse_status",
 }
-_PARSE_STATUSES = {"complete", "partial", "missing"}
 _METRIC_NAMES = ("spearman", "elo_mae")
 
 
@@ -44,57 +42,36 @@ def _validate_battles(battles: pd.DataFrame) -> None:
         raise ValueError(f"Meta-evaluation battles are missing columns: {missing}.")
     if battles["battle_id"].isna().any() or battles["battle_id"].duplicated().any():
         raise ValueError("Meta-evaluation battle_id values must be present and unique.")
-    if battles[["model_a", "model_b"]].isna().any().any():
-        raise ValueError("Meta-evaluation model names must not be missing.")
-    if not all(
-        isinstance(model, str)
-        for model in pd.concat([battles["model_a"], battles["model_b"]])
-    ):
-        raise ValueError("Meta-evaluation model names must be strings.")
+    models = pd.concat([battles["model_a"], battles["model_b"]])
+    if models.isna().any() or not all(isinstance(model, str) for model in models):
+        raise ValueError("Meta-evaluation model names must be non-null strings.")
     if (battles["model_a"] == battles["model_b"]).any():
         raise ValueError("Meta-evaluation battles do not allow self-comparisons.")
     if battles["sampled"].isna().any() or not all(
         isinstance(value, (bool, np.bool_)) for value in battles["sampled"]
     ):
         raise ValueError("Meta-evaluation sampled values must be booleans.")
-
-    sampled = battles["sampled"]
-    sampled_status = battles.loc[sampled, "parse_status"]
-    invalid_statuses = set(sampled_status.dropna()) - _PARSE_STATUSES
-    if sampled_status.isna().any() or invalid_statuses:
-        raise ValueError(
-            "Sampled meta-evaluation parse_status values must be complete, partial, "
-            f"or missing; got {sorted(map(str, invalid_statuses))}."
-        )
-
-    for column, allow_missing in (("reference_pref", False), ("pref", True)):
-        invalid = []
-        for value in battles[column]:
-            if pd.isna(value):
-                if not allow_missing:
-                    invalid.append(value)
-                continue
-            if (
-                isinstance(value, bool)
-                or not isinstance(value, Real)
-                or not math.isfinite(float(value))
-                or not 0.0 <= float(value) <= 1.0
-            ):
-                invalid.append(value)
-        if invalid:
-            raise ValueError(
-                f"Meta-evaluation {column} values must be numeric preferences in "
-                "[0, 1]."
-            )
-
-    if not battles["reference_pref"].isin((0.0, 0.5, 1.0)).all():
+    if not all(
+        not isinstance(value, bool)
+        and isinstance(value, Real)
+        and float(value) in (0.0, 0.5, 1.0)
+        for value in battles["reference_pref"]
+    ):
         raise ValueError("Meta-evaluation reference_pref values must be 0, 0.5, or 1.")
-    complete = sampled & battles["parse_status"].eq("complete")
-    if battles.loc[complete, "pref"].isna().any():
-        raise ValueError("Complete sampled battles must have a judge preference.")
-    missing = sampled & battles["parse_status"].eq("missing")
-    if battles.loc[missing, "pref"].notna().any():
-        raise ValueError("Missing sampled battles cannot have a judge preference.")
+    if not all(
+        pd.isna(value)
+        or (
+            not isinstance(value, bool)
+            and isinstance(value, Real)
+            and math.isfinite(float(value))
+            and 0.0 <= float(value) <= 1.0
+        )
+        for value in battles["pref"]
+    ):
+        raise ValueError(
+            "Meta-evaluation non-null pref values must be finite numeric preferences "
+            "in [0, 1]."
+        )
 
 
 def _reference_labels(values: pd.Series) -> np.ndarray:
@@ -144,22 +121,22 @@ def _agreement_point(
     rows: pd.DataFrame, tie_tolerance: float
 ) -> dict[str, float | int]:
     n_attempted = len(rows)
-    complete = rows["parse_status"].eq("complete")
-    parsed = rows.loc[complete]
-    n_complete = len(parsed)
+    complete = rows["pref"].notna()
+    complete_rows = rows.loc[complete]
+    n_complete = len(complete_rows)
     if n_complete:
-        parsed_reference = _reference_labels(parsed["reference_pref"])
-        parsed_judge = _hard_preferences(parsed["pref"], tie_tolerance)
-        parsed_correct = parsed_reference == parsed_judge
-        accuracy_parsed = float(np.mean(parsed_correct))
-        kappa = _cohen_kappa(parsed_reference, parsed_judge)
+        complete_reference = _reference_labels(complete_rows["reference_pref"])
+        complete_judge = _hard_preferences(complete_rows["pref"], tie_tolerance)
+        complete_correct = complete_reference == complete_judge
+        accuracy_complete = float(np.mean(complete_correct))
+        kappa = _cohen_kappa(complete_reference, complete_judge)
     else:
-        parsed_correct = np.array([], dtype=bool)
-        accuracy_parsed = kappa = float("nan")
+        complete_correct = np.array([], dtype=bool)
+        accuracy_complete = kappa = float("nan")
 
     if n_attempted:
         correct = np.zeros(n_attempted, dtype=bool)
-        correct[complete.to_numpy()] = parsed_correct
+        correct[complete.to_numpy()] = complete_correct
         accuracy_attempted = float(np.mean(correct))
         coverage = n_complete / n_attempted
     else:
@@ -169,7 +146,7 @@ def _agreement_point(
         "n_complete": n_complete,
         "coverage": coverage,
         "accuracy_attempted": accuracy_attempted,
-        "accuracy_parsed": accuracy_parsed,
+        "accuracy_complete": accuracy_complete,
         "cohen_kappa": kappa,
     }
 
@@ -188,7 +165,7 @@ def _agreement_view(
     )
     point = _agreement_point(rows, tie_tolerance)
     attempted_samples: list[float] = []
-    parsed_samples: list[float] = []
+    complete_samples: list[float] = []
     kappa_samples: list[float] = []
     if len(rows):
         for _ in range(n_bootstraps):
@@ -197,17 +174,17 @@ def _agreement_view(
             sample = rows.iloc[indices]
             values = _agreement_point(sample, tie_tolerance)
             attempted_samples.append(float(values["accuracy_attempted"]))
-            parsed_accuracy = float(values["accuracy_parsed"])
-            if math.isfinite(parsed_accuracy):
-                parsed_samples.append(parsed_accuracy)
+            complete_accuracy = float(values["accuracy_complete"])
+            if math.isfinite(complete_accuracy):
+                complete_samples.append(complete_accuracy)
             kappa = float(values["cohen_kappa"])
             if math.isfinite(kappa):
                 kappa_samples.append(kappa)
     return {
         **point,
         "accuracy_attempted_se": _sample_std(attempted_samples),
-        "accuracy_parsed_se": _sample_std(parsed_samples),
-        "accuracy_parsed_bootstraps_valid": len(parsed_samples),
+        "accuracy_complete_se": _sample_std(complete_samples),
+        "accuracy_complete_bootstraps_valid": len(complete_samples),
         "cohen_kappa_se": _sample_std(kappa_samples),
         "n_bootstraps_requested": n_bootstraps,
         "n_kappa_bootstraps_valid": len(kappa_samples),
@@ -230,7 +207,7 @@ class MetaEvalAgreementMetric:
         *,
         rng: np.random.Generator | None = None,
     ) -> dict[str, object]:
-        """Calculate attempted and parsed-complete agreement views."""
+        """Calculate attempted and complete agreement views."""
         _validate_battles(battles)
         if self.n_bootstraps and rng is None:
             raise ValueError("Bootstrapped meta-evaluation agreement requires an RNG.")
@@ -261,7 +238,7 @@ class MetaEvalAgreementMetric:
                 view["accuracy_attempted"], view["accuracy_attempted_se"]
             )
             complete = _format_estimate(
-                view["accuracy_parsed"], view["accuracy_parsed_se"]
+                view["accuracy_complete"], view["accuracy_complete_se"]
             )
             kappa = _format_estimate(view["cohen_kappa"], view["cohen_kappa_se"])
             lines.append(
@@ -322,13 +299,10 @@ def _fit_rating_bundle(
     fitting["human"] = rows["reference_pref"].to_numpy(dtype=float)
     fitting["hard"] = _hard_preferences(rows["pref"], tie_tolerance) / 2.0
     fitting["soft"] = rows["pref"].to_numpy(dtype=float)
-    try:
-        vectors = {
-            name: _centered_vector(fit_bradley_terry(fitting, pref_col=name), models)
-            for name in ("human", "hard", "soft")
-        }
-    except (TypeError, ValueError):
-        return None
+    vectors = {
+        name: _centered_vector(fit_bradley_terry(fitting, pref_col=name), models)
+        for name in ("human", "hard", "soft")
+    }
     if any(vector is None for vector in vectors.values()):
         return None
     human = vectors["human"]
@@ -381,7 +355,7 @@ class MetaEvalRankingMetric:
         if self.n_bootstraps and rng is None:
             raise ValueError("Bootstrapped meta-evaluation ranking requires an RNG.")
         models = sorted(set(battles["model_a"]) | set(battles["model_b"]))
-        complete = battles["sampled"] & battles["parse_status"].eq("complete")
+        complete = battles["sampled"] & battles["pref"].notna()
         rows = battles.loc[complete].copy()
         if not self.include_human_ties:
             human_tie = rows["reference_pref"].eq(0.5)
@@ -471,11 +445,7 @@ def _elo_gap_priority(
 def _elo_gap_vector(rows: pd.DataFrame, models: list[str]) -> np.ndarray | None:
     if comparison_components(rows, models) != [frozenset(models)]:
         return None
-    try:
-        ratings = fit_bradley_terry(rows, pref_col="pref")
-    except (TypeError, ValueError):
-        return None
-    return _centered_vector(ratings, models)
+    return _centered_vector(fit_bradley_terry(rows, pref_col="pref"), models)
 
 
 def _elo_gap_rows(
@@ -503,7 +473,7 @@ def _elo_gap_rows(
 
     for battle_count in battle_counts:
         replicate_gaps = {variant: [] for variant in _ELO_GAP_VARIANTS}
-        parsed_counts: list[int] = []
+        complete_counts: list[int] = []
         used_counts = {variant: [] for variant in _ELO_GAP_VARIANTS}
 
         for replicate in range(n_seeds):
@@ -511,15 +481,15 @@ def _elo_gap_rows(
             for focal_index, focal_model in enumerate(models):
                 selected_ids = schedules[replicate, focal_model][:battle_count]
                 selected = by_id.loc[selected_ids]
-                parsed = selected.loc[selected["parse_status"].eq("complete")].copy()
-                hard_prefs = _hard_preferences(parsed["pref"], tie_tolerance) / 2.0
-                parsed_counts.append(len(parsed))
+                complete = selected.loc[selected["pref"].notna()].copy()
+                hard_prefs = _hard_preferences(complete["pref"], tie_tolerance) / 2.0
+                complete_counts.append(len(complete))
                 human = human_by_model[focal_model]
 
                 for variant in _ELO_GAP_VARIANTS:
-                    judge = parsed[["model_a", "model_b"]].copy()
+                    judge = complete[["model_a", "model_b"]].copy()
                     judge["pref"] = (
-                        parsed["pref"].to_numpy(dtype=float)
+                        complete["pref"].to_numpy(dtype=float)
                         if variant == "soft"
                         else hard_prefs
                     )
@@ -554,8 +524,8 @@ def _elo_gap_rows(
                     "n_seeds_valid": len(valid),
                     "n_seeds_failed": n_seeds - len(valid),
                     "n_models": len(models),
-                    "mean_parsed_per_model": float(np.mean(parsed_counts))
-                    if parsed_counts
+                    "mean_complete_per_model": float(np.mean(complete_counts))
+                    if complete_counts
                     else float("nan"),
                     "mean_used_per_model": float(np.mean(used_counts[variant]))
                     if used_counts[variant]
@@ -658,7 +628,7 @@ class MetaEvalEloGapMetric:
                     f"mean_gap={gap} (sampling SE; "
                     f"valid seeds {row['n_seeds_valid']}/"
                     f"{values['n_seeds_requested']}, "
-                    f"parsed/model={row['mean_parsed_per_model']:.1f}, "
+                    f"complete/model={row['mean_complete_per_model']:.1f}, "
                     f"used/model={row['mean_used_per_model']:.1f})"
                 )
         return "\n".join(lines)

--- a/judgearena/benchmarks/meta_eval/scoring.py
+++ b/judgearena/benchmarks/meta_eval/scoring.py
@@ -515,8 +515,6 @@ def _elo_gap_rows(
                     "mean_gap": mean_gap,
                     "sampling_se": sampling_se,
                     "n_seeds_valid": len(valid),
-                    "n_seeds_failed": n_seeds - len(valid),
-                    "n_models": len(models),
                     "mean_complete_per_model": float(np.mean(complete_counts))
                     if complete_counts
                     else float("nan"),
@@ -599,7 +597,7 @@ class MetaEvalEloGapMetric:
         )
         return {
             "schedule_seed": schedule_seed,
-            "battle_counts_requested": list(self.battle_counts),
+            "n_models": len(models),
             "n_seeds_requested": self.n_seeds,
             **methods,
         }

--- a/judgearena/benchmarks/meta_eval/scoring.py
+++ b/judgearena/benchmarks/meta_eval/scoring.py
@@ -1,0 +1,438 @@
+"""Agreement and ranking metrics for judge meta-evaluation."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from numbers import Real
+
+import numpy as np
+import pandas as pd
+
+from judgearena.benchmarks.elo.rating import fit_bradley_terry
+from judgearena.benchmarks.meta_eval.sampling import comparison_components
+
+_REQUIRED_COLUMNS = {
+    "battle_id",
+    "model_a",
+    "model_b",
+    "reference_pref",
+    "pref",
+    "sampled",
+    "parse_status",
+}
+_PARSE_STATUSES = {"complete", "partial", "missing"}
+_METRIC_NAMES = ("spearman", "elo_mae")
+
+
+def _validate_configuration(n_bootstraps: int, tie_tolerance: float) -> None:
+    if type(n_bootstraps) is not int or n_bootstraps < 0:
+        raise ValueError("n_bootstraps must be a non-negative integer")
+    if (
+        isinstance(tie_tolerance, bool)
+        or not isinstance(tie_tolerance, Real)
+        or not math.isfinite(float(tie_tolerance))
+        or not 0.0 <= float(tie_tolerance) < 0.5
+    ):
+        raise ValueError("tie_tolerance must be a finite number in [0, 0.5)")
+
+
+def _validate_battles(battles: pd.DataFrame) -> None:
+    missing = sorted(_REQUIRED_COLUMNS - set(battles.columns))
+    if missing:
+        raise ValueError(f"Meta-evaluation battles are missing columns: {missing}.")
+    if battles["battle_id"].isna().any() or battles["battle_id"].duplicated().any():
+        raise ValueError("Meta-evaluation battle_id values must be present and unique.")
+    if battles[["model_a", "model_b"]].isna().any().any():
+        raise ValueError("Meta-evaluation model names must not be missing.")
+    if not all(
+        isinstance(model, str)
+        for model in pd.concat([battles["model_a"], battles["model_b"]])
+    ):
+        raise ValueError("Meta-evaluation model names must be strings.")
+    if (battles["model_a"] == battles["model_b"]).any():
+        raise ValueError("Meta-evaluation battles do not allow self-comparisons.")
+    if battles["sampled"].isna().any() or not all(
+        isinstance(value, (bool, np.bool_)) for value in battles["sampled"]
+    ):
+        raise ValueError("Meta-evaluation sampled values must be booleans.")
+
+    sampled = battles["sampled"]
+    sampled_status = battles.loc[sampled, "parse_status"]
+    invalid_statuses = set(sampled_status.dropna()) - _PARSE_STATUSES
+    if sampled_status.isna().any() or invalid_statuses:
+        raise ValueError(
+            "Sampled meta-evaluation parse_status values must be complete, partial, "
+            f"or missing; got {sorted(map(str, invalid_statuses))}."
+        )
+
+    for column, allow_missing in (("reference_pref", False), ("pref", True)):
+        invalid = []
+        for value in battles[column]:
+            if pd.isna(value):
+                if not allow_missing:
+                    invalid.append(value)
+                continue
+            if (
+                isinstance(value, bool)
+                or not isinstance(value, Real)
+                or not math.isfinite(float(value))
+                or not 0.0 <= float(value) <= 1.0
+            ):
+                invalid.append(value)
+        if invalid:
+            raise ValueError(
+                f"Meta-evaluation {column} values must be numeric preferences in "
+                "[0, 1]."
+            )
+
+    if not battles["reference_pref"].isin((0.0, 0.5, 1.0)).all():
+        raise ValueError("Meta-evaluation reference_pref values must be 0, 0.5, or 1.")
+    complete = sampled & battles["parse_status"].eq("complete")
+    if battles.loc[complete, "pref"].isna().any():
+        raise ValueError("Complete sampled battles must have a judge preference.")
+    missing = sampled & battles["parse_status"].eq("missing")
+    if battles.loc[missing, "pref"].notna().any():
+        raise ValueError("Missing sampled battles cannot have a judge preference.")
+
+
+def _reference_labels(values: pd.Series) -> np.ndarray:
+    return (values.to_numpy(dtype=float) * 2).astype(int)
+
+
+def _hard_preferences(values: pd.Series, tie_tolerance: float) -> np.ndarray:
+    numeric = values.to_numpy(dtype=float)
+    return np.where(
+        numeric < 0.5 - tie_tolerance,
+        0,
+        np.where(numeric > 0.5 + tie_tolerance, 2, 1),
+    )
+
+
+def _cohen_kappa(reference: np.ndarray, judge: np.ndarray) -> float:
+    if len(reference) == 0:
+        return float("nan")
+    observed = float(np.mean(reference == judge))
+    reference_counts = np.bincount(reference, minlength=3) / len(reference)
+    judge_counts = np.bincount(judge, minlength=3) / len(judge)
+    expected = float(np.dot(reference_counts, judge_counts))
+    if expected == 1.0:
+        return float("nan")
+    return (observed - expected) / (1.0 - expected)
+
+
+def _sample_std(values: list[float]) -> float:
+    return float(np.std(values, ddof=1)) if len(values) >= 2 else float("nan")
+
+
+def _format_estimate(value: object, se: object, *, digits: int = 3) -> str:
+    estimate = float(value)
+    uncertainty = float(se)
+    if not math.isfinite(estimate):
+        return "n/a"
+    if not math.isfinite(uncertainty):
+        return f"{estimate:.{digits}f}"
+    return f"{estimate:.{digits}f} ± {uncertainty:.{digits}f}"
+
+
+def _battle_sort_key(value: object) -> tuple[str, str]:
+    return type(value).__name__, repr(value)
+
+
+def _agreement_point(
+    rows: pd.DataFrame, tie_tolerance: float
+) -> dict[str, float | int]:
+    n_attempted = len(rows)
+    complete = rows["parse_status"].eq("complete")
+    parsed = rows.loc[complete]
+    n_complete = len(parsed)
+    if n_complete:
+        parsed_reference = _reference_labels(parsed["reference_pref"])
+        parsed_judge = _hard_preferences(parsed["pref"], tie_tolerance)
+        parsed_correct = parsed_reference == parsed_judge
+        accuracy_parsed = float(np.mean(parsed_correct))
+        kappa = _cohen_kappa(parsed_reference, parsed_judge)
+    else:
+        parsed_correct = np.array([], dtype=bool)
+        accuracy_parsed = kappa = float("nan")
+
+    if n_attempted:
+        correct = np.zeros(n_attempted, dtype=bool)
+        correct[complete.to_numpy()] = parsed_correct
+        accuracy_attempted = float(np.mean(correct))
+        coverage = n_complete / n_attempted
+    else:
+        accuracy_attempted = coverage = float("nan")
+    return {
+        "n_attempted": n_attempted,
+        "n_complete": n_complete,
+        "coverage": coverage,
+        "accuracy_attempted": accuracy_attempted,
+        "accuracy_parsed": accuracy_parsed,
+        "cohen_kappa": kappa,
+    }
+
+
+def _agreement_view(
+    rows: pd.DataFrame,
+    *,
+    tie_tolerance: float,
+    n_bootstraps: int,
+    rng: np.random.Generator | None,
+) -> dict[str, float | int]:
+    rows = (
+        rows.assign(_battle_sort=rows["battle_id"].map(_battle_sort_key))
+        .sort_values("_battle_sort", kind="stable")
+        .drop(columns="_battle_sort")
+    )
+    point = _agreement_point(rows, tie_tolerance)
+    attempted_samples: list[float] = []
+    parsed_samples: list[float] = []
+    kappa_samples: list[float] = []
+    if len(rows):
+        for _ in range(n_bootstraps):
+            assert rng is not None
+            indices = rng.integers(0, len(rows), size=len(rows))
+            sample = rows.iloc[indices]
+            values = _agreement_point(sample, tie_tolerance)
+            attempted_samples.append(float(values["accuracy_attempted"]))
+            parsed_accuracy = float(values["accuracy_parsed"])
+            if math.isfinite(parsed_accuracy):
+                parsed_samples.append(parsed_accuracy)
+            kappa = float(values["cohen_kappa"])
+            if math.isfinite(kappa):
+                kappa_samples.append(kappa)
+    return {
+        **point,
+        "accuracy_attempted_se": _sample_std(attempted_samples),
+        "accuracy_parsed_se": _sample_std(parsed_samples),
+        "accuracy_parsed_bootstraps_valid": len(parsed_samples),
+        "cohen_kappa_se": _sample_std(kappa_samples),
+        "n_bootstraps_requested": n_bootstraps,
+        "n_kappa_bootstraps_valid": len(kappa_samples),
+    }
+
+
+@dataclass(frozen=True, kw_only=True)
+class MetaEvalAgreementMetric:
+    """Configured battle-level agreement with human reference preferences."""
+
+    tie_tolerance: float = 0.01
+    n_bootstraps: int = 1000
+
+    def __post_init__(self) -> None:
+        _validate_configuration(self.n_bootstraps, self.tie_tolerance)
+
+    def calculate(
+        self,
+        battles: pd.DataFrame,
+        *,
+        rng: np.random.Generator | None = None,
+    ) -> dict[str, object]:
+        """Calculate attempted and parsed-complete agreement views."""
+        _validate_battles(battles)
+        if self.n_bootstraps and rng is None:
+            raise ValueError("Bootstrapped meta-evaluation agreement requires an RNG.")
+        attempted = battles.loc[battles["sampled"]].copy()
+        reference_is_tie = attempted["reference_pref"].eq(0.5)
+        return {
+            "all": _agreement_view(
+                attempted,
+                tie_tolerance=self.tie_tolerance,
+                n_bootstraps=self.n_bootstraps,
+                rng=rng,
+            ),
+            "no_human_ties": _agreement_view(
+                attempted.loc[~reference_is_tie],
+                tie_tolerance=self.tie_tolerance,
+                n_bootstraps=self.n_bootstraps,
+                rng=rng,
+            ),
+        }
+
+    @staticmethod
+    def render(values: dict[str, object]) -> str:
+        """Render the two agreement views."""
+        lines = ["meta_eval_agreement:"]
+        for name in ("all", "no_human_ties"):
+            view = values[name]
+            attempted = _format_estimate(
+                view["accuracy_attempted"], view["accuracy_attempted_se"]
+            )
+            complete = _format_estimate(
+                view["accuracy_parsed"], view["accuracy_parsed_se"]
+            )
+            kappa = _format_estimate(view["cohen_kappa"], view["cohen_kappa_se"])
+            lines.append(
+                f"  {name} (complete {view['n_complete']}/{view['n_attempted']}): "
+                f"accuracy={attempted}, complete_accuracy={complete}, "
+                f"complete_kappa={kappa}, complete_coverage={view['coverage']:.3f}"
+            )
+        return "\n".join(lines)
+
+
+def _unavailable_ranking(
+    *, n_battles: int, n_models: int, n_bootstraps: int
+) -> dict[str, object]:
+    unavailable = {
+        "spearman": float("nan"),
+        "spearman_se": float("nan"),
+        "spearman_bootstraps_valid": 0,
+        "elo_mae": float("nan"),
+        "elo_mae_se": float("nan"),
+        "elo_mae_bootstraps_valid": 0,
+    }
+    return {
+        "n_battles": n_battles,
+        "n_models": n_models,
+        "n_bootstraps_requested": n_bootstraps,
+        "n_bootstraps_valid": 0,
+        "hard": dict(unavailable),
+        "soft": dict(unavailable),
+    }
+
+
+def _centered_vector(ratings: dict[str, float], models: list[str]) -> np.ndarray | None:
+    if set(ratings) != set(models):
+        return None
+    vector = np.asarray([ratings[model] for model in models], dtype=float)
+    if not np.isfinite(vector).all():
+        return None
+    return vector - vector.mean()
+
+
+def _ranking_values(reference: np.ndarray, judge: np.ndarray) -> dict[str, float]:
+    if len(np.unique(reference)) < 2 or len(np.unique(judge)) < 2:
+        spearman = float("nan")
+    else:
+        reference_ranks = pd.Series(reference).rank(method="average").to_numpy()
+        judge_ranks = pd.Series(judge).rank(method="average").to_numpy()
+        spearman = float(np.corrcoef(reference_ranks, judge_ranks)[0, 1])
+    return {
+        "spearman": spearman,
+        "elo_mae": float(np.mean(np.abs(reference - judge))),
+    }
+
+
+def _fit_rating_bundle(
+    rows: pd.DataFrame, models: list[str], tie_tolerance: float
+) -> dict[str, dict[str, float]] | None:
+    fitting = rows[["model_a", "model_b"]].copy()
+    fitting["human"] = rows["reference_pref"].to_numpy(dtype=float)
+    fitting["hard"] = _hard_preferences(rows["pref"], tie_tolerance) / 2.0
+    fitting["soft"] = rows["pref"].to_numpy(dtype=float)
+    try:
+        vectors = {
+            name: _centered_vector(fit_bradley_terry(fitting, pref_col=name), models)
+            for name in ("human", "hard", "soft")
+        }
+    except (TypeError, ValueError):
+        return None
+    if any(vector is None for vector in vectors.values()):
+        return None
+    human = vectors["human"]
+    assert human is not None
+    return {
+        name: _ranking_values(human, vector)
+        for name, vector in (("hard", vectors["hard"]), ("soft", vectors["soft"]))
+        if vector is not None
+    }
+
+
+def _pair_stratified_sample(
+    rows: pd.DataFrame, rng: np.random.Generator
+) -> pd.DataFrame:
+    working = rows.assign(
+        _pair=[
+            tuple(sorted(pair))
+            for pair in zip(rows["model_a"], rows["model_b"], strict=True)
+        ],
+        _battle_sort=rows["battle_id"].map(_battle_sort_key),
+    ).sort_values(["_pair", "_battle_sort"], kind="stable")
+    parts = []
+    for _, stratum in working.groupby("_pair", sort=True):
+        indices = rng.integers(0, len(stratum), size=len(stratum))
+        parts.append(stratum.iloc[indices])
+    return pd.concat(parts, ignore_index=True).drop(columns=["_pair", "_battle_sort"])
+
+
+@dataclass(frozen=True, kw_only=True)
+class MetaEvalRankingMetric:
+    """Configured hard and soft Bradley-Terry agreement with human rankings."""
+
+    tie_tolerance: float = 0.01
+    include_human_ties: bool = False
+    n_bootstraps: int = 1000
+
+    def __post_init__(self) -> None:
+        _validate_configuration(self.n_bootstraps, self.tie_tolerance)
+        if type(self.include_human_ties) is not bool:
+            raise TypeError("include_human_ties must be a boolean")
+
+    def calculate(
+        self,
+        battles: pd.DataFrame,
+        *,
+        rng: np.random.Generator | None = None,
+    ) -> dict[str, object]:
+        """Fit and bootstrap human, hard-judge, and soft-judge rankings."""
+        _validate_battles(battles)
+        if self.n_bootstraps and rng is None:
+            raise ValueError("Bootstrapped meta-evaluation ranking requires an RNG.")
+        models = sorted(set(battles["model_a"]) | set(battles["model_b"]))
+        complete = battles["sampled"] & battles["parse_status"].eq("complete")
+        rows = battles.loc[complete].copy()
+        if not self.include_human_ties:
+            human_tie = rows["reference_pref"].eq(0.5)
+            rows = rows.loc[~human_tie]
+
+        unavailable = _unavailable_ranking(
+            n_battles=len(rows),
+            n_models=len(models),
+            n_bootstraps=self.n_bootstraps,
+        )
+        if len(models) < 3 or comparison_components(rows, models) != [
+            frozenset(models)
+        ]:
+            return unavailable
+        point = _fit_rating_bundle(rows, models, self.tie_tolerance)
+        if point is None:
+            return unavailable
+
+        samples: list[dict[str, dict[str, float]]] = []
+        for _ in range(self.n_bootstraps):
+            assert rng is not None
+            sample = _pair_stratified_sample(rows, rng)
+            fitted = _fit_rating_bundle(sample, models, self.tie_tolerance)
+            if fitted is not None:
+                samples.append(fitted)
+
+        result = unavailable
+        result["n_bootstraps_valid"] = len(samples)
+        for kind in ("hard", "soft"):
+            result[kind] = dict(point[kind])
+            for metric in _METRIC_NAMES:
+                valid = [
+                    sample[kind][metric]
+                    for sample in samples
+                    if math.isfinite(sample[kind][metric])
+                ]
+                result[kind][f"{metric}_se"] = _sample_std(valid)
+                result[kind][f"{metric}_bootstraps_valid"] = len(valid)
+        return result
+
+    @staticmethod
+    def render(values: dict[str, object]) -> str:
+        """Render hard and soft ranking summaries."""
+        lines = [
+            "meta_eval_ranking: "
+            f"{values['n_battles']} battles, {values['n_models']} models"
+        ]
+        for name in ("hard", "soft"):
+            ranking = values[name]
+            spearman = _format_estimate(ranking["spearman"], ranking["spearman_se"])
+            elo_mae = _format_estimate(
+                ranking["elo_mae"], ranking["elo_mae_se"], digits=1
+            )
+            lines.append(f"  {name}: spearman={spearman}, elo_mae={elo_mae}")
+        return "\n".join(lines)

--- a/judgearena/benchmarks/meta_eval/scoring.py
+++ b/judgearena/benchmarks/meta_eval/scoring.py
@@ -406,7 +406,7 @@ class MetaEvalRankingMetric:
         return "\n".join(lines)
 
 
-_ELO_GAP_METHODS = ("hard", "soft", "hard_no_judge_ties")
+_ELO_GAP_METHODS = ("hard", "soft")
 
 
 def _validate_elo_gap_configuration(
@@ -486,8 +486,6 @@ def _elo_gap_rows(
                         if variant == "soft"
                         else hard_prefs
                     )
-                    if variant == "hard_no_judge_ties":
-                        judge = judge.loc[judge["pref"].ne(0.5)]
                     used_counts[variant].append(len(judge))
 
                     hybrid = pd.concat([human, judge], ignore_index=True)
@@ -546,7 +544,7 @@ class MetaEvalEloGapMetric:
         *,
         rng: np.random.Generator | None = None,
     ) -> dict[str, object]:
-        """Calculate the hard, soft, and judge-tie-excluded Elo-gap methods."""
+        """Calculate hard and soft Elo gaps, retaining ties in both methods."""
         _validate_battles(battles)
         if rng is None:
             raise ValueError("Meta-evaluation Elo gap requires an RNG.")

--- a/judgearena/benchmarks/meta_eval/scoring.py
+++ b/judgearena/benchmarks/meta_eval/scoring.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import hashlib
 import math
 from dataclasses import dataclass
 from numbers import Real
@@ -79,10 +78,6 @@ def _validate_battles(battles: pd.DataFrame) -> None:
         )
 
 
-def _reference_labels(values: pd.Series) -> np.ndarray:
-    return (values.to_numpy(dtype=float) * 2).astype(int)
-
-
 def _hard_preferences(values: pd.Series, tie_tolerance: float) -> np.ndarray:
     numeric = values.to_numpy(dtype=float)
     return np.where(
@@ -117,80 +112,6 @@ def _battle_sort_key(value: object) -> tuple[str, str]:
     return type(value).__name__, repr(value)
 
 
-def _agreement_point(
-    rows: pd.DataFrame, tie_tolerance: float
-) -> dict[str, float | int]:
-    n_attempted = len(rows)
-    complete = rows["pref"].notna()
-    complete_rows = rows.loc[complete]
-    n_complete = len(complete_rows)
-    if n_complete:
-        complete_reference = _reference_labels(complete_rows["reference_pref"])
-        complete_judge = _hard_preferences(complete_rows["pref"], tie_tolerance)
-        complete_correct = complete_reference == complete_judge
-        accuracy_complete = float(np.mean(complete_correct))
-        kappa = _cohen_kappa(complete_reference, complete_judge)
-    else:
-        complete_correct = np.array([], dtype=bool)
-        accuracy_complete = kappa = float("nan")
-
-    if n_attempted:
-        correct = np.zeros(n_attempted, dtype=bool)
-        correct[complete.to_numpy()] = complete_correct
-        accuracy_attempted = float(np.mean(correct))
-        coverage = n_complete / n_attempted
-    else:
-        accuracy_attempted = coverage = float("nan")
-    return {
-        "n_attempted": n_attempted,
-        "n_complete": n_complete,
-        "coverage": coverage,
-        "accuracy_attempted": accuracy_attempted,
-        "accuracy_complete": accuracy_complete,
-        "cohen_kappa": kappa,
-    }
-
-
-def _agreement_view(
-    rows: pd.DataFrame,
-    *,
-    tie_tolerance: float,
-    n_bootstraps: int,
-    rng: np.random.Generator | None,
-) -> dict[str, float | int]:
-    rows = (
-        rows.assign(_battle_sort=rows["battle_id"].map(_battle_sort_key))
-        .sort_values("_battle_sort", kind="stable")
-        .drop(columns="_battle_sort")
-    )
-    point = _agreement_point(rows, tie_tolerance)
-    attempted_samples: list[float] = []
-    complete_samples: list[float] = []
-    kappa_samples: list[float] = []
-    if len(rows):
-        for _ in range(n_bootstraps):
-            assert rng is not None
-            indices = rng.integers(0, len(rows), size=len(rows))
-            sample = rows.iloc[indices]
-            values = _agreement_point(sample, tie_tolerance)
-            attempted_samples.append(float(values["accuracy_attempted"]))
-            complete_accuracy = float(values["accuracy_complete"])
-            if math.isfinite(complete_accuracy):
-                complete_samples.append(complete_accuracy)
-            kappa = float(values["cohen_kappa"])
-            if math.isfinite(kappa):
-                kappa_samples.append(kappa)
-    return {
-        **point,
-        "accuracy_attempted_se": _sample_std(attempted_samples),
-        "accuracy_complete_se": _sample_std(complete_samples),
-        "accuracy_complete_bootstraps_valid": len(complete_samples),
-        "cohen_kappa_se": _sample_std(kappa_samples),
-        "n_bootstraps_requested": n_bootstraps,
-        "n_kappa_bootstraps_valid": len(kappa_samples),
-    }
-
-
 @dataclass(frozen=True, kw_only=True)
 class MetaEvalAgreementMetric:
     """Configured battle-level agreement with human reference preferences."""
@@ -214,18 +135,78 @@ class MetaEvalAgreementMetric:
         attempted = battles.loc[battles["sampled"]].copy()
         reference_is_tie = attempted["reference_pref"].eq(0.5)
         return {
-            "all": _agreement_view(
-                attempted,
-                tie_tolerance=self.tie_tolerance,
-                n_bootstraps=self.n_bootstraps,
-                rng=rng,
+            "all": self._agreement_view(attempted, rng),
+            "no_human_ties": self._agreement_view(
+                attempted.loc[~reference_is_tie], rng
             ),
-            "no_human_ties": _agreement_view(
-                attempted.loc[~reference_is_tie],
-                tie_tolerance=self.tie_tolerance,
-                n_bootstraps=self.n_bootstraps,
-                rng=rng,
-            ),
+        }
+
+    def _agreement_point(self, rows: pd.DataFrame) -> dict[str, float | int]:
+        n_attempted = len(rows)
+        complete = rows["pref"].notna()
+        complete_rows = rows.loc[complete]
+        n_complete = len(complete_rows)
+        if n_complete:
+            complete_reference = (
+                complete_rows["reference_pref"].to_numpy(dtype=float) * 2
+            ).astype(int)
+            complete_judge = _hard_preferences(
+                complete_rows["pref"], self.tie_tolerance
+            )
+            n_correct = int(np.count_nonzero(complete_reference == complete_judge))
+            accuracy_complete = n_correct / n_complete
+            kappa = _cohen_kappa(complete_reference, complete_judge)
+        else:
+            n_correct = 0
+            accuracy_complete = kappa = float("nan")
+
+        if n_attempted:
+            accuracy_attempted = n_correct / n_attempted
+            coverage = n_complete / n_attempted
+        else:
+            accuracy_attempted = coverage = float("nan")
+        return {
+            "n_attempted": n_attempted,
+            "n_complete": n_complete,
+            "coverage": coverage,
+            "accuracy_attempted": accuracy_attempted,
+            "accuracy_complete": accuracy_complete,
+            "cohen_kappa": kappa,
+        }
+
+    def _agreement_view(
+        self, rows: pd.DataFrame, rng: np.random.Generator | None
+    ) -> dict[str, float | int]:
+        rows = (
+            rows.assign(_battle_sort=rows["battle_id"].map(_battle_sort_key))
+            .sort_values("_battle_sort", kind="stable")
+            .drop(columns="_battle_sort")
+        )
+        point = self._agreement_point(rows)
+        attempted_samples: list[float] = []
+        complete_samples: list[float] = []
+        kappa_samples: list[float] = []
+        if len(rows):
+            for _ in range(self.n_bootstraps):
+                assert rng is not None
+                indices = rng.integers(0, len(rows), size=len(rows))
+                sample = rows.iloc[indices]
+                values = self._agreement_point(sample)
+                attempted_samples.append(float(values["accuracy_attempted"]))
+                complete_accuracy = float(values["accuracy_complete"])
+                if math.isfinite(complete_accuracy):
+                    complete_samples.append(complete_accuracy)
+                kappa = float(values["cohen_kappa"])
+                if math.isfinite(kappa):
+                    kappa_samples.append(kappa)
+        return {
+            **point,
+            "accuracy_attempted_se": _sample_std(attempted_samples),
+            "accuracy_complete_se": _sample_std(complete_samples),
+            "accuracy_complete_bootstraps_valid": len(complete_samples),
+            "cohen_kappa_se": _sample_std(kappa_samples),
+            "n_bootstraps_requested": self.n_bootstraps,
+            "n_kappa_bootstraps_valid": len(kappa_samples),
         }
 
     @staticmethod
@@ -290,31 +271,7 @@ def _ranking_values(reference: np.ndarray, judge: np.ndarray) -> dict[str, float
     }
 
 
-def _fit_rating_bundle(
-    rows: pd.DataFrame, models: list[str], tie_tolerance: float
-) -> dict[str, dict[str, float]] | None:
-    fitting = rows[["model_a", "model_b"]].copy()
-    fitting["human"] = rows["reference_pref"].to_numpy(dtype=float)
-    fitting["hard"] = _hard_preferences(rows["pref"], tie_tolerance) / 2.0
-    fitting["soft"] = rows["pref"].to_numpy(dtype=float)
-    vectors = {
-        name: _centered_vector(fit_bradley_terry(fitting, pref_col=name), models)
-        for name in ("human", "hard", "soft")
-    }
-    if any(vector is None for vector in vectors.values()):
-        return None
-    human = vectors["human"]
-    assert human is not None
-    return {
-        name: _ranking_values(human, vector)
-        for name, vector in (("hard", vectors["hard"]), ("soft", vectors["soft"]))
-        if vector is not None
-    }
-
-
-def _pair_stratified_sample(
-    rows: pd.DataFrame, rng: np.random.Generator
-) -> pd.DataFrame:
+def _pair_strata(rows: pd.DataFrame) -> list[pd.DataFrame]:
     working = rows.assign(
         _pair=[
             tuple(sorted(pair))
@@ -322,11 +279,10 @@ def _pair_stratified_sample(
         ],
         _battle_sort=rows["battle_id"].map(_battle_sort_key),
     ).sort_values(["_pair", "_battle_sort"], kind="stable")
-    parts = []
-    for _, stratum in working.groupby("_pair", sort=True):
-        indices = rng.integers(0, len(stratum), size=len(stratum))
-        parts.append(stratum.iloc[indices])
-    return pd.concat(parts, ignore_index=True).drop(columns=["_pair", "_battle_sort"])
+    return [
+        stratum.drop(columns=["_pair", "_battle_sort"])
+        for _, stratum in working.groupby("_pair", sort=True)
+    ]
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -366,15 +322,22 @@ class MetaEvalRankingMetric:
         )
         if comparison_components(rows, models) != [frozenset(models)]:
             return unavailable
-        point = _fit_rating_bundle(rows, models, self.tie_tolerance)
+        point = self._fit_rating_bundle(rows, models)
         if point is None:
             return unavailable
 
+        strata = _pair_strata(rows) if self.n_bootstraps else []
         samples: list[dict[str, dict[str, float]]] = []
         for _ in range(self.n_bootstraps):
             assert rng is not None
-            sample = _pair_stratified_sample(rows, rng)
-            fitted = _fit_rating_bundle(sample, models, self.tie_tolerance)
+            sample = pd.concat(
+                [
+                    stratum.iloc[rng.integers(0, len(stratum), size=len(stratum))]
+                    for stratum in strata
+                ],
+                ignore_index=True,
+            )
+            fitted = self._fit_rating_bundle(sample, models)
             if fitted is not None:
                 samples.append(fitted)
 
@@ -391,6 +354,24 @@ class MetaEvalRankingMetric:
                 result[kind][f"{metric}_se"] = _sample_std(valid)
                 result[kind][f"{metric}_bootstraps_valid"] = len(valid)
         return result
+
+    def _fit_rating_bundle(
+        self, rows: pd.DataFrame, models: list[str]
+    ) -> dict[str, dict[str, float]] | None:
+        fitting = rows[["model_a", "model_b"]].copy()
+        fitting["human"] = rows["reference_pref"].to_numpy(dtype=float)
+        fitting["hard"] = _hard_preferences(rows["pref"], self.tie_tolerance) / 2.0
+        fitting["soft"] = rows["pref"].to_numpy(dtype=float)
+        vectors = {
+            name: _centered_vector(fit_bradley_terry(fitting, pref_col=name), models)
+            for name in ("human", "hard", "soft")
+        }
+        if any(vector is None for vector in vectors.values()):
+            return None
+        return {
+            name: _ranking_values(vectors["human"], vectors[name])
+            for name in ("hard", "soft")
+        }
 
     @staticmethod
     def render(values: dict[str, object]) -> str:
@@ -412,119 +393,10 @@ class MetaEvalRankingMetric:
 _ELO_GAP_METHODS = ("hard", "soft")
 
 
-def _validate_elo_gap_configuration(
-    battle_counts: object, n_seeds: int, tie_tolerance: float
-) -> tuple[int, ...]:
-    _validate_configuration(0, tie_tolerance)
-    if not isinstance(battle_counts, (list, tuple)) or not battle_counts:
-        raise ValueError("battle_counts must be a non-empty ordered sequence")
-    if any(type(count) is not int or count <= 0 for count in battle_counts):
-        raise ValueError("battle_counts values must be positive integers")
-    counts = tuple(battle_counts)
-    if any(left >= right for left, right in zip(counts, counts[1:], strict=False)):
-        raise ValueError("battle_counts values must be unique and ordered ascending")
-    if type(n_seeds) is not int or n_seeds <= 0:
-        raise ValueError("n_seeds must be a positive integer")
-    return counts
-
-
-def _elo_gap_priority(
-    schedule_seed: int, replicate: int, focal_model: str, battle_id: object
-) -> bytes:
-    battle_type, battle_value = _battle_sort_key(battle_id)
-    payload = (
-        f"{schedule_seed}\0{replicate}\0{focal_model}\0{battle_type}\0{battle_value}"
-    )
-    return hashlib.sha256(payload.encode()).digest()
-
-
 def _elo_gap_vector(rows: pd.DataFrame, models: list[str]) -> np.ndarray | None:
     if comparison_components(rows, models) != [frozenset(models)]:
         return None
     return _centered_vector(fit_bradley_terry(rows, pref_col="pref"), models)
-
-
-def _elo_gap_rows(
-    *,
-    models: list[str],
-    battles: pd.DataFrame,
-    schedules: dict[tuple[int, str], list[object]],
-    reference: np.ndarray | None,
-    battle_counts: tuple[int, ...],
-    n_seeds: int,
-    tie_tolerance: float,
-) -> dict[str, list[dict[str, float | int]]]:
-    results: dict[str, list[dict[str, float | int]]] = {
-        variant: [] for variant in _ELO_GAP_METHODS
-    }
-    by_id = battles.set_index("battle_id", drop=False)
-    human_by_model = {}
-    for focal_model in models:
-        incident = battles["model_a"].eq(focal_model) | battles["model_b"].eq(
-            focal_model
-        )
-        human_by_model[focal_model] = battles.loc[
-            ~incident, ["model_a", "model_b", "reference_pref"]
-        ].rename(columns={"reference_pref": "pref"})
-
-    for battle_count in battle_counts:
-        replicate_gaps = {variant: [] for variant in _ELO_GAP_METHODS}
-        complete_counts: list[int] = []
-        used_counts = {variant: [] for variant in _ELO_GAP_METHODS}
-
-        for replicate in range(n_seeds):
-            gaps = {variant: [] for variant in _ELO_GAP_METHODS}
-            for focal_index, focal_model in enumerate(models):
-                selected_ids = schedules[replicate, focal_model][:battle_count]
-                selected = by_id.loc[selected_ids]
-                complete = selected.loc[selected["pref"].notna()].copy()
-                hard_prefs = _hard_preferences(complete["pref"], tie_tolerance) / 2.0
-                complete_counts.append(len(complete))
-                human = human_by_model[focal_model]
-
-                for variant in _ELO_GAP_METHODS:
-                    judge = complete[["model_a", "model_b"]].copy()
-                    judge["pref"] = (
-                        complete["pref"].to_numpy(dtype=float)
-                        if variant == "soft"
-                        else hard_prefs
-                    )
-                    used_counts[variant].append(len(judge))
-
-                    hybrid = pd.concat([human, judge], ignore_index=True)
-                    fitted = _elo_gap_vector(hybrid, models)
-                    if reference is not None and fitted is not None:
-                        gaps[variant].append(
-                            abs(fitted[focal_index] - reference[focal_index])
-                        )
-
-            for variant in _ELO_GAP_METHODS:
-                if len(gaps[variant]) == len(models) and models:
-                    replicate_gaps[variant].append(float(np.mean(gaps[variant])))
-
-        for variant in _ELO_GAP_METHODS:
-            valid = replicate_gaps[variant]
-            mean_gap = float(np.mean(valid)) if valid else float("nan")
-            sampling_se = (
-                float(np.std(valid, ddof=1) / np.sqrt(len(valid)))
-                if len(valid) >= 2
-                else float("nan")
-            )
-            results[variant].append(
-                {
-                    "attempted_battles_per_model": battle_count,
-                    "mean_gap": mean_gap,
-                    "sampling_se": sampling_se,
-                    "n_seeds_valid": len(valid),
-                    "mean_complete_per_model": float(np.mean(complete_counts))
-                    if complete_counts
-                    else float("nan"),
-                    "mean_used_per_model": float(np.mean(used_counts[variant]))
-                    if used_counts[variant]
-                    else float("nan"),
-                }
-            )
-    return results
 
 
 @dataclass(frozen=True, kw_only=True)
@@ -536,9 +408,19 @@ class MetaEvalEloGapMetric:
     tie_tolerance: float
 
     def __post_init__(self) -> None:
-        counts = _validate_elo_gap_configuration(
-            self.battle_counts, self.n_seeds, self.tie_tolerance
-        )
+        _validate_configuration(0, self.tie_tolerance)
+        battle_counts = self.battle_counts
+        if not isinstance(battle_counts, (list, tuple)) or not battle_counts:
+            raise ValueError("battle_counts must be a non-empty ordered sequence")
+        if any(type(count) is not int or count <= 0 for count in battle_counts):
+            raise ValueError("battle_counts values must be positive integers")
+        counts = tuple(battle_counts)
+        if any(left >= right for left, right in zip(counts, counts[1:], strict=False)):
+            raise ValueError(
+                "battle_counts values must be unique and ordered ascending"
+            )
+        if type(self.n_seeds) is not int or self.n_seeds <= 0:
+            raise ValueError("n_seeds must be a positive integer")
         object.__setattr__(self, "battle_counts", counts)
 
     def calculate(
@@ -560,7 +442,7 @@ class MetaEvalEloGapMetric:
         for model in models:
             incident = attempted["model_a"].eq(model) | attempted["model_b"].eq(model)
             battle_ids = attempted.loc[incident, "battle_id"].tolist()
-            attempted_ids_by_model[model] = battle_ids
+            attempted_ids_by_model[model] = sorted(battle_ids, key=_battle_sort_key)
             if len(battle_ids) < maximum:
                 shortfalls[model] = len(battle_ids)
         if shortfalls:
@@ -573,38 +455,103 @@ class MetaEvalEloGapMetric:
             return {}
 
         schedule_seed = int(rng.integers(0, 2**63))
+        schedule_rng = np.random.default_rng(schedule_seed)
         schedules: dict[tuple[int, str], list[object]] = {}
+        # Each budget takes a prefix of the same shuffle, shared by hard and soft.
         for replicate in range(self.n_seeds):
-            for focal_model in models:
-                schedules[replicate, focal_model] = sorted(
-                    attempted_ids_by_model[focal_model],
-                    key=lambda battle_id: (
-                        _elo_gap_priority(
-                            schedule_seed, replicate, focal_model, battle_id
-                        ),
-                        _battle_sort_key(battle_id),
-                    ),
-                )
+            for model, battle_ids in attempted_ids_by_model.items():
+                order = schedule_rng.permutation(len(battle_ids))
+                schedules[replicate, model] = [battle_ids[index] for index in order]
 
         human = battles[["model_a", "model_b", "reference_pref"]].rename(
             columns={"reference_pref": "pref"}
         )
         reference = _elo_gap_vector(human, models)
-        methods = _elo_gap_rows(
-            models=models,
-            battles=battles,
-            schedules=schedules,
-            reference=reference,
-            battle_counts=self.battle_counts,
-            n_seeds=self.n_seeds,
-            tie_tolerance=self.tie_tolerance,
-        )
+        methods = self._elo_gap_rows(battles, models, schedules, reference)
         return {
             "schedule_seed": schedule_seed,
             "n_models": len(models),
             "n_seeds_requested": self.n_seeds,
             **methods,
         }
+
+    def _elo_gap_rows(
+        self,
+        battles: pd.DataFrame,
+        models: list[str],
+        schedules: dict[tuple[int, str], list[object]],
+        reference: np.ndarray | None,
+    ) -> dict[str, list[dict[str, float | int]]]:
+        results: dict[str, list[dict[str, float | int]]] = {
+            variant: [] for variant in _ELO_GAP_METHODS
+        }
+        by_id = battles.set_index("battle_id", drop=False)
+        human_by_model = {}
+        for focal_model in models:
+            incident = battles["model_a"].eq(focal_model) | battles["model_b"].eq(
+                focal_model
+            )
+            human_by_model[focal_model] = battles.loc[
+                ~incident, ["model_a", "model_b", "reference_pref"]
+            ].rename(columns={"reference_pref": "pref"})
+
+        for battle_count in self.battle_counts:
+            replicate_gaps = {variant: [] for variant in _ELO_GAP_METHODS}
+            complete_counts: list[int] = []
+
+            for replicate in range(self.n_seeds):
+                gaps = {variant: [] for variant in _ELO_GAP_METHODS}
+                for focal_index, focal_model in enumerate(models):
+                    selected_ids = schedules[replicate, focal_model][:battle_count]
+                    selected = by_id.loc[selected_ids]
+                    complete = selected.loc[selected["pref"].notna()].copy()
+                    hard_prefs = (
+                        _hard_preferences(complete["pref"], self.tie_tolerance) / 2.0
+                    )
+                    complete_counts.append(len(complete))
+                    human = human_by_model[focal_model]
+
+                    for variant in _ELO_GAP_METHODS:
+                        judge = complete[["model_a", "model_b"]].copy()
+                        judge["pref"] = (
+                            complete["pref"].to_numpy(dtype=float)
+                            if variant == "soft"
+                            else hard_prefs
+                        )
+
+                        hybrid = pd.concat([human, judge], ignore_index=True)
+                        fitted = _elo_gap_vector(hybrid, models)
+                        if reference is not None and fitted is not None:
+                            gaps[variant].append(
+                                abs(fitted[focal_index] - reference[focal_index])
+                            )
+
+                for variant in _ELO_GAP_METHODS:
+                    if len(gaps[variant]) == len(models) and models:
+                        replicate_gaps[variant].append(float(np.mean(gaps[variant])))
+
+            mean_complete = (
+                float(np.mean(complete_counts)) if complete_counts else float("nan")
+            )
+            for variant in _ELO_GAP_METHODS:
+                valid = replicate_gaps[variant]
+                mean_gap = float(np.mean(valid)) if valid else float("nan")
+                sampling_se = (
+                    float(np.std(valid, ddof=1) / np.sqrt(len(valid)))
+                    if len(valid) >= 2
+                    else float("nan")
+                )
+                results[variant].append(
+                    {
+                        "attempted_battles_per_model": battle_count,
+                        "mean_gap": mean_gap,
+                        "sampling_se": sampling_se,
+                        "n_seeds_valid": len(valid),
+                        "mean_complete_per_model": mean_complete,
+                        "mean_used_per_model": mean_complete,
+                    }
+                )
+        return results
 
     @staticmethod
     def render(values: dict[str, object]) -> str:

--- a/judgearena/benchmarks/meta_eval/scoring.py
+++ b/judgearena/benchmarks/meta_eval/scoring.py
@@ -9,6 +9,8 @@ from numbers import Real
 
 import numpy as np
 import pandas as pd
+from scipy.stats import spearmanr
+from sklearn.metrics import cohen_kappa_score
 
 from judgearena.benchmarks.elo.rating import fit_bradley_terry
 from judgearena.benchmarks.meta_eval.sampling import comparison_components
@@ -88,15 +90,10 @@ def _hard_preferences(values: pd.Series, tie_tolerance: float) -> np.ndarray:
 
 
 def _cohen_kappa(reference: np.ndarray, judge: np.ndarray) -> float:
-    if len(reference) == 0:
+    labels = np.unique(np.concatenate((reference, judge)))
+    if len(labels) < 2:
         return float("nan")
-    observed = float(np.mean(reference == judge))
-    reference_counts = np.bincount(reference, minlength=3) / len(reference)
-    judge_counts = np.bincount(judge, minlength=3) / len(judge)
-    expected = float(np.dot(reference_counts, judge_counts))
-    if expected == 1.0:
-        return float("nan")
-    return (observed - expected) / (1.0 - expected)
+    return float(cohen_kappa_score(reference, judge, labels=[0, 1, 2]))
 
 
 def _sample_std(values: list[float]) -> float:
@@ -195,8 +192,8 @@ def _agreement_view(
 class MetaEvalAgreementMetric:
     """Configured battle-level agreement with human reference preferences."""
 
-    tie_tolerance: float = 0.01
-    n_bootstraps: int = 1000
+    tie_tolerance: float
+    n_bootstraps: int
 
     def __post_init__(self) -> None:
         _validate_configuration(self.n_bootstraps, self.tie_tolerance)
@@ -283,9 +280,7 @@ def _ranking_values(reference: np.ndarray, judge: np.ndarray) -> dict[str, float
     if len(np.unique(reference)) < 2 or len(np.unique(judge)) < 2:
         spearman = float("nan")
     else:
-        reference_ranks = pd.Series(reference).rank(method="average").to_numpy()
-        judge_ranks = pd.Series(judge).rank(method="average").to_numpy()
-        spearman = float(np.corrcoef(reference_ranks, judge_ranks)[0, 1])
+        spearman = float(spearmanr(reference, judge).statistic)
     return {
         "spearman": spearman,
         "elo_mae": float(np.mean(np.abs(reference - judge))),
@@ -335,9 +330,9 @@ def _pair_stratified_sample(
 class MetaEvalRankingMetric:
     """Configured hard and soft Bradley-Terry agreement with human rankings."""
 
-    tie_tolerance: float = 0.01
-    include_human_ties: bool = False
-    n_bootstraps: int = 1000
+    tie_tolerance: float
+    include_human_ties: bool
+    n_bootstraps: int
 
     def __post_init__(self) -> None:
         _validate_configuration(self.n_bootstraps, self.tie_tolerance)
@@ -366,9 +361,7 @@ class MetaEvalRankingMetric:
             n_models=len(models),
             n_bootstraps=self.n_bootstraps,
         )
-        if len(models) < 3 or comparison_components(rows, models) != [
-            frozenset(models)
-        ]:
+        if comparison_components(rows, models) != [frozenset(models)]:
             return unavailable
         point = _fit_rating_bundle(rows, models, self.tie_tolerance)
         if point is None:
@@ -413,7 +406,7 @@ class MetaEvalRankingMetric:
         return "\n".join(lines)
 
 
-_ELO_GAP_VARIANTS = ("hard", "soft", "hard_no_judge_ties")
+_ELO_GAP_METHODS = ("hard", "soft", "hard_no_judge_ties")
 
 
 def _validate_elo_gap_configuration(
@@ -459,7 +452,7 @@ def _elo_gap_rows(
     tie_tolerance: float,
 ) -> dict[str, list[dict[str, float | int]]]:
     results: dict[str, list[dict[str, float | int]]] = {
-        variant: [] for variant in _ELO_GAP_VARIANTS
+        variant: [] for variant in _ELO_GAP_METHODS
     }
     by_id = battles.set_index("battle_id", drop=False)
     human_by_model = {}
@@ -472,12 +465,12 @@ def _elo_gap_rows(
         ].rename(columns={"reference_pref": "pref"})
 
     for battle_count in battle_counts:
-        replicate_gaps = {variant: [] for variant in _ELO_GAP_VARIANTS}
+        replicate_gaps = {variant: [] for variant in _ELO_GAP_METHODS}
         complete_counts: list[int] = []
-        used_counts = {variant: [] for variant in _ELO_GAP_VARIANTS}
+        used_counts = {variant: [] for variant in _ELO_GAP_METHODS}
 
         for replicate in range(n_seeds):
-            gaps = {variant: [] for variant in _ELO_GAP_VARIANTS}
+            gaps = {variant: [] for variant in _ELO_GAP_METHODS}
             for focal_index, focal_model in enumerate(models):
                 selected_ids = schedules[replicate, focal_model][:battle_count]
                 selected = by_id.loc[selected_ids]
@@ -486,7 +479,7 @@ def _elo_gap_rows(
                 complete_counts.append(len(complete))
                 human = human_by_model[focal_model]
 
-                for variant in _ELO_GAP_VARIANTS:
+                for variant in _ELO_GAP_METHODS:
                     judge = complete[["model_a", "model_b"]].copy()
                     judge["pref"] = (
                         complete["pref"].to_numpy(dtype=float)
@@ -504,11 +497,11 @@ def _elo_gap_rows(
                             abs(fitted[focal_index] - reference[focal_index])
                         )
 
-            for variant in _ELO_GAP_VARIANTS:
+            for variant in _ELO_GAP_METHODS:
                 if len(gaps[variant]) == len(models) and models:
                     replicate_gaps[variant].append(float(np.mean(gaps[variant])))
 
-        for variant in _ELO_GAP_VARIANTS:
+        for variant in _ELO_GAP_METHODS:
             valid = replicate_gaps[variant]
             mean_gap = float(np.mean(valid)) if valid else float("nan")
             sampling_se = (
@@ -539,9 +532,9 @@ def _elo_gap_rows(
 class MetaEvalEloGapMetric:
     """Held-out focal-model Elo error at fixed annotation budgets."""
 
-    battle_counts: tuple[int, ...] = (10, 20, 30, 40, 50)
-    n_seeds: int = 10
-    tie_tolerance: float = 0.01
+    battle_counts: tuple[int, ...]
+    n_seeds: int
+    tie_tolerance: float
 
     def __post_init__(self) -> None:
         counts = _validate_elo_gap_configuration(
@@ -555,7 +548,7 @@ class MetaEvalEloGapMetric:
         *,
         rng: np.random.Generator | None = None,
     ) -> dict[str, object]:
-        """Calculate hard, soft, and judge-tie-excluded Elo gaps."""
+        """Calculate the hard, soft, and judge-tie-excluded Elo-gap methods."""
         _validate_battles(battles)
         if rng is None:
             raise ValueError("Meta-evaluation Elo gap requires an RNG.")
@@ -595,7 +588,7 @@ class MetaEvalEloGapMetric:
             columns={"reference_pref": "pref"}
         )
         reference = _elo_gap_vector(human, models)
-        variants = _elo_gap_rows(
+        methods = _elo_gap_rows(
             models=models,
             battles=battles,
             schedules=schedules,
@@ -608,7 +601,7 @@ class MetaEvalEloGapMetric:
             "schedule_seed": schedule_seed,
             "battle_counts_requested": list(self.battle_counts),
             "n_seeds_requested": self.n_seeds,
-            **variants,
+            **methods,
         }
 
     @staticmethod
@@ -619,7 +612,7 @@ class MetaEvalEloGapMetric:
             f"{values['n_seeds_requested']} sampling seeds "
             f"(schedule seed {values['schedule_seed']})"
         ]
-        for variant in _ELO_GAP_VARIANTS:
+        for variant in _ELO_GAP_METHODS:
             lines.append(f"  {variant}:")
             for row in values[variant]:
                 gap = _format_estimate(row["mean_gap"], row["sampling_se"], digits=1)

--- a/judgearena/benchmarks/registry.py
+++ b/judgearena/benchmarks/registry.py
@@ -45,11 +45,13 @@ class ResolvedBenchmark:
 def benchmark_adapters() -> tuple[BenchmarkAdapter, ...]:
     """Return registered benchmark implementations, specific first."""
     from judgearena.benchmarks.elo.runner import run_elo
+    from judgearena.benchmarks.meta_eval.runner import run_meta_eval
     from judgearena.benchmarks.mt_bench.runner import run_mt_bench_benchmark
     from judgearena.benchmarks.pairwise.runner import run_pairwise
 
     return (
         BenchmarkAdapter("elo", frozenset(), run_elo),
+        BenchmarkAdapter("meta_eval", frozenset(), run_meta_eval),
         BenchmarkAdapter("mt_bench", frozenset(), run_mt_bench_benchmark),
         BenchmarkAdapter("pairwise", None, run_pairwise),
     )

--- a/judgearena/benchmarks/scoring.py
+++ b/judgearena/benchmarks/scoring.py
@@ -8,6 +8,10 @@ from typing import Protocol
 import pandas as pd
 
 from judgearena.benchmarks.elo.scoring import BradleyTerryMetric
+from judgearena.benchmarks.meta_eval.scoring import (
+    MetaEvalAgreementMetric,
+    MetaEvalRankingMetric,
+)
 from judgearena.benchmarks.pairwise.scoring.alpaca_eval import (
     AlpacaEvalLengthControlledMetric,
 )
@@ -47,6 +51,8 @@ _METRIC_TYPES: dict[str, type[_Metric]] = {
     "arena_hard_v01": ArenaHardV01Metric,
     "arena_hard_v20": ArenaHardV20Metric,
     "alpaca_eval_length_controlled": AlpacaEvalLengthControlledMetric,
+    "meta_eval_agreement": MetaEvalAgreementMetric,
+    "meta_eval_ranking": MetaEvalRankingMetric,
 }
 
 ConfiguredMetrics = tuple[tuple[MetricRequest, _Metric], ...]

--- a/judgearena/benchmarks/scoring.py
+++ b/judgearena/benchmarks/scoring.py
@@ -146,9 +146,15 @@ def render_metrics(results: Mapping[str, dict[str, object]]) -> str:
     for name, result in results.items():
         metric_type = _metric_type(name)
         overall = {key: value for key, value in result.items() if key != "groups"}
-        sections.append(metric_type.render(overall))
+        sections.append(
+            metric_type.render(overall) if overall else f"{name}: unavailable"
+        )
         for field, groups in result.get("groups", {}).items():
             for group in groups:
-                rendered = metric_type.render(group["values"])
+                rendered = (
+                    metric_type.render(group["values"])
+                    if group["values"]
+                    else f"{name}: unavailable"
+                )
                 sections.append(f"{field}={group['group']}:\n{_indent(rendered)}")
     return "\n\n".join(sections)

--- a/judgearena/benchmarks/scoring.py
+++ b/judgearena/benchmarks/scoring.py
@@ -10,6 +10,7 @@ import pandas as pd
 from judgearena.benchmarks.elo.scoring import BradleyTerryMetric
 from judgearena.benchmarks.meta_eval.scoring import (
     MetaEvalAgreementMetric,
+    MetaEvalEloGapMetric,
     MetaEvalRankingMetric,
 )
 from judgearena.benchmarks.pairwise.scoring.alpaca_eval import (
@@ -52,6 +53,7 @@ _METRIC_TYPES: dict[str, type[_Metric]] = {
     "arena_hard_v20": ArenaHardV20Metric,
     "alpaca_eval_length_controlled": AlpacaEvalLengthControlledMetric,
     "meta_eval_agreement": MetaEvalAgreementMetric,
+    "meta_eval_elo_gap": MetaEvalEloGapMetric,
     "meta_eval_ranking": MetaEvalRankingMetric,
 }
 

--- a/judgearena/config.py
+++ b/judgearena/config.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Literal
 
 import yaml
-from pydantic import BaseModel, ConfigDict, Field, model_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 from pydantic_settings import (
     BaseSettings,
     CliSettingsSource,
@@ -19,7 +19,7 @@ from pydantic_settings import (
 from judgearena.benchmarks.pairwise.baselines import native_pairwise_baseline
 from judgearena.prompts.parsing import resolve_judge_parser
 from judgearena.tasks.registry import get_packaged_task
-from judgearena.tasks.schema import EloProtocol
+from judgearena.tasks.schema import EloProtocol, MetaEvalProtocol
 
 # Set by build_run_config() for the duration of RunConfig() construction.
 _ACTIVE_CONFIG_PATH: str | None = None
@@ -344,6 +344,55 @@ class EloArgs(BaseModel):
     Defaults to all. Requires ``calibrate_temperature``."""
 
 
+class MetaEvalArgs(BaseModel):
+    """Sampling and optional metric overrides for judge meta-evaluation."""
+
+    model_config = ConfigDict(use_attribute_docstrings=True)
+
+    top_models: int = Field(default=20, ge=3)
+    """Number of the arena's most-battled models to include."""
+
+    battles_per_model: int = Field(default=50, gt=0)
+    """Minimum number of sampled incident battles for each selected model."""
+
+    languages: list[str] | None = None
+    """Restrict arena battles to these language codes. Defaults to all languages."""
+
+    n_bootstraps: int | None = Field(default=None, ge=0)
+    """Override task-owned bootstrap counts for agreement and ranking metrics."""
+
+    include_human_ties: bool | None = None
+    """Override whether ranking metrics include human ties."""
+
+    elo_gap_battles: list[int] | None = None
+    """Override task-owned Elo-gap annotation budgets."""
+
+    elo_gap_seeds: int | None = Field(default=None, gt=0)
+    """Override the number of Elo-gap sampling seeds."""
+
+    @field_validator("languages")
+    @classmethod
+    def _validate_languages(cls, value: list[str] | None) -> list[str] | None:
+        if value is None:
+            return None
+        if not value or any(not isinstance(item, str) or not item for item in value):
+            raise ValueError("languages must be a non-empty list of non-empty strings")
+        if len(set(value)) != len(value):
+            raise ValueError("languages must not contain duplicates")
+        return value
+
+    @field_validator("elo_gap_battles")
+    @classmethod
+    def _validate_elo_gap_battles(cls, value: list[int] | None) -> list[int] | None:
+        if value is None:
+            return None
+        if not value or any(type(item) is not int or item <= 0 for item in value):
+            raise ValueError("elo_gap_battles must contain positive integers")
+        if any(left >= right for left, right in zip(value, value[1:], strict=False)):
+            raise ValueError("elo_gap_battles must be unique and ordered ascending")
+        return value
+
+
 class RunArgs(BaseModel):
     """Run-level settings: seed, output location, caching, and logging."""
 
@@ -396,6 +445,9 @@ class RunConfig(BaseSettings):
 
     elo: EloArgs | None = None
     """Runtime settings used only by tasks with an ELO protocol."""
+
+    meta_eval: MetaEvalArgs | None = None
+    """Runtime settings used only by tasks with a meta-evaluation protocol."""
 
     run: RunArgs = Field(default_factory=RunArgs)
     """Run-level settings (seed, output, caching, logging)."""
@@ -457,7 +509,12 @@ class RunConfig(BaseSettings):
             self.judge.top_logprobs = task_judge.default_top_logprobs
 
         is_elo = isinstance(protocol, EloProtocol)
+        is_meta_eval = isinstance(protocol, MetaEvalProtocol)
         if is_elo:
+            if self.meta_eval is not None:
+                raise ValueError(
+                    "meta_eval config is only valid for meta-evaluation tasks."
+                )
             if self.elo is None:
                 self.elo = EloArgs()
             if "soft_elo" not in self.elo.model_fields_set:
@@ -468,9 +525,28 @@ class RunConfig(BaseSettings):
                 raise ValueError("model.name is required for ELO tasks.")
             if self.model.baseline is not None:
                 raise ValueError("model.baseline is not supported for ELO tasks.")
+        elif is_meta_eval:
+            if self.elo is not None:
+                raise ValueError("elo config is only valid for ELO tasks.")
+            if self.meta_eval is None:
+                self.meta_eval = MetaEvalArgs()
+            if self.model.name is not None or self.model.baseline is not None:
+                raise ValueError(
+                    "model.name and model.baseline are not supported for "
+                    "meta-evaluation tasks."
+                )
+            if self.judge.swap_mode == "random":
+                raise ValueError(
+                    "judge.swap_mode='random' is not supported for "
+                    "meta-evaluation tasks."
+                )
         else:
             if self.elo is not None:
                 raise ValueError("elo config is only valid for ELO tasks.")
+            if self.meta_eval is not None:
+                raise ValueError(
+                    "meta_eval config is only valid for meta-evaluation tasks."
+                )
             if self.model.name is None:
                 raise ValueError("model.name is required.")
             if (

--- a/judgearena/config.py
+++ b/judgearena/config.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from typing import Literal
 
 import yaml
-from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+from pydantic import BaseModel, ConfigDict, Field, model_validator
 from pydantic_settings import (
     BaseSettings,
     CliSettingsSource,
@@ -345,9 +345,9 @@ class EloArgs(BaseModel):
 
 
 class MetaEvalArgs(BaseModel):
-    """Sampling and optional metric overrides for judge meta-evaluation."""
+    """Sampling settings for judge meta-evaluation."""
 
-    model_config = ConfigDict(use_attribute_docstrings=True)
+    model_config = ConfigDict(use_attribute_docstrings=True, extra="forbid")
 
     top_models: int = Field(default=20, ge=3)
     """Number of the arena's most-battled models to include."""
@@ -357,40 +357,6 @@ class MetaEvalArgs(BaseModel):
 
     languages: list[str] | None = None
     """Restrict arena battles to these language codes. Defaults to all languages."""
-
-    n_bootstraps: int | None = Field(default=None, ge=0)
-    """Override task-owned bootstrap counts for agreement and ranking metrics."""
-
-    include_human_ties: bool | None = None
-    """Override whether ranking metrics include human ties."""
-
-    elo_gap_battles: list[int] | None = None
-    """Override task-owned Elo-gap annotation budgets."""
-
-    elo_gap_seeds: int | None = Field(default=None, gt=0)
-    """Override the number of Elo-gap sampling seeds."""
-
-    @field_validator("languages")
-    @classmethod
-    def _validate_languages(cls, value: list[str] | None) -> list[str] | None:
-        if value is None:
-            return None
-        if not value or any(not isinstance(item, str) or not item for item in value):
-            raise ValueError("languages must be a non-empty list of non-empty strings")
-        if len(set(value)) != len(value):
-            raise ValueError("languages must not contain duplicates")
-        return value
-
-    @field_validator("elo_gap_battles")
-    @classmethod
-    def _validate_elo_gap_battles(cls, value: list[int] | None) -> list[int] | None:
-        if value is None:
-            return None
-        if not value or any(type(item) is not int or item <= 0 for item in value):
-            raise ValueError("elo_gap_battles must contain positive integers")
-        if any(left >= right for left, right in zip(value, value[1:], strict=False)):
-            raise ValueError("elo_gap_battles must be unique and ordered ascending")
-        return value
 
 
 class RunArgs(BaseModel):

--- a/judgearena/config.py
+++ b/judgearena/config.py
@@ -349,7 +349,7 @@ class MetaEvalArgs(BaseModel):
 
     model_config = ConfigDict(use_attribute_docstrings=True, extra="forbid")
 
-    top_models: int = Field(default=20, ge=3)
+    top_models: int = Field(default=20, ge=2)
     """Number of the arena's most-battled models to include."""
 
     battles_per_model: int = Field(default=50, gt=0)

--- a/judgearena/config.py
+++ b/judgearena/config.py
@@ -476,11 +476,13 @@ class RunConfig(BaseSettings):
 
         is_elo = isinstance(protocol, EloProtocol)
         is_meta_eval = isinstance(protocol, MetaEvalProtocol)
+        if self.elo is not None and not is_elo:
+            raise ValueError("elo config is only valid for ELO tasks.")
+        if self.meta_eval is not None and not is_meta_eval:
+            raise ValueError(
+                "meta_eval config is only valid for meta-evaluation tasks."
+            )
         if is_elo:
-            if self.meta_eval is not None:
-                raise ValueError(
-                    "meta_eval config is only valid for meta-evaluation tasks."
-                )
             if self.elo is None:
                 self.elo = EloArgs()
             if "soft_elo" not in self.elo.model_fields_set:
@@ -492,8 +494,6 @@ class RunConfig(BaseSettings):
             if self.model.baseline is not None:
                 raise ValueError("model.baseline is not supported for ELO tasks.")
         elif is_meta_eval:
-            if self.elo is not None:
-                raise ValueError("elo config is only valid for ELO tasks.")
             if self.meta_eval is None:
                 self.meta_eval = MetaEvalArgs()
             if self.model.name is not None or self.model.baseline is not None:
@@ -507,12 +507,6 @@ class RunConfig(BaseSettings):
                     "meta-evaluation tasks."
                 )
         else:
-            if self.elo is not None:
-                raise ValueError("elo config is only valid for ELO tasks.")
-            if self.meta_eval is not None:
-                raise ValueError(
-                    "meta_eval config is only valid for meta-evaluation tasks."
-                )
             if self.model.name is None:
                 raise ValueError("model.name is required.")
             if (

--- a/judgearena/datasets/arena_battles.py
+++ b/judgearena/datasets/arena_battles.py
@@ -1,4 +1,4 @@
-"""Dataset adapter for human preference battles used by ELO tasks."""
+"""Dataset adapter for human preference battles used by arena-backed tasks."""
 
 from __future__ import annotations
 
@@ -14,25 +14,26 @@ from judgearena.arenas_utils import (
 from judgearena.tasks.schema import (
     EloProtocol,
     HuggingFaceDatasetSource,
+    MetaEvalProtocol,
     ResolvedTaskSpec,
 )
 
 
 def _task_sources(
     task: ResolvedTaskSpec,
-) -> tuple[EloProtocol, dict[str, HuggingFaceDatasetSource]]:
+) -> tuple[EloProtocol | MetaEvalProtocol, dict[str, HuggingFaceDatasetSource]]:
     protocol = task.spec.protocol
-    if not isinstance(protocol, EloProtocol):
-        raise ValueError(f"Task {task.task!r} does not define an ELO protocol.")
+    if not isinstance(protocol, (EloProtocol, MetaEvalProtocol)):
+        raise ValueError(f"Task {task.task!r} does not define an arena protocol.")
     if protocol.arena not in {*KNOWN_ARENAS, "LMArena"}:
-        raise ValueError(f"Unsupported ELO arena {protocol.arena!r}.")
+        raise ValueError(f"Unsupported arena {protocol.arena!r}.")
 
     sources: dict[str, HuggingFaceDatasetSource] = {}
     for source in task.spec.dataset.sources.values():
         if not isinstance(source, HuggingFaceDatasetSource):
-            raise ValueError("ELO arena sources must be Hugging Face datasets.")
+            raise ValueError("Arena sources must be Hugging Face datasets.")
         if source.repo_id in sources:
-            raise ValueError(f"Duplicate ELO arena source {source.repo_id!r}.")
+            raise ValueError(f"Duplicate arena source {source.repo_id!r}.")
         sources[source.repo_id] = source
     return protocol, sources
 

--- a/judgearena/evaluate.py
+++ b/judgearena/evaluate.py
@@ -209,12 +209,7 @@ def annotate_battles(
 
 
 def combine_swapped_prefs(prefs_ab: pd.Series, prefs_ba: pd.Series) -> pd.Series:
-    """Combine swap_mode='both' prefs into one P(B wins) series: [pref_AB, 1 - pref_BA].
-
-    ``prefs_ab`` are P(B wins) from the AB ordering; ``prefs_ba`` are P(B wins)
-    from the swapped BA ordering, so ``1 - prefs_ba`` re-orients them to the AB
-    frame before stacking.
-    """
+    """Stack direct preferences before reversed preferences reoriented to A/B."""
     return pd.concat(
         [prefs_ab.reset_index(drop=True), 1 - prefs_ba.reset_index(drop=True)]
     ).reset_index(drop=True)
@@ -239,8 +234,8 @@ def judge_and_parse_prefs(
     Returns:
         annotations: original-order JudgeAnnotations
         annotations_reversed: reversed-order JudgeAnnotations (None if swap_mode != "both")
-        prefs: pd.Series of floats (0=A wins, 0.5=tie, 1=B wins, None=unparseable),
-               already combined for swap_mode="both"
+        prefs: canonical A/B preferences. With swap_mode="both", the direct
+               block is followed by the reoriented reversed block.
     """
     if parse is None:
         parse = PairScore()

--- a/judgearena/evaluate.py
+++ b/judgearena/evaluate.py
@@ -303,7 +303,8 @@ def judge_and_parse_prefs(
         n_failed = sum(1 for result in results if result is None)
         if n_failed:
             logger.warning(
-                "%d/%d judge outputs could not be parsed (%s) — those battles are dropped from stats.",
+                "%d/%d judge outputs could not be parsed (%s) — "
+                "those outputs are treated as missing preferences.",
                 n_failed,
                 len(results),
                 label,

--- a/judgearena/evaluate.py
+++ b/judgearena/evaluate.py
@@ -1,3 +1,4 @@
+import json
 from dataclasses import dataclass
 
 import pandas as pd
@@ -156,18 +157,23 @@ def annotate_battles(
         completions_A = [strip_thinking_tags(c) for c in completions_A]
         completions_B = [strip_thinking_tags(c) for c in completions_B]
 
-    inputs = prompt_template.batch(
-        [
+    prompt_inputs = []
+    for user_prompt, completion_A, completion_B in zip(
+        instructions, completions_A, completions_B, strict=True
+    ):
+        completion_A = truncate(completion_A, max_len=truncate_input_chars)
+        completion_B = truncate(completion_B, max_len=truncate_input_chars)
+        prompt_inputs.append(
             {
                 "user_prompt": user_prompt,
-                "completion_A": truncate(completion_A, max_len=truncate_input_chars),
-                "completion_B": truncate(completion_B, max_len=truncate_input_chars),
+                "completion_A": completion_A,
+                "completion_B": completion_B,
+                "user_prompt_json": json.dumps(user_prompt, ensure_ascii=False),
+                "completion_A_json": json.dumps(completion_A, ensure_ascii=False),
+                "completion_B_json": json.dumps(completion_B, ensure_ascii=False),
             }
-            for user_prompt, completion_A, completion_B in zip(
-                instructions, completions_A, completions_B, strict=True
-            )
-        ]
-    )
+        )
+    inputs = prompt_template.batch(prompt_inputs)
 
     logger.info("Start LLM judge annotation (%d annotations).", len(inputs))
     judge_results = do_inference(

--- a/judgearena/prompts/parsing.py
+++ b/judgearena/prompts/parsing.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import abc
+import json
 import math
 import re
 from dataclasses import dataclass, field
@@ -249,6 +250,101 @@ class PairScore(JudgeParser):
             return float(m.group(group_index).strip(" "))
 
 
+class MetaEvalPairScore(PairScore):
+    """Parse complete integer score pairs in the meta-evaluation format."""
+
+    name = "meta-eval-score"
+
+    def __init__(self) -> None:
+        super().__init__(temperature=0.5)
+
+    @staticmethod
+    def parse_raw_scores(
+        judge_completion: str,
+    ) -> tuple[float | None, float | None]:
+        text = strip_thinking_tags(judge_completion).lower()
+
+        def parse_score(label: str) -> float | None:
+            match = re.search(
+                rf'(?m)^[ \t\r]*["\']?score_{label}["\']?'
+                rf"[ \t\r]*:[ \t\r]*([0-9]+)[ \t\r]*,?[ \t\r]*$",
+                text,
+            )
+            if match is None:
+                return None
+            digits = match.group(1)
+            if len(digits) > 2:
+                return None
+            score = int(digits)
+            return float(score) if 0 <= score <= 10 else None
+
+        return parse_score("a"), parse_score("b")
+
+
+class AlpacaEvalJSON(JudgeParser):
+    """Parse the ordered-model JSON emitted by the meta-eval Alpaca prompt."""
+
+    name = "alpaca-eval-json"
+
+    def __call__(
+        self,
+        judge_completion: str,
+        *,
+        top_logprobs: dict[str, float] | None = None,
+    ) -> float | None:
+        result = self.parse_result(judge_completion, top_logprobs=top_logprobs)
+        return None if result is None else result.preference
+
+    def parse_result(
+        self,
+        judge_completion: str,
+        *,
+        top_logprobs: dict[str, float] | None = None,
+    ) -> ParsedPreference | None:
+        text = strip_thinking_tags(judge_completion)
+        fenced = re.search(r"```json\s*(.*?)\s*```", text, re.DOTALL)
+        if fenced:
+            text = fenced.group(1)
+        else:
+            obj_match = re.search(
+                r'\{[^{}]*"ordered_models"[^{}]*\[[^\[\]]*\][^{}]*\}',
+                text,
+                re.DOTALL,
+            )
+            if obj_match:
+                text = obj_match.group(0)
+        try:
+            data = json.loads(text)
+        except (json.JSONDecodeError, TypeError):
+            return None
+        if not isinstance(data, dict):
+            return None
+        ordered_models = data.get("ordered_models")
+        if not isinstance(ordered_models, list) or len(ordered_models) != 2:
+            return None
+
+        ranks: dict[str, int] = {}
+        for entry in ordered_models:
+            if not isinstance(entry, dict):
+                return None
+            model = entry.get("model")
+            rank = entry.get("rank")
+            if not isinstance(model, str) or model not in {"m", "M"} or model in ranks:
+                return None
+            if type(rank) is not int or rank not in {1, 2}:
+                return None
+            ranks[model] = rank
+        if set(ranks) != {"m", "M"} or set(ranks.values()) != {1, 2}:
+            return None
+
+        winner = "m" if ranks["m"] == 1 else "M"
+        return ParsedPreference(
+            preference=0.0 if winner == "m" else 1.0,
+            label=winner,
+            details={"ranks": ranks},
+        )
+
+
 def parser_name(parse) -> str:
     """Short identifier of a parser for run metadata.
 
@@ -262,7 +358,9 @@ def parser_name(parse) -> str:
 # presets reference these same instances.
 JUDGE_PARSERS: dict[str, JudgeParser] = {
     "score": PairScore(),
+    "meta-eval-score": MetaEvalPairScore(),
     "arena-hard-verdict": ArenaHardVerdict(),
+    "alpaca-eval-json": AlpacaEvalJSON(),
     "alpaca-eval-token": AlpacaEvalToken(),
 }
 

--- a/judgearena/prompts/parsing.py
+++ b/judgearena/prompts/parsing.py
@@ -334,7 +334,7 @@ class AlpacaEvalJSON(JudgeParser):
             if type(rank) is not int or rank not in {1, 2}:
                 return None
             ranks[model] = rank
-        if set(ranks) != {"m", "M"} or set(ranks.values()) != {1, 2}:
+        if ranks["m"] == ranks["M"]:
             return None
 
         winner = "m" if ranks["m"] == 1 else "M"

--- a/judgearena/prompts/registry.py
+++ b/judgearena/prompts/registry.py
@@ -22,6 +22,9 @@ FASTCHAT_PAIRWISE_PROMPT_PRESET = "fastchat-pairwise"
 ARENA_HARD_JUDGE_PROMPT_PRESET = "arena-hard"
 ARENA_HARD_CREATIVE_JUDGE_PROMPT_PRESET = "arena-hard-creative"
 ALPACA_EVAL_JUDGE_PROMPT_PRESET = "alpaca-eval"
+META_EVAL_PAIR_SCORE_PROMPT_PRESET = "meta-eval-pair-score"
+META_EVAL_ALPACA_EVAL_JSON_PROMPT_PRESET = "meta-eval-alpaca-eval-json"
+META_EVAL_ALPACA_EVAL_PAIR_SCORE_PROMPT_PRESET = "meta-eval-alpaca-eval-pair-score"
 
 PROMPTS_PACKAGE = "judgearena.prompts"
 _COMPLETION_LABEL_SINGLE = "Answer"
@@ -132,6 +135,24 @@ PRESETS: dict[str, JudgePromptPreset] = {
         parser=JUDGE_PARSERS["alpaca-eval-token"],
         system_file="alpaca-eval-system-prompt.txt",
         user_file="alpaca-eval-prompt.txt",
+    ),
+    META_EVAL_PAIR_SCORE_PROMPT_PRESET: JudgePromptPreset(
+        name=META_EVAL_PAIR_SCORE_PROMPT_PRESET,
+        parser=JUDGE_PARSERS["meta-eval-score"],
+        system_file="system-prompt.txt",
+        user_file="meta-eval-pair-score-prompt.txt",
+    ),
+    META_EVAL_ALPACA_EVAL_JSON_PROMPT_PRESET: JudgePromptPreset(
+        name=META_EVAL_ALPACA_EVAL_JSON_PROMPT_PRESET,
+        parser=JUDGE_PARSERS["alpaca-eval-json"],
+        system_file="meta-eval-alpaca-eval-system-prompt.txt",
+        user_file="meta-eval-alpaca-eval-json-prompt.txt",
+    ),
+    META_EVAL_ALPACA_EVAL_PAIR_SCORE_PROMPT_PRESET: JudgePromptPreset(
+        name=META_EVAL_ALPACA_EVAL_PAIR_SCORE_PROMPT_PRESET,
+        parser=JUDGE_PARSERS["meta-eval-score"],
+        system_file="meta-eval-alpaca-eval-system-prompt.txt",
+        user_file="meta-eval-alpaca-eval-pair-score-prompt.txt",
     ),
 }
 

--- a/judgearena/prompts/templates/meta-eval-alpaca-eval-json-prompt.txt
+++ b/judgearena/prompts/templates/meta-eval-alpaca-eval-json-prompt.txt
@@ -1,0 +1,30 @@
+I require a leaderboard for various large language models. I'll provide you with prompts given to these models and their corresponding responses. Your task is to assess these responses, ranking the models in order of preference from a human perspective.
+
+## Prompt
+
+{{
+    "instruction": {user_prompt_json}
+}}
+
+## Model Outputs
+
+Here are the unordered outputs from the models. Each output is associated with a specific model, identified by a unique model identifier.
+
+[
+    {{
+        "model": "m",
+        "output": {completion_A_json}
+    }},
+    {{
+        "model": "M",
+        "output": {completion_B_json}
+    }}
+]
+
+## Task
+
+Evaluate and rank the models based on the quality and relevance of their outputs. The ranking should be such that the model with the highest quality output is ranked first.
+
+Output ONLY a JSON object in this exact format (no other text):
+{{"ordered_models": [{{"model": "m", "rank": 1}}, {{"model": "M", "rank": 2}}]}}
+where rank 1 = best. Replace ranks according to your evaluation.

--- a/judgearena/prompts/templates/meta-eval-alpaca-eval-pair-score-prompt.txt
+++ b/judgearena/prompts/templates/meta-eval-alpaca-eval-pair-score-prompt.txt
@@ -1,0 +1,32 @@
+I require a leaderboard for various large language models. I'll provide you with prompts given to these models and their corresponding responses. Your task is to assess these responses, ranking the models in order of preference from a human perspective.
+
+## Prompt
+
+{{
+    "instruction": {user_prompt_json}
+}}
+
+## Model Outputs
+
+Here are the unordered outputs from the models. Each output is associated with a specific model, identified by a unique model identifier.
+
+[
+    {{
+        "model": "model A",
+        "output": {completion_A_json}
+    }},
+    {{
+        "model": "model B",
+        "output": {completion_B_json}
+    }}
+]
+
+## Task
+
+Evaluate and rank the models based on the quality and relevance of their outputs. The ranking should be such that the model with the highest quality output is ranked first.
+
+## Your output, do not repeat the input above
+```
+score_A: <an integer between 0 and 10 to indicate the quality of model A's answer>
+score_B: <an integer between 0 and 10 to indicate the quality of model B's answer>
+```

--- a/judgearena/prompts/templates/meta-eval-alpaca-eval-system-prompt.txt
+++ b/judgearena/prompts/templates/meta-eval-alpaca-eval-system-prompt.txt
@@ -1,0 +1,1 @@
+You are a highly efficient assistant, who evaluates and ranks large language models (LLMs) based on the quality of their responses to given prompts. This process will create a leaderboard reflecting the most accurate and human-preferred answers.

--- a/judgearena/prompts/templates/meta-eval-pair-score-prompt.txt
+++ b/judgearena/prompts/templates/meta-eval-pair-score-prompt.txt
@@ -1,0 +1,21 @@
+<|User Prompt|>
+{user_prompt}
+
+<|The Start of Assistant A's {completion_label}|>
+{completion_A}
+<|The End of Assistant A's {completion_label}|>
+
+<|The Start of Assistant B's {completion_label}|>
+{completion_B}
+<|The End of Assistant B's {completion_label}|>
+
+# Your output
+
+## Format description
+Your output should follow this format:
+```
+score_A: <an integer between 0 and 10 to indicate the quality of Assistant A's answer>
+score_B: <an integer between 0 and 10 to indicate the quality of Assistant B's answer>
+```
+
+## Your output, do not repeat the input above{explanation_suffix}

--- a/judgearena/reports.py
+++ b/judgearena/reports.py
@@ -99,14 +99,8 @@ class MetaEvalReport(Report):
     prompt_preset: str
     languages: list[str]
     top_models: list[str]
-    n_battles: int
-    n_annotations: int
-    n_parsed_annotations: int
-    n_scored_battles: int
-    battle_parse_status: dict[str, int]
+    n_sampled_battles: int
     swap_mode: str
-    battles_per_language: dict[str, int]
-    human_winner_counts: dict[str, int]
     metrics: dict[str, dict[str, object]]
 
     def render(self) -> None:
@@ -115,12 +109,7 @@ class MetaEvalReport(Report):
         print(f"\n=== Meta-eval: {self.task} ===")
         print(f"Arena: {self.arena} | Judge: {self.judge_model}")
         print(
-            f"Models: {len(self.top_models)} | Battles: {self.n_battles} | "
-            f"Judge passes: {self.n_annotations} ({self.swap_mode})"
-        )
-        print(
-            f"Parsed passes: {self.n_parsed_annotations}/"
-            f"{self.n_annotations} | Scored battles: "
-            f"{self.n_scored_battles}/{self.n_battles}"
+            f"Models: {len(self.top_models)} | Sampled battles: {self.n_sampled_battles} | "
+            f"Swap mode: {self.swap_mode}"
         )
         print(render_metrics(self.metrics))

--- a/judgearena/reports.py
+++ b/judgearena/reports.py
@@ -88,3 +88,39 @@ class EloReport(Report):
         print(f"\n=== Results for {self.model_name} ===")
         print(f"Arena: {self.arena} | Judge: {self.judge_model}")
         print(render_metrics(self.metrics))
+
+
+class MetaEvalReport(Report):
+    """Configured metrics and run context for judge meta-evaluation."""
+
+    task: str
+    arena: str
+    judge_model: str
+    prompt_preset: str
+    languages: list[str]
+    top_models: list[str]
+    n_battles: int
+    n_annotations: int
+    n_parsed_annotations: int
+    n_scored_battles: int
+    battle_parse_status: dict[str, int]
+    swap_mode: str
+    battles_per_language: dict[str, int]
+    human_winner_counts: dict[str, int]
+    metrics: dict[str, dict[str, object]]
+
+    def render(self) -> None:
+        from judgearena.benchmarks.scoring import render_metrics
+
+        print(f"\n=== Meta-eval: {self.task} ===")
+        print(f"Arena: {self.arena} | Judge: {self.judge_model}")
+        print(
+            f"Models: {len(self.top_models)} | Battles: {self.n_battles} | "
+            f"Judge passes: {self.n_annotations} ({self.swap_mode})"
+        )
+        print(
+            f"Parsed passes: {self.n_parsed_annotations}/"
+            f"{self.n_annotations} | Scored battles: "
+            f"{self.n_scored_battles}/{self.n_battles}"
+        )
+        print(render_metrics(self.metrics))

--- a/judgearena/tasks/definitions/meta_eval/_base.yaml
+++ b/judgearena/tasks/definitions/meta_eval/_base.yaml
@@ -1,0 +1,36 @@
+schema_version: 1
+task_version: 1
+tags: [meta-eval, arena, judge]
+
+dataset:
+  adapter: arena_battles
+  fields:
+    id: question_id
+    instruction: conversation_a
+    category: lang
+
+protocol:
+  runner: meta_eval
+  baseline:
+    strategy: none
+  judge:
+    default_prompt_preset: meta-eval-pair-score
+    default_swap_mode: fixed
+  scoring:
+    metrics:
+      - metric: meta_eval_agreement
+        group_by: [language_group]
+        parameters:
+          n_bootstraps: 1000
+          tie_tolerance: 0.01
+      - metric: meta_eval_ranking
+        group_by: [language_group]
+        parameters:
+          n_bootstraps: 1000
+          tie_tolerance: 0.01
+          include_human_ties: false
+      - metric: meta_eval_elo_gap
+        parameters:
+          battle_counts: [10, 20, 30, 40, 50]
+          n_seeds: 10
+          tie_tolerance: 0.01

--- a/judgearena/tasks/definitions/meta_eval/_base.yaml
+++ b/judgearena/tasks/definitions/meta_eval/_base.yaml
@@ -19,12 +19,10 @@ protocol:
   scoring:
     metrics:
       - metric: meta_eval_agreement
-        group_by: [language_group]
         parameters:
           n_bootstraps: 1000
           tie_tolerance: 0.01
       - metric: meta_eval_ranking
-        group_by: [language_group]
         parameters:
           n_bootstraps: 1000
           tie_tolerance: 0.01

--- a/judgearena/tasks/definitions/meta_eval/meta-eval-comparia.yaml
+++ b/judgearena/tasks/definitions/meta_eval/meta-eval-comparia.yaml
@@ -1,0 +1,21 @@
+extends: _base.yaml
+task: meta-eval-comparia
+description: Score a judge against human votes from the ComparIA arena.
+
+variants:
+  selector: language
+  values: [fr, en]
+
+dataset:
+  sources:
+    comparia:
+      type: huggingface_dataset
+      repo_id: ministere-culture/comparia-votes
+      revision: "7a40bce496c1f2aa3be4001da85a49cb4743042b"
+      allow_patterns: [votes.parquet]
+
+protocol:
+  arena: ComparIA
+
+metadata:
+  reference_implementation: https://huggingface.co/datasets/ministere-culture/comparia-votes

--- a/judgearena/tasks/definitions/meta_eval/meta-eval-lmarena-100k.yaml
+++ b/judgearena/tasks/definitions/meta_eval/meta-eval-lmarena-100k.yaml
@@ -1,0 +1,21 @@
+extends: _base.yaml
+task: meta-eval-lmarena-100k
+description: Score a judge against human votes from LMSYS Chatbot Arena 100k.
+
+variants:
+  selector: language
+  values: [en, pl, ru, zh, de, ja, es, fr, ko, pt, fa, it, tr, vi, cs, ar, uk]
+
+dataset:
+  sources:
+    lmarena_100k:
+      type: huggingface_dataset
+      repo_id: lmarena-ai/arena-human-preference-100k
+      revision: "72e85b3ddc9c81bf7b659d6b03d4126dfd8fb34a"
+      allow_patterns: [data/*.parquet]
+
+protocol:
+  arena: LMArena-100k
+
+metadata:
+  reference_implementation: https://huggingface.co/datasets/lmarena-ai/arena-human-preference-100k

--- a/judgearena/tasks/definitions/meta_eval/meta-eval-lmarena-140k.yaml
+++ b/judgearena/tasks/definitions/meta_eval/meta-eval-lmarena-140k.yaml
@@ -1,0 +1,21 @@
+extends: _base.yaml
+task: meta-eval-lmarena-140k
+description: Score a judge against human votes from LMSYS Chatbot Arena 140k.
+
+variants:
+  selector: language
+  values: [en, pl, ru, zh, de, ja, es, fr, ko, pt, fa, it, tr, vi, cs, ar, uk]
+
+dataset:
+  sources:
+    lmarena_140k:
+      type: huggingface_dataset
+      repo_id: lmarena-ai/arena-human-preference-140k
+      revision: "6322995ab34d7c2693e3f47dd13fa5caa0789a74"
+      allow_patterns: [data/*.parquet]
+
+protocol:
+  arena: LMArena-140k
+
+metadata:
+  reference_implementation: https://huggingface.co/datasets/lmarena-ai/arena-human-preference-140k

--- a/judgearena/tasks/registry.py
+++ b/judgearena/tasks/registry.py
@@ -21,6 +21,7 @@ from judgearena.log import get_logger
 from judgearena.prompts.registry import JUDGE_PROMPT_PRESETS
 from judgearena.tasks.schema import (
     EloProtocol,
+    MetaEvalProtocol,
     MTBenchProtocol,
     ResolvedTaskSpec,
     ResourceDigest,
@@ -316,9 +317,9 @@ def _discover_tasks(
 
 def _validate_adapter_ids(resolved: ResolvedTaskSpec, adapters: AdapterCatalog) -> None:
     spec = resolved.spec
-    is_elo = isinstance(spec.protocol, EloProtocol)
+    is_battle_backed = isinstance(spec.protocol, (EloProtocol, MetaEvalProtocol))
     dataset_names = (
-        adapters.battle_datasets if is_elo else adapters.instruction_datasets
+        adapters.battle_datasets if is_battle_backed else adapters.instruction_datasets
     )
     references = {
         "runner": (spec.protocol.runner, adapters.runners),

--- a/judgearena/tasks/schema/__init__.py
+++ b/judgearena/tasks/schema/__init__.py
@@ -15,6 +15,7 @@ from judgearena.tasks.schema.baselines import (
 )
 from judgearena.tasks.schema.dataset import DatasetFields, DatasetSpec
 from judgearena.tasks.schema.elo import EloProtocol, EloScoringSpec
+from judgearena.tasks.schema.meta_eval import MetaEvalProtocol
 from judgearena.tasks.schema.metrics import MetricSpec, ScoringSpec
 from judgearena.tasks.schema.mt_bench import (
     MTBenchJudgeSpec,
@@ -58,6 +59,7 @@ __all__ = [
     "HuggingFaceSpaceSource",
     "MTBenchJudgeSpec",
     "MTBenchProtocol",
+    "MetaEvalProtocol",
     "MetricSpec",
     "MultiTurnGeneration",
     "NoBaseline",

--- a/judgearena/tasks/schema/meta_eval.py
+++ b/judgearena/tasks/schema/meta_eval.py
@@ -34,8 +34,8 @@ class MetaEvalProtocol(StrictFrozenModel):
                 raise ValueError(
                     f"unsupported meta-evaluation metric: {request.metric}"
                 )
-            if request.group_by:
+            if request.breakdown_by:
                 raise ValueError(
-                    f"meta-evaluation metric {request.metric} does not support group_by"
+                    f"meta-evaluation metric {request.metric} does not support breakdown_by"
                 )
         return self

--- a/judgearena/tasks/schema/meta_eval.py
+++ b/judgearena/tasks/schema/meta_eval.py
@@ -1,0 +1,22 @@
+"""Schema for judge meta-evaluation against human arena labels."""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import Field
+
+from judgearena.tasks.schema.base import StrictFrozenModel
+from judgearena.tasks.schema.baselines import NoBaseline
+from judgearena.tasks.schema.metrics import ScoringSpec
+from judgearena.tasks.schema.pairwise import PairwiseJudgeSpec
+
+
+class MetaEvalProtocol(StrictFrozenModel):
+    """Policy for scoring a judge against human-labeled arena battles."""
+
+    runner: Literal["meta_eval"]
+    arena: str = Field(min_length=1)
+    baseline: NoBaseline
+    judge: PairwiseJudgeSpec
+    scoring: ScoringSpec

--- a/judgearena/tasks/schema/meta_eval.py
+++ b/judgearena/tasks/schema/meta_eval.py
@@ -4,12 +4,18 @@ from __future__ import annotations
 
 from typing import Literal
 
-from pydantic import Field
+from pydantic import Field, model_validator
 
 from judgearena.tasks.schema.base import StrictFrozenModel
 from judgearena.tasks.schema.baselines import NoBaseline
 from judgearena.tasks.schema.metrics import ScoringSpec
 from judgearena.tasks.schema.pairwise import PairwiseJudgeSpec
+
+_META_EVAL_METRICS = {
+    "meta_eval_agreement",
+    "meta_eval_elo_gap",
+    "meta_eval_ranking",
+}
 
 
 class MetaEvalProtocol(StrictFrozenModel):
@@ -20,3 +26,16 @@ class MetaEvalProtocol(StrictFrozenModel):
     baseline: NoBaseline
     judge: PairwiseJudgeSpec
     scoring: ScoringSpec
+
+    @model_validator(mode="after")
+    def _validate_scoring(self) -> MetaEvalProtocol:
+        for request in self.scoring.metrics:
+            if request.metric not in _META_EVAL_METRICS:
+                raise ValueError(
+                    f"unsupported meta-evaluation metric: {request.metric}"
+                )
+            if request.group_by:
+                raise ValueError(
+                    f"meta-evaluation metric {request.metric} does not support group_by"
+                )
+        return self

--- a/judgearena/tasks/schema/task.py
+++ b/judgearena/tasks/schema/task.py
@@ -13,11 +13,12 @@ from judgearena.tasks.schema.baselines import (
 )
 from judgearena.tasks.schema.dataset import DatasetSpec
 from judgearena.tasks.schema.elo import EloProtocol
+from judgearena.tasks.schema.meta_eval import MetaEvalProtocol
 from judgearena.tasks.schema.mt_bench import MTBenchProtocol
 from judgearena.tasks.schema.pairwise import PairwiseProtocol
 
 ProtocolSpec = Annotated[
-    PairwiseProtocol | MTBenchProtocol | EloProtocol,
+    PairwiseProtocol | MTBenchProtocol | EloProtocol | MetaEvalProtocol,
     Field(discriminator="runner"),
 ]
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -365,39 +365,17 @@ def test_build_run_config_elo_defaults():
     assert cfg.elo.soft_elo is True
 
 
-def _base_meta_eval() -> dict:
-    return {
-        "task": "meta-eval-comparia",
-        "judge": {"model": "Dummy/j"},
-    }
-
-
-def test_meta_eval_config_uses_sampling_defaults_and_task_metric_defaults():
-    cfg = RunConfig(**_base_meta_eval())
+def test_meta_eval_config_defaults():
+    cfg = RunConfig(task="meta-eval-comparia", judge={"model": "Dummy/j"})
 
     assert cfg.model.name is None
     assert cfg.model.baseline is None
     assert cfg.elo is None
-    assert cfg.meta_eval is not None
-    assert cfg.meta_eval.top_models == 20
-    assert cfg.meta_eval.battles_per_model == 50
-    assert cfg.meta_eval.languages is None
-
-
-def test_meta_eval_config_accepts_explicit_sampling_settings():
-    data = _base_meta_eval()
-    data["meta_eval"] = {
-        "top_models": 4,
-        "battles_per_model": 12,
-        "languages": ["fr", "en"],
+    assert cfg.meta_eval.model_dump() == {
+        "top_models": 20,
+        "battles_per_model": 50,
+        "languages": None,
     }
-
-    cfg = RunConfig(**data)
-
-    assert cfg.meta_eval is not None
-    assert cfg.meta_eval.top_models == 4
-    assert cfg.meta_eval.battles_per_model == 12
-    assert cfg.meta_eval.languages == ["fr", "en"]
 
 
 @pytest.mark.parametrize(
@@ -412,7 +390,7 @@ def test_meta_eval_config_accepts_explicit_sampling_settings():
     ],
 )
 def test_meta_eval_config_rejects_invalid_runtime_settings(update, message):
-    data = _base_meta_eval()
+    data = {"task": "meta-eval-comparia", "judge": {"model": "Dummy/j"}}
     data.update(update)
 
     with pytest.raises(ValidationError, match=message):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -382,29 +382,22 @@ def test_meta_eval_config_uses_sampling_defaults_and_task_metric_defaults():
     assert cfg.meta_eval.top_models == 20
     assert cfg.meta_eval.battles_per_model == 50
     assert cfg.meta_eval.languages is None
-    assert cfg.meta_eval.n_bootstraps is None
-    assert cfg.meta_eval.include_human_ties is None
-    assert cfg.meta_eval.elo_gap_battles is None
-    assert cfg.meta_eval.elo_gap_seeds is None
 
 
-def test_meta_eval_config_accepts_explicit_valid_overrides():
+def test_meta_eval_config_accepts_explicit_sampling_settings():
     data = _base_meta_eval()
     data["meta_eval"] = {
         "top_models": 4,
         "battles_per_model": 12,
         "languages": ["fr", "en"],
-        "n_bootstraps": 5,
-        "include_human_ties": True,
-        "elo_gap_battles": [2, 6, 12],
-        "elo_gap_seeds": 3,
     }
 
     cfg = RunConfig(**data)
 
     assert cfg.meta_eval is not None
-    assert cfg.meta_eval.elo_gap_battles == [2, 6, 12]
-    assert cfg.meta_eval.include_human_ties is True
+    assert cfg.meta_eval.top_models == 4
+    assert cfg.meta_eval.battles_per_model == 12
+    assert cfg.meta_eval.languages == ["fr", "en"]
 
 
 @pytest.mark.parametrize(
@@ -415,10 +408,7 @@ def test_meta_eval_config_accepts_explicit_valid_overrides():
         ({"elo": {}}, "elo config"),
         ({"judge": {"model": "Dummy/j", "swap_mode": "random"}}, "random"),
         ({"meta_eval": {"top_models": 2}}, "greater than or equal to 3"),
-        ({"meta_eval": {"languages": []}}, "languages"),
-        ({"meta_eval": {"languages": ["en", "en"]}}, "duplicates"),
-        ({"meta_eval": {"elo_gap_battles": [10, 5]}}, "ordered ascending"),
-        ({"meta_eval": {"elo_gap_battles": []}}, "positive integers"),
+        ({"meta_eval": {"n_bootstraps": 7}}, "Extra inputs are not permitted"),
     ],
 )
 def test_meta_eval_config_rejects_invalid_runtime_settings(update, message):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -365,19 +365,6 @@ def test_build_run_config_elo_defaults():
     assert cfg.elo.soft_elo is True
 
 
-def test_meta_eval_config_defaults():
-    cfg = RunConfig(task="meta-eval-comparia", judge={"model": "Dummy/j"})
-
-    assert cfg.model.name is None
-    assert cfg.model.baseline is None
-    assert cfg.elo is None
-    assert cfg.meta_eval.model_dump() == {
-        "top_models": 20,
-        "battles_per_model": 50,
-        "languages": None,
-    }
-
-
 @pytest.mark.parametrize(
     ("update", "message"),
     [

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -363,3 +363,75 @@ def test_build_run_config_elo_defaults():
     )
     assert cfg.elo is not None
     assert cfg.elo.soft_elo is True
+
+
+def _base_meta_eval() -> dict:
+    return {
+        "task": "meta-eval-comparia",
+        "judge": {"model": "Dummy/j"},
+    }
+
+
+def test_meta_eval_config_uses_sampling_defaults_and_task_metric_defaults():
+    cfg = RunConfig(**_base_meta_eval())
+
+    assert cfg.model.name is None
+    assert cfg.model.baseline is None
+    assert cfg.elo is None
+    assert cfg.meta_eval is not None
+    assert cfg.meta_eval.top_models == 20
+    assert cfg.meta_eval.battles_per_model == 50
+    assert cfg.meta_eval.languages is None
+    assert cfg.meta_eval.n_bootstraps is None
+    assert cfg.meta_eval.include_human_ties is None
+    assert cfg.meta_eval.elo_gap_battles is None
+    assert cfg.meta_eval.elo_gap_seeds is None
+
+
+def test_meta_eval_config_accepts_explicit_valid_overrides():
+    data = _base_meta_eval()
+    data["meta_eval"] = {
+        "top_models": 4,
+        "battles_per_model": 12,
+        "languages": ["fr", "en"],
+        "n_bootstraps": 5,
+        "include_human_ties": True,
+        "elo_gap_battles": [2, 6, 12],
+        "elo_gap_seeds": 3,
+    }
+
+    cfg = RunConfig(**data)
+
+    assert cfg.meta_eval is not None
+    assert cfg.meta_eval.elo_gap_battles == [2, 6, 12]
+    assert cfg.meta_eval.include_human_ties is True
+
+
+@pytest.mark.parametrize(
+    ("update", "message"),
+    [
+        ({"model": {"name": "Dummy/m"}}, "model.name"),
+        ({"model": {"baseline": "Dummy/b"}}, "model.baseline"),
+        ({"elo": {}}, "elo config"),
+        ({"judge": {"model": "Dummy/j", "swap_mode": "random"}}, "random"),
+        ({"meta_eval": {"top_models": 2}}, "greater than or equal to 3"),
+        ({"meta_eval": {"languages": []}}, "languages"),
+        ({"meta_eval": {"languages": ["en", "en"]}}, "duplicates"),
+        ({"meta_eval": {"elo_gap_battles": [10, 5]}}, "ordered ascending"),
+        ({"meta_eval": {"elo_gap_battles": []}}, "positive integers"),
+    ],
+)
+def test_meta_eval_config_rejects_invalid_runtime_settings(update, message):
+    data = _base_meta_eval()
+    data.update(update)
+
+    with pytest.raises(ValidationError, match=message):
+        RunConfig(**data)
+
+
+def test_meta_eval_block_is_rejected_for_non_meta_task():
+    data = _base_generate()
+    data["meta_eval"] = {"top_models": 4}
+
+    with pytest.raises(ValidationError, match="only valid for meta-evaluation"):
+        RunConfig(**data)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -407,7 +407,7 @@ def test_meta_eval_config_accepts_explicit_sampling_settings():
         ({"model": {"baseline": "Dummy/b"}}, "model.baseline"),
         ({"elo": {}}, "elo config"),
         ({"judge": {"model": "Dummy/j", "swap_mode": "random"}}, "random"),
-        ({"meta_eval": {"top_models": 2}}, "greater than or equal to 3"),
+        ({"meta_eval": {"top_models": 1}}, "greater than or equal to 2"),
         ({"meta_eval": {"n_bootstraps": 7}}, "Extra inputs are not permitted"),
     ],
 )

--- a/tests/test_estimate_elo_ratings.py
+++ b/tests/test_estimate_elo_ratings.py
@@ -615,13 +615,13 @@ def test_run_elo_temperature_calibration_builds_judge(monkeypatch, tmp_path):
     assert captured["n_pairs"] >= 10
 
 
-def test_extract_instruction_text_tolerates_moderated_turns():
-    from judgearena.arenas_utils import _extract_instruction_text
+def test_extract_turn_text_tolerates_moderated_turns():
+    from judgearena.arenas_utils import extract_turn_text
 
-    assert _extract_instruction_text({"content": None}) == ""
-    assert _extract_instruction_text({"content": "plain"}) == "plain"
+    assert extract_turn_text({"content": None}) == ""
+    assert extract_turn_text({"content": "plain"}) == "plain"
     assert (
-        _extract_instruction_text(
+        extract_turn_text(
             {"content": [{"type": "text", "text": None}, {"type": "image"}, None]}
         )
         == ""

--- a/tests/test_eval_reports.py
+++ b/tests/test_eval_reports.py
@@ -134,3 +134,38 @@ def test_eloreport_to_dict_envelope():
         "schema_version": "1",
         "report_type": "EloReport",
     }
+
+
+def test_meta_eval_report_keeps_results_under_metrics_and_renders_them(
+    capsys, monkeypatch
+):
+    from judgearena.benchmarks import scoring
+    from judgearena.reports import MetaEvalReport
+
+    metrics = {"meta_eval_agreement": {"ok": True}}
+    monkeypatch.setattr(scoring, "render_metrics", lambda result: "rendered metrics")
+    report = MetaEvalReport(
+        task="meta-eval-comparia",
+        arena="ComparIA",
+        judge_model="judge",
+        prompt_preset="meta-eval-pair-score",
+        languages=["en"],
+        top_models=["a", "b", "c"],
+        n_battles=1,
+        n_annotations=1,
+        n_parsed_annotations=1,
+        n_scored_battles=1,
+        battle_parse_status={"complete": 1},
+        swap_mode="fixed",
+        battles_per_language={"en": 1},
+        human_winner_counts={"model_a": 1},
+        metrics=metrics,
+    )
+
+    result = report.to_dict()
+    report.render()
+
+    assert result["metrics"] == metrics
+    assert "agreement" not in result
+    assert "language_summary" not in result
+    assert "rendered metrics" in capsys.readouterr().out

--- a/tests/test_eval_reports.py
+++ b/tests/test_eval_reports.py
@@ -151,14 +151,8 @@ def test_meta_eval_report_keeps_results_under_metrics_and_renders_them(
         prompt_preset="meta-eval-pair-score",
         languages=["en"],
         top_models=["a", "b", "c"],
-        n_battles=1,
-        n_annotations=1,
-        n_parsed_annotations=1,
-        n_scored_battles=1,
-        battle_parse_status={"complete": 1},
+        n_sampled_battles=1,
         swap_mode="fixed",
-        battles_per_language={"en": 1},
-        human_winner_counts={"model_a": 1},
         metrics=metrics,
     )
 
@@ -166,6 +160,4 @@ def test_meta_eval_report_keeps_results_under_metrics_and_renders_them(
     report.render()
 
     assert result["metrics"] == metrics
-    assert "agreement" not in result
-    assert "language_summary" not in result
     assert "rendered metrics" in capsys.readouterr().out

--- a/tests/test_eval_reports.py
+++ b/tests/test_eval_reports.py
@@ -134,30 +134,3 @@ def test_eloreport_to_dict_envelope():
         "schema_version": "1",
         "report_type": "EloReport",
     }
-
-
-def test_meta_eval_report_keeps_results_under_metrics_and_renders_them(
-    capsys, monkeypatch
-):
-    from judgearena.benchmarks import scoring
-    from judgearena.reports import MetaEvalReport
-
-    metrics = {"meta_eval_agreement": {"ok": True}}
-    monkeypatch.setattr(scoring, "render_metrics", lambda result: "rendered metrics")
-    report = MetaEvalReport(
-        task="meta-eval-comparia",
-        arena="ComparIA",
-        judge_model="judge",
-        prompt_preset="meta-eval-pair-score",
-        languages=["en"],
-        top_models=["a", "b", "c"],
-        n_sampled_battles=1,
-        swap_mode="fixed",
-        metrics=metrics,
-    )
-
-    result = report.to_dict()
-    report.render()
-
-    assert result["metrics"] == metrics
-    assert "rendered metrics" in capsys.readouterr().out

--- a/tests/test_meta_eval_annotations.py
+++ b/tests/test_meta_eval_annotations.py
@@ -10,9 +10,9 @@ import pytest
 
 import judgearena.benchmarks.meta_eval.annotate as annotate_module
 from judgearena.benchmarks.meta_eval.annotate import (
+    _battle_texts,
     aggregate_battle_preferences,
     annotate_sample,
-    validate_battle_conversations,
 )
 from judgearena.evaluate import JudgeAnnotation
 from judgearena.prompts.parsing import ParsedPreference
@@ -69,25 +69,12 @@ def _annotation(
     )
 
 
-def _pass_row(
-    battle_id: str,
-    orientation: str,
-    pref: float,
-    **overrides,
-) -> dict[str, object]:
-    row: dict[str, object] = {
+def _pass_row(battle_id: str, orientation: str, pref: float) -> dict[str, object]:
+    return {
         "battle_id": battle_id,
-        "question_id": battle_id,
-        "model_a": "a",
-        "model_b": "b",
-        "winner": "model_a",
-        "lang": "en",
-        "parse_ok": not pd.isna(pref),
-        "pref": pref,
         "orientation": orientation,
+        "pref": pref,
     }
-    row.update(overrides)
-    return row
 
 
 def test_annotation_uses_each_structured_parse_and_preserves_raw_evidence(
@@ -116,8 +103,6 @@ def test_annotation_uses_each_structured_parse_and_preserves_raw_evidence(
 
     def fake_judge_and_parse_prefs(**kwargs):
         assert kwargs["swap_mode"] == "both"
-        # The shared function returns already-combined preferences. Annotation
-        # production must instead read the structured result attached to each pass.
         return [direct], [reversed_pass], pd.Series([0.99, 0.01])
 
     monkeypatch.setattr(
@@ -130,15 +115,19 @@ def test_annotation_uses_each_structured_parse_and_preserves_raw_evidence(
         resolved_prompt=resolve_judge_prompt(preset="meta-eval-pair-score"),
     )
 
-    assert rows["orientation"].tolist() == ["direct", "reversed"]
-    assert rows["pref_judge_input"].tolist() == pytest.approx([0.2, 0.8])
-    assert rows["pref"].tolist() == pytest.approx([0.2, 0.2])
-    assert rows["completion_a"].tolist() == ["Alpha answer", "Alpha answer"]
-    assert rows["completion_b"].tolist() == ["Beta answer", "Beta answer"]
-    assert rows["judge_input_completion_a"].tolist() == [
-        "Alpha answer",
-        "Beta answer",
+    assert list(rows.columns) == [
+        "battle_id",
+        "orientation",
+        "pref",
+        "judge_input",
+        "judge_completion",
+        "judge_top_logprobs_json",
+        "parsed_label",
+        "parsed_scores_json",
+        "parsed_details_json",
     ]
+    assert rows["orientation"].tolist() == ["direct", "reversed"]
+    assert rows["pref"].tolist() == pytest.approx([0.99, 0.01])
     assert rows["parsed_label"].tolist() == ["A", "B"]
     assert json.loads(rows.loc[1, "parsed_scores_json"]) == {"A": 1.0, "B": 9.0}
     assert json.loads(rows.loc[1, "parsed_details_json"]) == {"reason": "reversed"}
@@ -167,39 +156,15 @@ def test_fixed_annotation_uses_single_orientation(monkeypatch):
     assert rows["pref"].tolist() == [0.75]
 
 
-def test_annotation_rejects_unimplemented_random_swap_mode(monkeypatch):
-    monkeypatch.setattr(
-        annotate_module,
-        "judge_and_parse_prefs",
-        lambda **kwargs: pytest.fail("judge must not be called"),
-    )
-
-    with pytest.raises(ValueError, match="supports fixed or both"):
-        annotate_sample(
-            _sample(),
-            _config("random"),
-            judge_chat_model=object(),
-            resolved_prompt=resolve_judge_prompt(preset="meta-eval-pair-score"),
-        )
-
-
-def test_aggregate_produces_one_physical_row_and_all_parse_statuses():
+def test_aggregate_requires_every_pass_and_leaves_partial_evidence_raw():
     annotations = pd.DataFrame(
         [
             _pass_row("complete", "direct", 0.2),
             _pass_row("complete", "reversed", 0.4),
-            _pass_row("partial", "direct", 0.5001, winner="model_b"),
-            _pass_row(
-                "partial",
-                "reversed",
-                float("nan"),
-                winner="model_b",
-                parse_ok=False,
-            ),
-            _pass_row("missing", "direct", float("nan"), winner="tie", parse_ok=False),
-            _pass_row(
-                "missing", "reversed", float("nan"), winner="tie", parse_ok=False
-            ),
+            _pass_row("partial", "direct", 0.5001),
+            _pass_row("partial", "reversed", float("nan")),
+            _pass_row("missing", "direct", float("nan")),
+            _pass_row("missing", "reversed", float("nan")),
         ]
     )
 
@@ -207,19 +172,10 @@ def test_aggregate_produces_one_physical_row_and_all_parse_statuses():
         "battle_id"
     )
 
-    assert len(battles) == 3
+    assert list(battles.reset_index().columns) == ["battle_id", "pref"]
     assert battles.loc["complete", "pref"] == pytest.approx(0.3)
-    assert battles.loc["complete", "pref_hard"] == 0.0
-    assert battles.loc["complete", "parse_status"] == "complete"
-    assert battles.loc["complete", "n_passes_parsed"] == 2
-    assert battles.loc["partial", "pref"] == pytest.approx(0.5001)
-    assert battles.loc["partial", "pref_hard"] == 1.0
-    assert battles.loc["partial", "parse_status"] == "partial"
-    assert battles.loc["partial", "n_passes_parsed"] == 1
+    assert pd.isna(battles.loc["partial", "pref"])
     assert pd.isna(battles.loc["missing", "pref"])
-    assert pd.isna(battles.loc["missing", "pref_hard"])
-    assert battles.loc["missing", "parse_status"] == "missing"
-    assert battles.loc["missing", "n_passes_expected"] == 2
 
 
 def test_aggregate_rejects_incomplete_orientation_sets():
@@ -227,57 +183,6 @@ def test_aggregate_rejects_incomplete_orientation_sets():
 
     with pytest.raises(ValueError, match="expected.*direct.*reversed"):
         aggregate_battle_preferences(annotations, swap_mode="both")
-
-
-def test_aggregate_rejects_invalid_mode_and_conflicting_metadata():
-    with pytest.raises(ValueError, match="supports fixed or both"):
-        aggregate_battle_preferences(pd.DataFrame(), swap_mode="random")
-
-    annotations = pd.DataFrame(
-        [
-            _pass_row("q1", "direct", 0.2),
-            _pass_row("q1", "reversed", 0.2, model_b="other"),
-        ]
-    )
-    with pytest.raises(ValueError, match="conflicting metadata.*model_b"):
-        aggregate_battle_preferences(annotations, swap_mode="both")
-
-
-@pytest.mark.parametrize(
-    ("swap_mode", "direct", "reversed_passes", "message"),
-    [
-        ("fixed", [], None, "direct passes"),
-        ("fixed", ["annotation"], ["annotation"], "returned reversed passes"),
-        ("both", ["annotation"], None, "reversed passes"),
-    ],
-)
-def test_annotation_validates_shared_judge_pass_contract(
-    swap_mode, direct, reversed_passes, message, monkeypatch
-):
-    annotation = _annotation(
-        "Alpha answer", "Beta answer", ParsedPreference(preference=0.25)
-    )
-    direct_annotations = [annotation for _ in direct]
-    reversed_annotations = (
-        None if reversed_passes is None else [annotation for _ in reversed_passes]
-    )
-    monkeypatch.setattr(
-        annotate_module,
-        "judge_and_parse_prefs",
-        lambda **kwargs: (
-            direct_annotations,
-            reversed_annotations,
-            pd.Series(dtype="float64"),
-        ),
-    )
-
-    with pytest.raises(ValueError, match=message):
-        annotate_sample(
-            _sample(),
-            _config(swap_mode),
-            judge_chat_model=object(),
-            resolved_prompt=resolve_judge_prompt(preset="meta-eval-pair-score"),
-        )
 
 
 @pytest.mark.parametrize(
@@ -308,4 +213,4 @@ def test_conversation_validation_requires_matching_user_assistant_pairs(
     mutate(sample)
 
     with pytest.raises(ValueError, match=message):
-        validate_battle_conversations(sample)
+        _battle_texts(sample)

--- a/tests/test_meta_eval_annotations.py
+++ b/tests/test_meta_eval_annotations.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 from types import SimpleNamespace
 
+import numpy as np
 import pandas as pd
 import pytest
 
@@ -75,6 +76,18 @@ def _pass_row(battle_id: str, orientation: str, pref: float) -> dict[str, object
         "orientation": orientation,
         "pref": pref,
     }
+
+
+def test_battle_texts_accepts_parquet_array_conversations():
+    sample = _sample()
+    for column in ("conversation_a", "conversation_b"):
+        sample.at[0, column] = np.asarray(sample.at[0, column], dtype=object)
+
+    assert _battle_texts(sample) == (
+        ["Same prompt"],
+        ["Alpha answer"],
+        ["Beta answer"],
+    )
 
 
 def test_annotation_uses_each_structured_parse_and_preserves_raw_evidence(

--- a/tests/test_meta_eval_annotations.py
+++ b/tests/test_meta_eval_annotations.py
@@ -25,11 +25,6 @@ def _sample() -> pd.DataFrame:
         [
             {
                 "battle_id": "arena:q1",
-                "question_id": "q1",
-                "model_a": "alpha",
-                "model_b": "beta",
-                "winner": "model_a",
-                "lang": "en",
                 "conversation_a": [
                     {"role": "user", "content": "Same prompt"},
                     {"role": "assistant", "content": "Alpha answer"},
@@ -70,34 +65,18 @@ def _annotation(
     )
 
 
-def _pass_row(battle_id: str, orientation: str, pref: float) -> dict[str, object]:
-    return {
-        "battle_id": battle_id,
-        "orientation": orientation,
-        "pref": pref,
-    }
-
-
-def test_battle_texts_accepts_parquet_array_conversations():
+def test_annotation_preserves_canonical_preferences_and_raw_evidence(monkeypatch):
     sample = _sample()
     for column in ("conversation_a", "conversation_b"):
         sample.at[0, column] = np.asarray(sample.at[0, column], dtype=object)
-
-    assert _battle_texts(sample) == (
-        ["Same prompt"],
-        ["Alpha answer"],
-        ["Beta answer"],
-    )
-
-
-def test_annotation_uses_each_structured_parse_and_preserves_raw_evidence(
-    monkeypatch,
-):
+    prompt = resolve_judge_prompt(preset="meta-eval-pair-score")
+    preference = prompt.parser.preference_from_scores(9.0, 1.0)
+    reversed_preference = prompt.parser.preference_from_scores(1.0, 7.0)
     direct = _annotation(
         "Alpha answer",
         "Beta answer",
         ParsedPreference(
-            preference=0.2,
+            preference=preference,
             label="A",
             scores={"A": 9.0, "B": 1.0},
             details={"reason": "direct"},
@@ -107,42 +86,42 @@ def test_annotation_uses_each_structured_parse_and_preserves_raw_evidence(
         "Beta answer",
         "Alpha answer",
         ParsedPreference(
-            preference=0.8,
+            preference=reversed_preference,
             label="B",
-            scores={"A": 1.0, "B": 9.0},
+            scores={"A": 1.0, "B": 7.0},
             details={"reason": "reversed"},
         ),
     )
 
     def fake_judge_and_parse_prefs(**kwargs):
         assert kwargs["swap_mode"] == "both"
-        return [direct], [reversed_pass], pd.Series([0.99, 0.01])
+        assert kwargs["instructions"] == ["Same prompt"]
+        assert kwargs["completions_A"] == ["Alpha answer"]
+        assert kwargs["completions_B"] == ["Beta answer"]
+        # judge_and_parse_prefs already reorients the reversed preference.
+        return (
+            [direct],
+            [reversed_pass],
+            pd.Series([preference, 1 - reversed_preference]),
+        )
 
     monkeypatch.setattr(
         annotate_module, "judge_and_parse_prefs", fake_judge_and_parse_prefs
     )
     rows = annotate_sample(
-        _sample(),
+        sample,
         _config("both"),
         judge_chat_model=object(),
-        resolved_prompt=resolve_judge_prompt(preset="meta-eval-pair-score"),
+        resolved_prompt=prompt,
     )
 
-    assert list(rows.columns) == [
-        "battle_id",
-        "orientation",
-        "pref",
-        "judge_input",
-        "judge_completion",
-        "judge_top_logprobs_json",
-        "parsed_label",
-        "parsed_scores_json",
-        "parsed_details_json",
-    ]
     assert rows["orientation"].tolist() == ["direct", "reversed"]
-    assert rows["pref"].tolist() == pytest.approx([0.99, 0.01])
+    assert rows["pref"].tolist() == pytest.approx([preference, 1 - reversed_preference])
     assert rows["parsed_label"].tolist() == ["A", "B"]
-    assert json.loads(rows.loc[1, "parsed_scores_json"]) == {"A": 1.0, "B": 9.0}
+    assert rows["judge_input"].tolist() == ["judge input", "judge input"]
+    assert rows["judge_completion"].tolist() == ["judge output", "judge output"]
+    assert json.loads(rows.loc[1, "judge_top_logprobs_json"]) == {"token": -0.25}
+    assert json.loads(rows.loc[1, "parsed_scores_json"]) == {"A": 1.0, "B": 7.0}
     assert json.loads(rows.loc[1, "parsed_details_json"]) == {"reason": "reversed"}
 
 
@@ -172,27 +151,29 @@ def test_fixed_annotation_uses_single_orientation(monkeypatch):
 def test_aggregate_requires_every_pass_and_leaves_partial_evidence_raw():
     annotations = pd.DataFrame(
         [
-            _pass_row("complete", "direct", 0.2),
-            _pass_row("complete", "reversed", 0.4),
-            _pass_row("partial", "direct", 0.5001),
-            _pass_row("partial", "reversed", float("nan")),
-            _pass_row("missing", "direct", float("nan")),
-            _pass_row("missing", "reversed", float("nan")),
-        ]
+            ("complete", "direct", 0.2),
+            ("complete", "reversed", 0.4),
+            ("partial", "direct", 0.5001),
+            ("partial", "reversed", float("nan")),
+            ("missing", "direct", float("nan")),
+            ("missing", "reversed", float("nan")),
+        ],
+        columns=["battle_id", "orientation", "pref"],
     )
 
     battles = aggregate_battle_preferences(annotations, swap_mode="both").set_index(
         "battle_id"
     )
 
-    assert list(battles.reset_index().columns) == ["battle_id", "pref"]
     assert battles.loc["complete", "pref"] == pytest.approx(0.3)
     assert pd.isna(battles.loc["partial", "pref"])
     assert pd.isna(battles.loc["missing", "pref"])
 
 
 def test_aggregate_rejects_incomplete_orientation_sets():
-    annotations = pd.DataFrame([_pass_row("q1", "direct", 0.2)])
+    annotations = pd.DataFrame(
+        {"battle_id": ["q1"], "orientation": ["direct"], "pref": [0.2]}
+    )
 
     with pytest.raises(ValueError, match="expected.*direct.*reversed"):
         aggregate_battle_preferences(annotations, swap_mode="both")

--- a/tests/test_meta_eval_annotations.py
+++ b/tests/test_meta_eval_annotations.py
@@ -1,0 +1,311 @@
+"""Focused tests for canonical meta-evaluation annotation rows."""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pandas as pd
+import pytest
+
+import judgearena.benchmarks.meta_eval.annotate as annotate_module
+from judgearena.benchmarks.meta_eval.annotate import (
+    aggregate_battle_preferences,
+    annotate_sample,
+    validate_battle_conversations,
+)
+from judgearena.evaluate import JudgeAnnotation
+from judgearena.prompts.parsing import ParsedPreference
+from judgearena.prompts.registry import resolve_judge_prompt
+
+
+def _sample() -> pd.DataFrame:
+    return pd.DataFrame(
+        [
+            {
+                "battle_id": "arena:q1",
+                "question_id": "q1",
+                "model_a": "alpha",
+                "model_b": "beta",
+                "winner": "model_a",
+                "lang": "en",
+                "conversation_a": [
+                    {"role": "user", "content": "Same prompt"},
+                    {"role": "assistant", "content": "Alpha answer"},
+                ],
+                "conversation_b": [
+                    {"role": "user", "content": "Same prompt"},
+                    {"role": "assistant", "content": "Beta answer"},
+                ],
+            }
+        ]
+    )
+
+
+def _config(swap_mode: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        judge=SimpleNamespace(
+            swap_mode=swap_mode,
+            strip_thinking_before_judging=False,
+        ),
+        generation=SimpleNamespace(truncate_judge_input_chars=8192),
+        run=SimpleNamespace(use_tqdm=False),
+    )
+
+
+def _annotation(
+    completion_a: str,
+    completion_b: str,
+    parsed: ParsedPreference | None,
+) -> JudgeAnnotation:
+    return JudgeAnnotation(
+        instruction="Same prompt",
+        completion_A=completion_a,
+        completion_B=completion_b,
+        judge_completion="judge output",
+        judge_input="judge input",
+        judge_top_logprobs={"token": -0.25},
+        parsed=parsed,
+    )
+
+
+def _pass_row(
+    battle_id: str,
+    orientation: str,
+    pref: float,
+    **overrides,
+) -> dict[str, object]:
+    row: dict[str, object] = {
+        "battle_id": battle_id,
+        "question_id": battle_id,
+        "model_a": "a",
+        "model_b": "b",
+        "winner": "model_a",
+        "lang": "en",
+        "parse_ok": not pd.isna(pref),
+        "pref": pref,
+        "orientation": orientation,
+    }
+    row.update(overrides)
+    return row
+
+
+def test_annotation_uses_each_structured_parse_and_preserves_raw_evidence(
+    monkeypatch,
+):
+    direct = _annotation(
+        "Alpha answer",
+        "Beta answer",
+        ParsedPreference(
+            preference=0.2,
+            label="A",
+            scores={"A": 9.0, "B": 1.0},
+            details={"reason": "direct"},
+        ),
+    )
+    reversed_pass = _annotation(
+        "Beta answer",
+        "Alpha answer",
+        ParsedPreference(
+            preference=0.8,
+            label="B",
+            scores={"A": 1.0, "B": 9.0},
+            details={"reason": "reversed"},
+        ),
+    )
+
+    def fake_judge_and_parse_prefs(**kwargs):
+        assert kwargs["swap_mode"] == "both"
+        # The shared function returns already-combined preferences. Annotation
+        # production must instead read the structured result attached to each pass.
+        return [direct], [reversed_pass], pd.Series([0.99, 0.01])
+
+    monkeypatch.setattr(
+        annotate_module, "judge_and_parse_prefs", fake_judge_and_parse_prefs
+    )
+    rows = annotate_sample(
+        _sample(),
+        _config("both"),
+        judge_chat_model=object(),
+        resolved_prompt=resolve_judge_prompt(preset="meta-eval-pair-score"),
+    )
+
+    assert rows["orientation"].tolist() == ["direct", "reversed"]
+    assert rows["pref_judge_input"].tolist() == pytest.approx([0.2, 0.8])
+    assert rows["pref"].tolist() == pytest.approx([0.2, 0.2])
+    assert rows["completion_a"].tolist() == ["Alpha answer", "Alpha answer"]
+    assert rows["completion_b"].tolist() == ["Beta answer", "Beta answer"]
+    assert rows["judge_input_completion_a"].tolist() == [
+        "Alpha answer",
+        "Beta answer",
+    ]
+    assert rows["parsed_label"].tolist() == ["A", "B"]
+    assert json.loads(rows.loc[1, "parsed_scores_json"]) == {"A": 1.0, "B": 9.0}
+    assert json.loads(rows.loc[1, "parsed_details_json"]) == {"reason": "reversed"}
+
+
+def test_fixed_annotation_uses_single_orientation(monkeypatch):
+    annotation = _annotation(
+        "Alpha answer",
+        "Beta answer",
+        ParsedPreference(preference=0.75),
+    )
+    monkeypatch.setattr(
+        annotate_module,
+        "judge_and_parse_prefs",
+        lambda **kwargs: ([annotation], None, pd.Series([0.75])),
+    )
+
+    rows = annotate_sample(
+        _sample(),
+        _config("fixed"),
+        judge_chat_model=object(),
+        resolved_prompt=resolve_judge_prompt(preset="meta-eval-pair-score"),
+    )
+
+    assert rows["orientation"].tolist() == ["single"]
+    assert rows["pref"].tolist() == [0.75]
+
+
+def test_annotation_rejects_unimplemented_random_swap_mode(monkeypatch):
+    monkeypatch.setattr(
+        annotate_module,
+        "judge_and_parse_prefs",
+        lambda **kwargs: pytest.fail("judge must not be called"),
+    )
+
+    with pytest.raises(ValueError, match="supports fixed or both"):
+        annotate_sample(
+            _sample(),
+            _config("random"),
+            judge_chat_model=object(),
+            resolved_prompt=resolve_judge_prompt(preset="meta-eval-pair-score"),
+        )
+
+
+def test_aggregate_produces_one_physical_row_and_all_parse_statuses():
+    annotations = pd.DataFrame(
+        [
+            _pass_row("complete", "direct", 0.2),
+            _pass_row("complete", "reversed", 0.4),
+            _pass_row("partial", "direct", 0.5001, winner="model_b"),
+            _pass_row(
+                "partial",
+                "reversed",
+                float("nan"),
+                winner="model_b",
+                parse_ok=False,
+            ),
+            _pass_row("missing", "direct", float("nan"), winner="tie", parse_ok=False),
+            _pass_row(
+                "missing", "reversed", float("nan"), winner="tie", parse_ok=False
+            ),
+        ]
+    )
+
+    battles = aggregate_battle_preferences(annotations, swap_mode="both").set_index(
+        "battle_id"
+    )
+
+    assert len(battles) == 3
+    assert battles.loc["complete", "pref"] == pytest.approx(0.3)
+    assert battles.loc["complete", "pref_hard"] == 0.0
+    assert battles.loc["complete", "parse_status"] == "complete"
+    assert battles.loc["complete", "n_passes_parsed"] == 2
+    assert battles.loc["partial", "pref"] == pytest.approx(0.5001)
+    assert battles.loc["partial", "pref_hard"] == 1.0
+    assert battles.loc["partial", "parse_status"] == "partial"
+    assert battles.loc["partial", "n_passes_parsed"] == 1
+    assert pd.isna(battles.loc["missing", "pref"])
+    assert pd.isna(battles.loc["missing", "pref_hard"])
+    assert battles.loc["missing", "parse_status"] == "missing"
+    assert battles.loc["missing", "n_passes_expected"] == 2
+
+
+def test_aggregate_rejects_incomplete_orientation_sets():
+    annotations = pd.DataFrame([_pass_row("q1", "direct", 0.2)])
+
+    with pytest.raises(ValueError, match="expected.*direct.*reversed"):
+        aggregate_battle_preferences(annotations, swap_mode="both")
+
+
+def test_aggregate_rejects_invalid_mode_and_conflicting_metadata():
+    with pytest.raises(ValueError, match="supports fixed or both"):
+        aggregate_battle_preferences(pd.DataFrame(), swap_mode="random")
+
+    annotations = pd.DataFrame(
+        [
+            _pass_row("q1", "direct", 0.2),
+            _pass_row("q1", "reversed", 0.2, model_b="other"),
+        ]
+    )
+    with pytest.raises(ValueError, match="conflicting metadata.*model_b"):
+        aggregate_battle_preferences(annotations, swap_mode="both")
+
+
+@pytest.mark.parametrize(
+    ("swap_mode", "direct", "reversed_passes", "message"),
+    [
+        ("fixed", [], None, "direct passes"),
+        ("fixed", ["annotation"], ["annotation"], "returned reversed passes"),
+        ("both", ["annotation"], None, "reversed passes"),
+    ],
+)
+def test_annotation_validates_shared_judge_pass_contract(
+    swap_mode, direct, reversed_passes, message, monkeypatch
+):
+    annotation = _annotation(
+        "Alpha answer", "Beta answer", ParsedPreference(preference=0.25)
+    )
+    direct_annotations = [annotation for _ in direct]
+    reversed_annotations = (
+        None if reversed_passes is None else [annotation for _ in reversed_passes]
+    )
+    monkeypatch.setattr(
+        annotate_module,
+        "judge_and_parse_prefs",
+        lambda **kwargs: (
+            direct_annotations,
+            reversed_annotations,
+            pd.Series(dtype="float64"),
+        ),
+    )
+
+    with pytest.raises(ValueError, match=message):
+        annotate_sample(
+            _sample(),
+            _config(swap_mode),
+            judge_chat_model=object(),
+            resolved_prompt=resolve_judge_prompt(preset="meta-eval-pair-score"),
+        )
+
+
+@pytest.mark.parametrize(
+    "mutate, message",
+    [
+        (
+            lambda sample: sample.at[0, "conversation_b"].pop(),
+            "requires user and assistant turns",
+        ),
+        (
+            lambda sample: sample.at[0, "conversation_a"][0].update(
+                {"role": "assistant"}
+            ),
+            "requires user and assistant turns",
+        ),
+        (
+            lambda sample: sample.at[0, "conversation_b"][0].update(
+                {"content": "Different prompt"}
+            ),
+            "different user prompts",
+        ),
+    ],
+)
+def test_conversation_validation_requires_matching_user_assistant_pairs(
+    mutate, message
+):
+    sample = _sample()
+    mutate(sample)
+
+    with pytest.raises(ValueError, match=message):
+        validate_battle_conversations(sample)

--- a/tests/test_meta_eval_annotations.py
+++ b/tests/test_meta_eval_annotations.py
@@ -9,14 +9,12 @@ import numpy as np
 import pandas as pd
 import pytest
 
-import judgearena.benchmarks.meta_eval.annotate as annotate_module
+import judgearena.evaluate as evaluate
 from judgearena.benchmarks.meta_eval.annotate import (
     _battle_texts,
     aggregate_battle_preferences,
     annotate_sample,
 )
-from judgearena.evaluate import JudgeAnnotation
-from judgearena.prompts.parsing import ParsedPreference
 from judgearena.prompts.registry import resolve_judge_prompt
 
 
@@ -40,134 +38,89 @@ def _sample() -> pd.DataFrame:
 
 def _config(swap_mode: str) -> SimpleNamespace:
     return SimpleNamespace(
-        judge=SimpleNamespace(
-            swap_mode=swap_mode,
-            strip_thinking_before_judging=False,
-        ),
+        judge=SimpleNamespace(swap_mode=swap_mode, strip_thinking_before_judging=False),
         generation=SimpleNamespace(truncate_judge_input_chars=8192),
         run=SimpleNamespace(use_tqdm=False),
     )
 
 
-def _annotation(
-    completion_a: str,
-    completion_b: str,
-    parsed: ParsedPreference | None,
-) -> JudgeAnnotation:
-    return JudgeAnnotation(
-        instruction="Same prompt",
-        completion_A=completion_a,
-        completion_B=completion_b,
-        judge_completion="judge output",
-        judge_input="judge input",
-        judge_top_logprobs={"token": -0.25},
-        parsed=parsed,
-    )
-
-
-def test_annotation_preserves_canonical_preferences_and_raw_evidence(monkeypatch):
-    sample = _sample()
+@pytest.mark.parametrize("swap_mode", ["fixed", "both"])
+def test_annotation_parses_swaps_and_aggregates_physical_battles(
+    monkeypatch, swap_mode
+):
+    sample = pd.concat([_sample()] * 3, ignore_index=True)
+    sample["battle_id"] = ["complete", "partial", "missing"]
     for column in ("conversation_a", "conversation_b"):
-        sample.at[0, column] = np.asarray(sample.at[0, column], dtype=object)
-    prompt = resolve_judge_prompt(preset="meta-eval-pair-score")
-    preference = prompt.parser.preference_from_scores(9.0, 1.0)
-    reversed_preference = prompt.parser.preference_from_scores(1.0, 7.0)
-    direct = _annotation(
-        "Alpha answer",
-        "Beta answer",
-        ParsedPreference(
-            preference=preference,
-            label="A",
-            scores={"A": 9.0, "B": 1.0},
-            details={"reason": "direct"},
-        ),
-    )
-    reversed_pass = _annotation(
-        "Beta answer",
-        "Alpha answer",
-        ParsedPreference(
-            preference=reversed_preference,
-            label="B",
-            scores={"A": 1.0, "B": 7.0},
-            details={"reason": "reversed"},
-        ),
-    )
-
-    def fake_judge_and_parse_prefs(**kwargs):
-        assert kwargs["swap_mode"] == "both"
-        assert kwargs["instructions"] == ["Same prompt"]
-        assert kwargs["completions_A"] == ["Alpha answer"]
-        assert kwargs["completions_B"] == ["Beta answer"]
-        # judge_and_parse_prefs already reorients the reversed preference.
-        return (
-            [direct],
-            [reversed_pass],
-            pd.Series([preference, 1 - reversed_preference]),
+        sample[column] = sample[column].map(
+            lambda turns: np.asarray(turns, dtype=object)
         )
+    prompt = resolve_judge_prompt(preset="meta-eval-pair-score")
+    direct = ["score_A: 9\nscore_B: 1", "score_A: 5\nscore_B: 6", "unparseable"]
+    reversed_outputs = ["score_A: 1\nscore_B: 7", "unparseable", "unparseable"]
+    responses = iter([direct, reversed_outputs])
+    rendered = []
 
-    monkeypatch.setattr(
-        annotate_module, "judge_and_parse_prefs", fake_judge_and_parse_prefs
-    )
+    def fake_inference(*, inputs, **kwargs):
+        rendered.extend(value.to_string() for value in inputs)
+        return next(responses)
+
+    monkeypatch.setattr(evaluate, "do_inference", fake_inference)
     rows = annotate_sample(
-        sample,
-        _config("both"),
-        judge_chat_model=object(),
-        resolved_prompt=prompt,
+        sample, _config(swap_mode), judge_chat_model=object(), resolved_prompt=prompt
     )
 
-    assert rows["orientation"].tolist() == ["direct", "reversed"]
-    assert rows["pref"].tolist() == pytest.approx([preference, 1 - reversed_preference])
-    assert rows["parsed_label"].tolist() == ["A", "B"]
-    assert rows["judge_input"].tolist() == ["judge input", "judge input"]
-    assert rows["judge_completion"].tolist() == ["judge output", "judge output"]
-    assert json.loads(rows.loc[1, "judge_top_logprobs_json"]) == {"token": -0.25}
-    assert json.loads(rows.loc[1, "parsed_scores_json"]) == {"A": 1.0, "B": 7.0}
-    assert json.loads(rows.loc[1, "parsed_details_json"]) == {"reason": "reversed"}
-
-
-def test_fixed_annotation_uses_single_orientation(monkeypatch):
-    annotation = _annotation(
-        "Alpha answer",
-        "Beta answer",
-        ParsedPreference(preference=0.75),
+    both = swap_mode == "both"
+    assert rows["orientation"].tolist() == (
+        ["direct"] * 3 + ["reversed"] * 3 if both else ["single"] * 3
     )
-    monkeypatch.setattr(
-        annotate_module,
-        "judge_and_parse_prefs",
-        lambda **kwargs: ([annotation], None, pd.Series([0.75])),
+    assert rows["judge_input"].tolist() == rendered
+    for i, value in enumerate(rendered):
+        assert "Same prompt" in value
+        assert (value.index("Alpha answer") < value.index("Beta answer")) == (i < 3)
+    assert rows["judge_completion"].tolist() == direct + (
+        reversed_outputs if both else []
     )
+    direct_pref = prompt.parser.preference_from_scores(9, 1)
+    partial_pref = prompt.parser.preference_from_scores(5, 6)
+    assert pd.isna(rows.loc[2, "pref"])
+    missing_evidence = rows.loc[
+        2, ["parsed_label", "parsed_scores_json", "parsed_details_json"]
+    ]
+    assert missing_evidence.isna().all()
+    assert json.loads(rows.loc[0, "parsed_scores_json"]) == {"A": 9.0, "B": 1.0}
+    expected = direct_pref
+    if both:
+        reversed_pref = 1 - prompt.parser.preference_from_scores(1, 7)
+        assert rows.loc[3, "pref"] == pytest.approx(reversed_pref)
+        assert rows.loc[4:, "pref"].isna().all()
+        assert json.loads(rows.loc[3, "parsed_scores_json"]) == {"A": 1.0, "B": 7.0}
+        expected = (direct_pref + reversed_pref) / 2
+    battles = aggregate_battle_preferences(rows, swap_mode=swap_mode).set_index(
+        "battle_id"
+    )
+    assert rows.loc[:1, "pref"].tolist() == pytest.approx([direct_pref, partial_pref])
+    assert battles.loc["complete", "pref"] == pytest.approx(expected)
+    if both:
+        assert pd.isna(battles.loc["partial", "pref"])
+    else:
+        assert battles.loc["partial", "pref"] == pytest.approx(partial_pref)
+    assert pd.isna(battles.loc["missing", "pref"])
 
+
+def test_annotation_preserves_parser_label_and_details(monkeypatch):
+    output = (
+        '{"ordered_models": [{"model": "M", "rank": 1}, {"model": "m", "rank": 2}]}'
+    )
+    monkeypatch.setattr(evaluate, "do_inference", lambda **kwargs: [output])
     rows = annotate_sample(
         _sample(),
         _config("fixed"),
         judge_chat_model=object(),
-        resolved_prompt=resolve_judge_prompt(preset="meta-eval-pair-score"),
+        resolved_prompt=resolve_judge_prompt(preset="meta-eval-alpaca-eval-json"),
     )
-
-    assert rows["orientation"].tolist() == ["single"]
-    assert rows["pref"].tolist() == [0.75]
-
-
-def test_aggregate_requires_every_pass_and_leaves_partial_evidence_raw():
-    annotations = pd.DataFrame(
-        [
-            ("complete", "direct", 0.2),
-            ("complete", "reversed", 0.4),
-            ("partial", "direct", 0.5001),
-            ("partial", "reversed", float("nan")),
-            ("missing", "direct", float("nan")),
-            ("missing", "reversed", float("nan")),
-        ],
-        columns=["battle_id", "orientation", "pref"],
-    )
-
-    battles = aggregate_battle_preferences(annotations, swap_mode="both").set_index(
-        "battle_id"
-    )
-
-    assert battles.loc["complete", "pref"] == pytest.approx(0.3)
-    assert pd.isna(battles.loc["partial", "pref"])
-    assert pd.isna(battles.loc["missing", "pref"])
+    assert rows.loc[0, "pref"] == 1.0
+    assert rows.loc[0, "parsed_label"] == "M"
+    assert json.loads(rows.loc[0, "parsed_details_json"]) == {"ranks": {"M": 1, "m": 2}}
 
 
 def test_aggregate_rejects_incomplete_orientation_sets():

--- a/tests/test_meta_eval_foundation.py
+++ b/tests/test_meta_eval_foundation.py
@@ -17,11 +17,11 @@ from judgearena.benchmarks.meta_eval.sampling import (
     select_top_models,
 )
 from judgearena.prompts.parsing import JUDGE_PARSERS
-from judgearena.prompts.registry import resolve_judge_prompt
-from judgearena.tasks.schema import MetaEvalProtocol, TaskSpec
+from judgearena.tasks.registry import get_packaged_task
+from judgearena.tasks.schema import TaskSpec
 
 
-def _battles() -> pd.DataFrame:
+def test_sampling_is_deterministic_connected_and_limited_to_top_models():
     models = ["m1", "m2", "m3"]
     rows = [
         {
@@ -40,11 +40,7 @@ def _battles() -> pd.DataFrame:
             "model_b": "m1",
         }
     )
-    return pd.DataFrame(rows)
-
-
-def test_sampling_is_deterministic_connected_and_limited_to_top_models():
-    battles = _battles()
+    battles = pd.DataFrame(rows)
     top, top_pool = select_top_models(battles, top_models=3)
 
     sample = sample_battles_per_model(top_pool, top, battles_per_model=4, seed=7)
@@ -92,65 +88,23 @@ def test_sampling_rejects_self_comparisons_and_insufficient_quota():
         sample_battles_per_model(top_pool, top, battles_per_model=3, seed=0)
 
 
-def _meta_task() -> dict[str, object]:
-    return {
-        "schema_version": 1,
-        "task": "meta-test",
-        "task_version": 1,
-        "description": "Meta-evaluation schema test.",
-        "dataset": {
-            "adapter": "arena_battles",
-            "sources": {
-                "battles": {
-                    "type": "huggingface_dataset",
-                    "repo_id": "example/battles",
-                    "revision": "a" * 40,
-                }
-            },
-            "fields": {"id": "question_id", "instruction": "conversation_a"},
-        },
-        "protocol": {
-            "runner": "meta_eval",
-            "arena": "Test Arena",
-            "baseline": {"strategy": "none"},
-            "judge": {"default_prompt_preset": "meta-eval-pair-score"},
-            "scoring": {
-                "metrics": [
-                    {
-                        "metric": "meta_eval_agreement",
-                        "parameters": {"n_bootstraps": 10, "tie_tolerance": 0.01},
-                    }
-                ]
-            },
-        },
-    }
+def test_meta_eval_protocol_requires_no_baseline_and_compatible_metrics():
+    definition = get_packaged_task("meta-eval-comparia").spec.model_dump()
+    protocol = definition["protocol"]
+    assert protocol["baseline"]["strategy"] == "none"
 
-
-def test_meta_eval_protocol_uses_no_baseline_and_current_scoring_schema():
-    definition = _meta_task()
-    task = TaskSpec.model_validate(definition)
-
-    assert isinstance(task.protocol, MetaEvalProtocol)
-    assert task.protocol.baseline.strategy == "none"
-    assert task.protocol.scoring.metrics[0].metric == "meta_eval_agreement"
-
-    metric = definition["protocol"]["scoring"]["metrics"][0]  # type: ignore[index]
+    metric = protocol["scoring"]["metrics"][0]
     metric["metric"] = "pairwise_win_rate"
-    with pytest.raises(ValueError, match="unsupported meta-evaluation metric"):
+    with pytest.raises(ValidationError, match="unsupported meta-evaluation metric"):
         TaskSpec.model_validate(definition)
 
     metric["metric"] = "meta_eval_agreement"
     metric["group_by"] = ["lang"]
-    with pytest.raises(ValueError, match="does not support group_by"):
+    with pytest.raises(ValidationError, match="does not support group_by"):
         TaskSpec.model_validate(definition)
 
-
-def test_meta_eval_protocol_rejects_a_model_baseline():
-    definition = _meta_task()
-    definition["protocol"]["baseline"] = {  # type: ignore[index]
-        "strategy": "runtime_required"
-    }
-
+    metric["group_by"] = []
+    protocol["baseline"] = {"strategy": "runtime_required"}
     with pytest.raises(ValidationError):
         TaskSpec.model_validate(definition)
 
@@ -203,22 +157,6 @@ def test_alpaca_eval_json_preserves_complete_ranks():
 )
 def test_alpaca_eval_json_rejects_malformed_rankings(completion):
     assert JUDGE_PARSERS["alpaca-eval-json"].parse_result(completion) is None
-
-
-@pytest.mark.parametrize(
-    ("preset", "parser_name"),
-    [
-        ("meta-eval-pair-score", "meta-eval-score"),
-        ("meta-eval-alpaca-eval-json", "alpaca-eval-json"),
-        ("meta-eval-alpaca-eval-pair-score", "meta-eval-score"),
-    ],
-)
-def test_meta_eval_prompt_presets_select_their_parser(preset, parser_name):
-    resolved = resolve_judge_prompt(preset=preset)
-
-    assert resolved.parser is JUDGE_PARSERS[parser_name]
-    assert resolved.system_prompt
-    assert resolved.user_prompt_template
 
 
 @pytest.mark.parametrize(

--- a/tests/test_meta_eval_foundation.py
+++ b/tests/test_meta_eval_foundation.py
@@ -1,0 +1,266 @@
+"""Focused tests for meta-evaluation schema, prompts, parsers, and sampling."""
+
+from __future__ import annotations
+
+import json
+
+import pandas as pd
+import pytest
+from pydantic import ValidationError
+
+import judgearena.evaluate as evaluate_module
+from judgearena.benchmarks.meta_eval.sampling import (
+    MetaEvalSamplingError,
+    comparison_components,
+    count_battles_per_model,
+    sample_battles_per_model,
+    select_top_models,
+)
+from judgearena.prompts.parsing import JUDGE_PARSERS
+from judgearena.prompts.registry import resolve_judge_prompt
+from judgearena.tasks.schema import MetaEvalProtocol, TaskSpec
+
+
+def _battles() -> pd.DataFrame:
+    models = ["m1", "m2", "m3"]
+    rows = [
+        {
+            "battle_id": f"arena:q{i}",
+            "question_id": f"q{i}",
+            "model_a": models[i % 3],
+            "model_b": models[(i + 1) % 3],
+        }
+        for i in range(18)
+    ]
+    rows.append(
+        {
+            "battle_id": "arena:rare",
+            "question_id": "rare",
+            "model_a": "rare",
+            "model_b": "m1",
+        }
+    )
+    return pd.DataFrame(rows)
+
+
+def test_sampling_is_deterministic_connected_and_limited_to_top_models():
+    battles = _battles()
+    top, top_pool = select_top_models(battles, top_models=3)
+
+    sample = sample_battles_per_model(top_pool, top, battles_per_model=4, seed=7)
+    shuffled = sample_battles_per_model(
+        top_pool.sample(frac=1, random_state=42),
+        top,
+        battles_per_model=4,
+        seed=7,
+    )
+
+    assert set(top) == {"m1", "m2", "m3"}
+    assert "rare" not in set(top_pool["question_id"])
+    assert sample["battle_id"].is_unique
+    assert all(count >= 4 for count in count_battles_per_model(sample).values())
+    assert comparison_components(sample, top) == [frozenset(top)]
+    pd.testing.assert_frame_equal(sample, shuffled)
+
+
+def test_sampling_rejects_disconnected_top_model_pool():
+    battles = pd.DataFrame(
+        [
+            {"model_a": "a", "model_b": "b"},
+            {"model_a": "c", "model_b": "d"},
+        ]
+    )
+
+    with pytest.raises(MetaEvalSamplingError, match="disconnected"):
+        select_top_models(battles, top_models=4)
+
+
+def test_sampling_requires_unique_stable_battle_ids():
+    top, top_pool = select_top_models(_battles(), top_models=3)
+
+    with pytest.raises(MetaEvalSamplingError, match="Stable battle_id"):
+        sample_battles_per_model(
+            top_pool.drop(columns="battle_id"),
+            top,
+            battles_per_model=4,
+            seed=0,
+        )
+
+    top_pool.loc[1, "battle_id"] = top_pool.loc[0, "battle_id"]
+    with pytest.raises(MetaEvalSamplingError, match="present and unique"):
+        sample_battles_per_model(top_pool, top, battles_per_model=4, seed=0)
+
+
+def test_sampling_rejects_self_comparisons_and_insufficient_quota():
+    self_comparison = pd.DataFrame(
+        [
+            {"battle_id": "self", "model_a": "a", "model_b": "a"},
+            {"battle_id": "ab", "model_a": "a", "model_b": "b"},
+        ]
+    )
+    with pytest.raises(MetaEvalSamplingError, match="self-comparisons"):
+        select_top_models(self_comparison, top_models=2)
+    assert count_battles_per_model(self_comparison) == {"a": 2, "b": 1}
+
+    battles = pd.DataFrame(
+        [{"battle_id": f"q{i}", "model_a": "a", "model_b": "b"} for i in range(2)]
+    )
+    top, top_pool = select_top_models(battles, top_models=2)
+    with pytest.raises(MetaEvalSamplingError, match="Insufficient unique battles"):
+        sample_battles_per_model(top_pool, top, battles_per_model=3, seed=0)
+
+
+def _meta_task() -> dict[str, object]:
+    return {
+        "schema_version": 1,
+        "task": "meta-test",
+        "task_version": 1,
+        "description": "Meta-evaluation schema test.",
+        "dataset": {
+            "adapter": "arena_battles",
+            "sources": {
+                "battles": {
+                    "type": "huggingface_dataset",
+                    "repo_id": "example/battles",
+                    "revision": "a" * 40,
+                }
+            },
+            "fields": {"id": "question_id", "instruction": "conversation_a"},
+        },
+        "protocol": {
+            "runner": "meta_eval",
+            "arena": "Test Arena",
+            "baseline": {"strategy": "none"},
+            "judge": {"default_prompt_preset": "meta-eval-pair-score"},
+            "scoring": {"metrics": [{"metric": "pairwise_win_rate"}]},
+        },
+    }
+
+
+def test_meta_eval_protocol_uses_no_baseline_and_current_scoring_schema():
+    task = TaskSpec.model_validate(_meta_task())
+
+    assert isinstance(task.protocol, MetaEvalProtocol)
+    assert task.protocol.baseline.strategy == "none"
+    assert task.protocol.scoring.metrics[0].metric == "pairwise_win_rate"
+
+
+def test_meta_eval_protocol_rejects_a_model_baseline():
+    definition = _meta_task()
+    definition["protocol"]["baseline"] = {  # type: ignore[index]
+        "strategy": "runtime_required"
+    }
+
+    with pytest.raises(ValidationError):
+        TaskSpec.model_validate(definition)
+
+
+def test_meta_eval_pair_score_preserves_scores():
+    result = JUDGE_PARSERS["meta-eval-score"].parse_result(
+        '<think>ignore score_A: 0</think>\n"score_A": 9,\n"score_B": 1'
+    )
+
+    assert result is not None
+    assert result.preference == pytest.approx(0.01798620996)
+    assert result.scores == {"A": 9.0, "B": 1.0}
+
+
+@pytest.mark.parametrize(
+    "completion",
+    [
+        "score_A: 8.9\nscore_B: 8",
+        "score_A: -1\nscore_B: 8",
+        "score_A: 11\nscore_B: 8",
+        "score_A: 0009\nscore_B: 1",
+        "score_A: 8\nscore_B: 3.0",
+    ],
+)
+def test_meta_eval_pair_score_rejects_invalid_scores(completion):
+    assert JUDGE_PARSERS["meta-eval-score"].parse_result(completion) is None
+
+
+def test_alpaca_eval_json_preserves_complete_ranks():
+    result = JUDGE_PARSERS["alpaca-eval-json"].parse_result(
+        '```json\n{"ordered_models": [{"model": "M", "rank": 1}, '
+        '{"model": "m", "rank": 2}]}\n```'
+    )
+
+    assert result is not None
+    assert result.preference == 1.0
+    assert result.label == "M"
+    assert result.details == {"ranks": {"M": 1, "m": 2}}
+
+
+@pytest.mark.parametrize(
+    "completion",
+    [
+        "[]",
+        '{"ordered_models": ["m", "M"]}',
+        '{"ordered_models": [{"model": "m", "rank": 1}]}',
+        '{"ordered_models": [{"model": "m", "rank": 1}, {"model": "M", "rank": 1}]}',
+        '{"ordered_models": [{"model": "m", "rank": true}, {"model": "M", "rank": 2}]}',
+    ],
+)
+def test_alpaca_eval_json_rejects_malformed_rankings(completion):
+    assert JUDGE_PARSERS["alpaca-eval-json"].parse_result(completion) is None
+
+
+@pytest.mark.parametrize(
+    ("preset", "parser_name"),
+    [
+        ("meta-eval-pair-score", "meta-eval-score"),
+        ("meta-eval-alpaca-eval-json", "alpaca-eval-json"),
+        ("meta-eval-alpaca-eval-pair-score", "meta-eval-score"),
+    ],
+)
+def test_meta_eval_prompt_presets_select_their_parser(preset, parser_name):
+    resolved = resolve_judge_prompt(preset=preset)
+
+    assert resolved.parser is JUDGE_PARSERS[parser_name]
+    assert resolved.system_prompt
+    assert resolved.user_prompt_template
+
+
+@pytest.mark.parametrize(
+    "preset",
+    ["meta-eval-alpaca-eval-json", "meta-eval-alpaca-eval-pair-score"],
+)
+def test_meta_eval_alpaca_prompts_embed_json_safe_inputs(preset, monkeypatch):
+    captured_inputs = []
+
+    def fake_do_inference(**kwargs):
+        captured_inputs.extend(kwargs["inputs"])
+        return ["unparsed"]
+
+    monkeypatch.setattr(evaluate_module, "do_inference", fake_do_inference)
+    instruction = 'Say "hi"\r\nnext \\ path {curly} café'
+    completion_a = 'A says "yes"\nC:\\tmp {a}'
+    completion_b = 'B says "no"\r\nD:\\tmp {b}'
+
+    evaluate_module.annotate_battles(
+        judge_chat_model=object(),
+        instructions=[instruction],
+        completions_A=[completion_a],
+        completions_B=[completion_b],
+        prompt_preset=preset,
+        truncate_input_chars=None,
+    )
+
+    rendered = captured_inputs[0].messages[-1].content
+    prompt_json = rendered.split("## Prompt\n\n", 1)[1].split(
+        "\n\n## Model Outputs", 1
+    )[0]
+    outputs_json = rendered.split("## Model Outputs\n\n", 1)[1]
+    outputs_json = outputs_json.split("\n\n## Task", 1)[0].split("\n\n", 1)[1]
+
+    assert json.loads(prompt_json) == {"instruction": instruction}
+    assert json.loads(outputs_json) == [
+        {
+            "model": "m" if preset.endswith("json") else "model A",
+            "output": completion_a,
+        },
+        {
+            "model": "M" if preset.endswith("json") else "model B",
+            "output": completion_b,
+        },
+    ]

--- a/tests/test_meta_eval_foundation.py
+++ b/tests/test_meta_eval_foundation.py
@@ -75,22 +75,6 @@ def test_sampling_rejects_disconnected_top_model_pool():
         select_top_models(battles, top_models=4)
 
 
-def test_sampling_requires_unique_stable_battle_ids():
-    top, top_pool = select_top_models(_battles(), top_models=3)
-
-    with pytest.raises(MetaEvalSamplingError, match="Stable battle_id"):
-        sample_battles_per_model(
-            top_pool.drop(columns="battle_id"),
-            top,
-            battles_per_model=4,
-            seed=0,
-        )
-
-    top_pool.loc[1, "battle_id"] = top_pool.loc[0, "battle_id"]
-    with pytest.raises(MetaEvalSamplingError, match="present and unique"):
-        sample_battles_per_model(top_pool, top, battles_per_model=4, seed=0)
-
-
 def test_sampling_rejects_self_comparisons_and_insufficient_quota():
     self_comparison = pd.DataFrame(
         [
@@ -100,8 +84,6 @@ def test_sampling_rejects_self_comparisons_and_insufficient_quota():
     )
     with pytest.raises(MetaEvalSamplingError, match="self-comparisons"):
         select_top_models(self_comparison, top_models=2)
-    assert count_battles_per_model(self_comparison) == {"a": 2, "b": 1}
-
     battles = pd.DataFrame(
         [{"battle_id": f"q{i}", "model_a": "a", "model_b": "b"} for i in range(2)]
     )

--- a/tests/test_meta_eval_foundation.py
+++ b/tests/test_meta_eval_foundation.py
@@ -11,8 +11,6 @@ from pydantic import ValidationError
 import judgearena.evaluate as evaluate_module
 from judgearena.benchmarks.meta_eval.sampling import (
     MetaEvalSamplingError,
-    comparison_components,
-    count_battles_per_model,
     sample_battles_per_model,
     select_top_models,
 )
@@ -21,50 +19,30 @@ from judgearena.tasks.registry import get_packaged_task
 from judgearena.tasks.schema import TaskSpec
 
 
-def test_sampling_is_deterministic_connected_and_limited_to_top_models():
-    models = ["m1", "m2", "m3"]
+def test_sampling_preserves_the_only_bridge_and_each_models_quota():
     rows = [
-        {
-            "battle_id": f"arena:q{i}",
-            "question_id": f"q{i}",
-            "model_a": models[i % 3],
-            "model_b": models[(i + 1) % 3],
-        }
-        for i in range(18)
+        (f"{a}{b}-{i}", a, b) for a, b in (("a", "b"), ("c", "d")) for i in range(6)
     ]
-    rows.append(
-        {
-            "battle_id": "arena:rare",
-            "question_id": "rare",
-            "model_a": "rare",
-            "model_b": "m1",
-        }
-    )
-    battles = pd.DataFrame(rows)
-    top, top_pool = select_top_models(battles, top_models=3)
-
-    sample = sample_battles_per_model(top_pool, top, battles_per_model=4, seed=7)
+    # The dense pairs can meet their quotas without connecting to each other.
+    rows += [("bridge", "b", "c"), ("rare", "rare", "a")]
+    battles = pd.DataFrame(rows, columns=["battle_id", "model_a", "model_b"])
+    top, pool = select_top_models(battles, top_models=4)
+    sample = sample_battles_per_model(pool, top, battles_per_model=4, seed=7)
     shuffled = sample_battles_per_model(
-        top_pool.sample(frac=1, random_state=42),
-        top,
-        battles_per_model=4,
-        seed=7,
+        pool.sample(frac=1, random_state=42), top, battles_per_model=4, seed=7
     )
 
-    assert set(top) == {"m1", "m2", "m3"}
-    assert "rare" not in set(top_pool["question_id"])
+    counts = pd.concat([sample["model_a"], sample["model_b"]]).value_counts()
+    assert set(counts.index) == set(top) == {"a", "b", "c", "d"}
+    assert counts.min() >= 4
     assert sample["battle_id"].is_unique
-    assert all(count >= 4 for count in count_battles_per_model(sample).values())
-    assert comparison_components(sample, top) == [frozenset(top)]
+    assert "bridge" in set(sample["battle_id"])
     pd.testing.assert_frame_equal(sample, shuffled)
 
 
 def test_sampling_rejects_disconnected_top_model_pool():
     battles = pd.DataFrame(
-        [
-            {"model_a": "a", "model_b": "b"},
-            {"model_a": "c", "model_b": "d"},
-        ]
+        [{"model_a": "a", "model_b": "b"}, {"model_a": "c", "model_b": "d"}]
     )
 
     with pytest.raises(MetaEvalSamplingError, match="disconnected"):
@@ -160,8 +138,7 @@ def test_alpaca_eval_json_rejects_malformed_rankings(completion):
 
 
 @pytest.mark.parametrize(
-    "preset",
-    ["meta-eval-alpaca-eval-json", "meta-eval-alpaca-eval-pair-score"],
+    "preset", ["meta-eval-alpaca-eval-json", "meta-eval-alpaca-eval-pair-score"]
 )
 def test_meta_eval_alpaca_prompts_embed_json_safe_inputs(preset, monkeypatch):
     captured_inputs = []

--- a/tests/test_meta_eval_foundation.py
+++ b/tests/test_meta_eval_foundation.py
@@ -114,17 +114,35 @@ def _meta_task() -> dict[str, object]:
             "arena": "Test Arena",
             "baseline": {"strategy": "none"},
             "judge": {"default_prompt_preset": "meta-eval-pair-score"},
-            "scoring": {"metrics": [{"metric": "pairwise_win_rate"}]},
+            "scoring": {
+                "metrics": [
+                    {
+                        "metric": "meta_eval_agreement",
+                        "parameters": {"n_bootstraps": 10, "tie_tolerance": 0.01},
+                    }
+                ]
+            },
         },
     }
 
 
 def test_meta_eval_protocol_uses_no_baseline_and_current_scoring_schema():
-    task = TaskSpec.model_validate(_meta_task())
+    definition = _meta_task()
+    task = TaskSpec.model_validate(definition)
 
     assert isinstance(task.protocol, MetaEvalProtocol)
     assert task.protocol.baseline.strategy == "none"
-    assert task.protocol.scoring.metrics[0].metric == "pairwise_win_rate"
+    assert task.protocol.scoring.metrics[0].metric == "meta_eval_agreement"
+
+    metric = definition["protocol"]["scoring"]["metrics"][0]  # type: ignore[index]
+    metric["metric"] = "pairwise_win_rate"
+    with pytest.raises(ValueError, match="unsupported meta-evaluation metric"):
+        TaskSpec.model_validate(definition)
+
+    metric["metric"] = "meta_eval_agreement"
+    metric["group_by"] = ["lang"]
+    with pytest.raises(ValueError, match="does not support group_by"):
+        TaskSpec.model_validate(definition)
 
 
 def test_meta_eval_protocol_rejects_a_model_baseline():

--- a/tests/test_meta_eval_foundation.py
+++ b/tests/test_meta_eval_foundation.py
@@ -77,11 +77,11 @@ def test_meta_eval_protocol_requires_no_baseline_and_compatible_metrics():
         TaskSpec.model_validate(definition)
 
     metric["metric"] = "meta_eval_agreement"
-    metric["group_by"] = ["lang"]
-    with pytest.raises(ValidationError, match="does not support group_by"):
+    metric["breakdown_by"] = ["lang"]
+    with pytest.raises(ValidationError, match="does not support breakdown_by"):
         TaskSpec.model_validate(definition)
 
-    metric["group_by"] = []
+    metric["breakdown_by"] = []
     protocol["baseline"] = {"strategy": "runtime_required"}
     with pytest.raises(ValidationError):
         TaskSpec.model_validate(definition)

--- a/tests/test_meta_eval_scoring.py
+++ b/tests/test_meta_eval_scoring.py
@@ -368,14 +368,13 @@ def test_elo_gap_bundles_shared_methods_and_is_row_order_invariant():
     )
 
     assert result == shuffled
-    assert result["battle_counts_requested"] == [1, 2, 4]
+    assert result["n_models"] == 3
     assert result["hard"] == result["hard_no_judge_ties"]
     assert result["soft"] == result["hard"]
     for variant in ("hard", "soft", "hard_no_judge_ties"):
         full_budget = result[variant][-1]
         assert full_budget["mean_gap"] == pytest.approx(0.0, abs=1e-6)
         assert full_budget["n_seeds_valid"] == 3
-        assert full_budget["n_models"] == 3
 
 
 def test_elo_gap_draws_attempts_before_parse_filtering_and_uses_nested_prefixes():
@@ -400,11 +399,10 @@ def test_elo_gap_keeps_fixed_model_set_and_fails_whole_replicates():
     battles.loc[focal_a, "pref"] = np.nan
     result = _elo_gap_metric((4,), 2).calculate(battles, rng=np.random.default_rng(3))
 
+    assert result["n_models"] == 3
     for variant in ("hard", "soft", "hard_no_judge_ties"):
         row = result[variant][0]
-        assert row["n_models"] == 3
         assert row["n_seeds_valid"] == 0
-        assert row["n_seeds_failed"] == 2
         assert math.isnan(row["mean_gap"])
 
 

--- a/tests/test_meta_eval_scoring.py
+++ b/tests/test_meta_eval_scoring.py
@@ -358,6 +358,7 @@ def test_elo_gap_surfaces_unexpected_fit_errors(monkeypatch):
 
 def test_elo_gap_bundles_shared_methods_and_is_row_order_invariant():
     battles = _elo_gap_battles()
+    battles.loc[0, ["reference_pref", "pref"]] = 0.5
     metric = _elo_gap_metric((1, 2, 4), 3)
 
     with pytest.raises(ValueError, match="requires an RNG"):
@@ -369,12 +370,12 @@ def test_elo_gap_bundles_shared_methods_and_is_row_order_invariant():
 
     assert result == shuffled
     assert result["n_models"] == 3
-    assert result["hard"] == result["hard_no_judge_ties"]
     assert result["soft"] == result["hard"]
-    for variant in ("hard", "soft", "hard_no_judge_ties"):
+    for variant in ("hard", "soft"):
         full_budget = result[variant][-1]
         assert full_budget["mean_gap"] == pytest.approx(0.0, abs=1e-6)
         assert full_budget["n_seeds_valid"] == 3
+        assert full_budget["mean_used_per_model"] == 4
 
 
 def test_elo_gap_draws_attempts_before_parse_filtering_and_uses_nested_prefixes():
@@ -384,7 +385,7 @@ def test_elo_gap_draws_attempts_before_parse_filtering_and_uses_nested_prefixes(
         battles, rng=np.random.default_rng(7)
     )
 
-    for variant in ("hard", "soft", "hard_no_judge_ties"):
+    for variant in ("hard", "soft"):
         rows = result[variant]
         complete = [row["mean_complete_per_model"] for row in rows]
         assert complete == sorted(complete)
@@ -400,7 +401,7 @@ def test_elo_gap_keeps_fixed_model_set_and_fails_whole_replicates():
     result = _elo_gap_metric((4,), 2).calculate(battles, rng=np.random.default_rng(3))
 
     assert result["n_models"] == 3
-    for variant in ("hard", "soft", "hard_no_judge_ties"):
+    for variant in ("hard", "soft"):
         row = result[variant][0]
         assert row["n_seeds_valid"] == 0
         assert math.isnan(row["mean_gap"])

--- a/tests/test_meta_eval_scoring.py
+++ b/tests/test_meta_eval_scoring.py
@@ -33,6 +33,28 @@ def _rows(specs: list[tuple[str, str, str, float, float]]) -> pd.DataFrame:
     )
 
 
+def _agreement_metric(n_bootstraps: int = 0) -> MetaEvalAgreementMetric:
+    return MetaEvalAgreementMetric(n_bootstraps=n_bootstraps, tie_tolerance=0.01)
+
+
+def _ranking_metric(
+    n_bootstraps: int = 0, *, include_human_ties: bool = False
+) -> MetaEvalRankingMetric:
+    return MetaEvalRankingMetric(
+        n_bootstraps=n_bootstraps,
+        tie_tolerance=0.01,
+        include_human_ties=include_human_ties,
+    )
+
+
+def _elo_gap_metric(
+    battle_counts: tuple[int, ...], n_seeds: int
+) -> MetaEvalEloGapMetric:
+    return MetaEvalEloGapMetric(
+        battle_counts=battle_counts, n_seeds=n_seeds, tie_tolerance=0.01
+    )
+
+
 def _ranking_battles() -> pd.DataFrame:
     rows = []
     preferences = {
@@ -62,15 +84,25 @@ def test_meta_eval_metrics_are_registered_as_configured_metrics():
         "meta_eval_ranking",
     } <= set(available_metrics())
     assert isinstance(
-        build_metric("meta_eval_agreement", {"n_bootstraps": 0}),
+        build_metric("meta_eval_agreement", {"n_bootstraps": 0, "tie_tolerance": 0.01}),
         MetaEvalAgreementMetric,
     )
     assert isinstance(
-        build_metric("meta_eval_ranking", {"n_bootstraps": 0}),
+        build_metric(
+            "meta_eval_ranking",
+            {
+                "n_bootstraps": 0,
+                "tie_tolerance": 0.01,
+                "include_human_ties": False,
+            },
+        ),
         MetaEvalRankingMetric,
     )
     assert isinstance(
-        build_metric("meta_eval_elo_gap", {"battle_counts": [1, 2], "n_seeds": 2}),
+        build_metric(
+            "meta_eval_elo_gap",
+            {"battle_counts": [1, 2], "n_seeds": 2, "tie_tolerance": 0.01},
+        ),
         MetaEvalEloGapMetric,
     )
 
@@ -94,7 +126,7 @@ def test_agreement_reports_attempted_missing_and_numeric_kappa_semantics():
         "pref": np.nan,
         "sampled": False,
     }
-    result = MetaEvalAgreementMetric(n_bootstraps=0).calculate(battles)
+    result = _agreement_metric().calculate(battles)
 
     assert result["all"] == {
         "n_attempted": 5,
@@ -127,7 +159,7 @@ def test_agreement_bootstrap_is_row_order_invariant_and_reports_finite_draws():
             ("3", "a", "c", 0.0, np.nan),
         ]
     )
-    metric = MetaEvalAgreementMetric(n_bootstraps=8)
+    metric = _agreement_metric(8)
     result = metric.calculate(battles, rng=np.random.default_rng(7))["all"]
     reordered = metric.calculate(battles.iloc[::-1], rng=np.random.default_rng(7))[
         "all"
@@ -158,20 +190,20 @@ def test_no_human_ties_drops_only_reference_ties_and_keeps_judge_ties():
         ]
     )
 
-    view = MetaEvalAgreementMetric(n_bootstraps=0).calculate(battles)["no_human_ties"]
+    view = _agreement_metric().calculate(battles)["no_human_ties"]
 
     assert view["n_attempted"] == 2
     assert view["accuracy_attempted"] == pytest.approx(0.5)
 
 
 def test_ranking_preserves_distinct_hard_and_soft_results():
-    point = MetaEvalRankingMetric(n_bootstraps=0).calculate(_ranking_battles())
+    point = _ranking_metric().calculate(_ranking_battles())
 
     assert math.isfinite(point["hard"]["spearman"])
     assert math.isfinite(point["soft"]["elo_mae"])
     assert point["hard"]["elo_mae"] != pytest.approx(point["soft"]["elo_mae"])
 
-    bootstrapped = MetaEvalRankingMetric(n_bootstraps=3).calculate(
+    bootstrapped = _ranking_metric(3).calculate(
         _ranking_battles(), rng=np.random.default_rng(4)
     )
     assert bootstrapped["n_bootstraps_requested"] == 3
@@ -184,7 +216,7 @@ def test_ranking_surfaces_unexpected_fit_errors(monkeypatch):
 
     monkeypatch.setattr(scoring_module, "fit_bradley_terry", fail_fit)
     with pytest.raises(ValueError, match="unexpected fit failure"):
-        MetaEvalRankingMetric(n_bootstraps=0).calculate(_ranking_battles())
+        _ranking_metric().calculate(_ranking_battles())
 
 
 def test_ranking_is_invariant_to_row_order_and_global_ab_swap():
@@ -194,7 +226,7 @@ def test_ranking_is_invariant_to_row_order_and_global_ab_swap():
     swapped[["model_a", "model_b"]] = swapped[["model_b", "model_a"]]
     swapped["reference_pref"] = 1.0 - swapped["reference_pref"]
     swapped["pref"] = 1.0 - swapped["pref"]
-    metric = MetaEvalRankingMetric(n_bootstraps=8)
+    metric = _ranking_metric(8)
 
     expected = metric.calculate(battles, rng=np.random.default_rng(9))
     reordered = metric.calculate(shuffled, rng=np.random.default_rng(9))
@@ -219,10 +251,8 @@ def test_ranking_human_ties_are_configurable_and_model_set_stays_fixed():
     tie["pref"] = 0.0
     battles = pd.concat([battles, tie], ignore_index=True)
 
-    excluded = MetaEvalRankingMetric(n_bootstraps=0).calculate(battles)
-    included = MetaEvalRankingMetric(n_bootstraps=0, include_human_ties=True).calculate(
-        battles
-    )
+    excluded = _ranking_metric().calculate(battles)
+    included = _ranking_metric(0, include_human_ties=True).calculate(battles)
 
     assert excluded["n_models"] == 4
     assert excluded["n_battles"] == 12
@@ -231,7 +261,7 @@ def test_ranking_human_ties_are_configurable_and_model_set_stays_fixed():
     assert math.isfinite(included["hard"]["elo_mae"])
 
 
-def test_ranking_returns_numeric_unavailable_for_insufficient_graphs():
+def test_ranking_returns_numeric_unavailable_for_disconnected_graphs():
     disconnected = _rows(
         [
             ("1", "a", "b", 0.0, 0.0),
@@ -240,13 +270,27 @@ def test_ranking_returns_numeric_unavailable_for_insufficient_graphs():
             ("4", "c", "d", 1.0, 1.0),
         ]
     )
-    too_few = disconnected.iloc[:2]
 
-    for battles in (disconnected, too_few):
-        result = MetaEvalRankingMetric(n_bootstraps=0).calculate(battles)
-        assert result["n_bootstraps_valid"] == 0
-        assert math.isnan(result["hard"]["spearman"])
-        assert math.isnan(result["soft"]["elo_mae"])
+    result = _ranking_metric().calculate(disconnected)
+
+    assert result["n_bootstraps_valid"] == 0
+    assert math.isnan(result["hard"]["spearman"])
+    assert math.isnan(result["soft"]["elo_mae"])
+
+
+def test_ranking_supports_connected_two_model_inputs():
+    battles = _rows(
+        [
+            ("1", "a", "b", 0.0, 0.0),
+            ("2", "a", "b", 0.5, 0.5),
+        ]
+    )
+
+    result = _ranking_metric(0, include_human_ties=True).calculate(battles)
+
+    assert result["n_models"] == 2
+    assert result["hard"]["spearman"] == pytest.approx(1.0)
+    assert result["soft"]["elo_mae"] == pytest.approx(0.0)
 
 
 @pytest.mark.parametrize(
@@ -265,7 +309,7 @@ def test_malformed_battles_raise_instead_of_becoming_unavailable(
     battles.loc[0, column] = value
 
     with pytest.raises(ValueError, match=message):
-        MetaEvalRankingMetric(n_bootstraps=0).calculate(battles)
+        _ranking_metric().calculate(battles)
 
 
 def _elo_gap_battles() -> pd.DataFrame:
@@ -292,8 +336,13 @@ def _elo_gap_battles() -> pd.DataFrame:
     ],
 )
 def test_elo_gap_configuration_rejects_invalid_parameters(parameters):
+    valid = {
+        "battle_counts": [1, 2],
+        "n_seeds": 2,
+        "tie_tolerance": 0.01,
+    }
     with pytest.raises(ValueError, match="Invalid parameters"):
-        build_metric("meta_eval_elo_gap", parameters)
+        build_metric("meta_eval_elo_gap", valid | parameters)
 
 
 def test_elo_gap_surfaces_unexpected_fit_errors(monkeypatch):
@@ -302,14 +351,14 @@ def test_elo_gap_surfaces_unexpected_fit_errors(monkeypatch):
 
     monkeypatch.setattr(scoring_module, "fit_bradley_terry", fail_fit)
     with pytest.raises(TypeError, match="unexpected Elo fit failure"):
-        MetaEvalEloGapMetric(battle_counts=(1,), n_seeds=1).calculate(
+        _elo_gap_metric((1,), 1).calculate(
             _elo_gap_battles(), rng=np.random.default_rng(11)
         )
 
 
-def test_elo_gap_bundles_shared_variants_and_is_row_order_invariant():
+def test_elo_gap_bundles_shared_methods_and_is_row_order_invariant():
     battles = _elo_gap_battles()
-    metric = MetaEvalEloGapMetric(battle_counts=(1, 2, 4), n_seeds=3)
+    metric = _elo_gap_metric((1, 2, 4), 3)
 
     with pytest.raises(ValueError, match="requires an RNG"):
         metric.calculate(battles)
@@ -332,7 +381,7 @@ def test_elo_gap_bundles_shared_variants_and_is_row_order_invariant():
 def test_elo_gap_draws_attempts_before_parse_filtering_and_uses_nested_prefixes():
     battles = _elo_gap_battles()
     battles.loc[battles["battle_id"].eq("ab-0"), "pref"] = np.nan
-    result = MetaEvalEloGapMetric(battle_counts=(1, 2, 4), n_seeds=4).calculate(
+    result = _elo_gap_metric((1, 2, 4), 4).calculate(
         battles, rng=np.random.default_rng(7)
     )
 
@@ -349,9 +398,7 @@ def test_elo_gap_keeps_fixed_model_set_and_fails_whole_replicates():
     battles = _elo_gap_battles()
     focal_a = battles["model_a"].eq("a") | battles["model_b"].eq("a")
     battles.loc[focal_a, "pref"] = np.nan
-    result = MetaEvalEloGapMetric(battle_counts=(4,), n_seeds=2).calculate(
-        battles, rng=np.random.default_rng(3)
-    )
+    result = _elo_gap_metric((4,), 2).calculate(battles, rng=np.random.default_rng(3))
 
     for variant in ("hard", "soft", "hard_no_judge_ties"):
         row = result[variant][0]
@@ -367,6 +414,4 @@ def test_elo_gap_rejects_attempted_battle_shortfalls():
     battles.loc[battles["battle_id"].eq("ab-0"), "pref"] = np.nan
 
     with pytest.raises(ValueError, match="Every model needs at least 4"):
-        MetaEvalEloGapMetric(battle_counts=(4,), n_seeds=1).calculate(
-            battles, rng=np.random.default_rng(1)
-        )
+        _elo_gap_metric((4,), 1).calculate(battles, rng=np.random.default_rng(1))

--- a/tests/test_meta_eval_scoring.py
+++ b/tests/test_meta_eval_scoring.py
@@ -11,6 +11,7 @@ import pytest
 import judgearena.benchmarks.meta_eval.scoring as scoring_module
 from judgearena.benchmarks.meta_eval.scoring import (
     MetaEvalAgreementMetric,
+    MetaEvalEloGapMetric,
     MetaEvalRankingMetric,
 )
 from judgearena.benchmarks.scoring import available_metrics, build_metric
@@ -57,7 +58,11 @@ def _ranking_battles() -> pd.DataFrame:
 
 
 def test_meta_eval_metrics_are_registered_as_configured_metrics():
-    assert {"meta_eval_agreement", "meta_eval_ranking"} <= set(available_metrics())
+    assert {
+        "meta_eval_agreement",
+        "meta_eval_elo_gap",
+        "meta_eval_ranking",
+    } <= set(available_metrics())
     assert isinstance(
         build_metric("meta_eval_agreement", {"n_bootstraps": 0}),
         MetaEvalAgreementMetric,
@@ -65,6 +70,10 @@ def test_meta_eval_metrics_are_registered_as_configured_metrics():
     assert isinstance(
         build_metric("meta_eval_ranking", {"n_bootstraps": 0}),
         MetaEvalRankingMetric,
+    )
+    assert isinstance(
+        build_metric("meta_eval_elo_gap", {"battle_counts": [1, 2], "n_seeds": 2}),
+        MetaEvalEloGapMetric,
     )
 
 
@@ -260,3 +269,122 @@ def test_malformed_preferences_raise_instead_of_becoming_unavailable(
 
     with pytest.raises(ValueError, match=message):
         MetaEvalRankingMetric(n_bootstraps=0).calculate(battles)
+
+
+def _elo_gap_battles() -> pd.DataFrame:
+    specs = []
+    for model_a, model_b in (("a", "b"), ("a", "c"), ("b", "c")):
+        specs.extend(
+            [
+                (f"{model_a}{model_b}-0", model_a, model_b, 0.0, 0.0, "complete"),
+                (f"{model_a}{model_b}-1", model_a, model_b, 1.0, 1.0, "complete"),
+            ]
+        )
+    return _rows(specs)
+
+
+@pytest.mark.parametrize(
+    "parameters",
+    [
+        {"battle_counts": []},
+        {"battle_counts": [0]},
+        {"battle_counts": [2, 1]},
+        {"battle_counts": [1, 1]},
+        {"n_seeds": 0},
+        {"tie_tolerance": 0.5},
+    ],
+)
+def test_elo_gap_configuration_rejects_invalid_parameters(parameters):
+    with pytest.raises(ValueError, match="Invalid parameters"):
+        build_metric("meta_eval_elo_gap", parameters)
+
+
+def test_elo_gap_bundles_shared_variants_and_is_row_order_invariant():
+    battles = _elo_gap_battles()
+    metric = MetaEvalEloGapMetric(battle_counts=(1, 2, 4), n_seeds=3)
+
+    with pytest.raises(ValueError, match="requires an RNG"):
+        metric.calculate(battles)
+    result = metric.calculate(battles, rng=np.random.default_rng(11))
+    shuffled = metric.calculate(
+        battles.sample(frac=1, random_state=4), rng=np.random.default_rng(11)
+    )
+
+    assert result == shuffled
+    assert result["battle_counts_requested"] == [1, 2, 4]
+    assert result["hard"] == result["hard_no_judge_ties"]
+    assert result["soft"] == result["hard"]
+    for variant in ("hard", "soft", "hard_no_judge_ties"):
+        full_budget = result[variant][-1]
+        assert full_budget["mean_gap"] == pytest.approx(0.0, abs=1e-6)
+        assert full_budget["n_seeds_valid"] == 3
+        assert full_budget["n_models"] == 3
+
+
+def test_elo_gap_draws_attempts_before_parse_filtering_and_uses_nested_prefixes():
+    battles = _elo_gap_battles()
+    battles.loc[battles["battle_id"].eq("ab-0"), ["pref", "parse_status"]] = [
+        np.nan,
+        "missing",
+    ]
+    result = MetaEvalEloGapMetric(battle_counts=(1, 2, 4), n_seeds=4).calculate(
+        battles, rng=np.random.default_rng(7)
+    )
+
+    for variant in ("hard", "soft", "hard_no_judge_ties"):
+        rows = result[variant]
+        parsed = [row["mean_parsed_per_model"] for row in rows]
+        assert parsed == sorted(parsed)
+        assert rows[-1]["attempted_battles_per_model"] == 4
+        assert rows[-1]["mean_parsed_per_model"] == pytest.approx(10 / 3)
+        assert rows[-1]["mean_used_per_model"] == pytest.approx(10 / 3)
+
+
+def test_elo_gap_keeps_fixed_model_set_and_fails_whole_replicates():
+    battles = _elo_gap_battles()
+    focal_a = battles["model_a"].eq("a") | battles["model_b"].eq("a")
+    battles.loc[focal_a, "pref"] = np.nan
+    battles.loc[focal_a, "parse_status"] = "missing"
+    result = MetaEvalEloGapMetric(battle_counts=(4,), n_seeds=2).calculate(
+        battles, rng=np.random.default_rng(3)
+    )
+
+    for variant in ("hard", "soft", "hard_no_judge_ties"):
+        row = result[variant][0]
+        assert row["n_models"] == 3
+        assert row["n_seeds_valid"] == 0
+        assert row["n_seeds_failed"] == 2
+        assert math.isnan(row["mean_gap"])
+
+
+def test_elo_gap_fits_the_full_human_reference_once(monkeypatch):
+    battles = _elo_gap_battles()
+    full_pool_fits = 0
+    original = scoring_module.fit_bradley_terry
+
+    def counted_fit(rows, *args, **kwargs):
+        nonlocal full_pool_fits
+        if len(rows) == len(battles):
+            full_pool_fits += 1
+        return original(rows, *args, **kwargs)
+
+    monkeypatch.setattr(scoring_module, "fit_bradley_terry", counted_fit)
+    MetaEvalEloGapMetric(battle_counts=(1,), n_seeds=1).calculate(
+        battles, rng=np.random.default_rng(5)
+    )
+
+    assert full_pool_fits == 1
+
+
+def test_elo_gap_rejects_attempted_battle_shortfalls():
+    battles = _elo_gap_battles()
+    battles.loc[battles["battle_id"].eq("ab-0"), "sampled"] = False
+    battles.loc[battles["battle_id"].eq("ab-0"), ["pref", "parse_status"]] = [
+        np.nan,
+        None,
+    ]
+
+    with pytest.raises(ValueError, match="Every model needs at least 4"):
+        MetaEvalEloGapMetric(battle_counts=(4,), n_seeds=1).calculate(
+            battles, rng=np.random.default_rng(1)
+        )

--- a/tests/test_meta_eval_scoring.py
+++ b/tests/test_meta_eval_scoring.py
@@ -17,7 +17,7 @@ from judgearena.benchmarks.meta_eval.scoring import (
 from judgearena.benchmarks.scoring import available_metrics, build_metric
 
 
-def _rows(specs: list[tuple[str, str, str, float, float, str]]) -> pd.DataFrame:
+def _rows(specs: list[tuple[str, str, str, float, float]]) -> pd.DataFrame:
     return pd.DataFrame(
         [
             {
@@ -27,9 +27,8 @@ def _rows(specs: list[tuple[str, str, str, float, float, str]]) -> pd.DataFrame:
                 "reference_pref": reference,
                 "pref": judge,
                 "sampled": True,
-                "parse_status": status,
             }
-            for battle_id, model_a, model_b, reference, judge, status in specs
+            for battle_id, model_a, model_b, reference, judge in specs
         ]
     )
 
@@ -51,7 +50,6 @@ def _ranking_battles() -> pd.DataFrame:
                     "reference_pref": reference_pref,
                     "pref": pref,
                     "sampled": True,
-                    "parse_status": "complete",
                 }
             )
     return pd.DataFrame(rows)
@@ -80,11 +78,11 @@ def test_meta_eval_metrics_are_registered_as_configured_metrics():
 def test_agreement_reports_attempted_missing_and_numeric_kappa_semantics():
     battles = _rows(
         [
-            ("1", "a", "b", 0.0, 0.0, "complete"),
-            ("2", "b", "c", 1.0, 0.0, "complete"),
-            ("3", "a", "c", 0.5, 0.5, "complete"),
-            ("4", "a", "b", 0.0, np.nan, "missing"),
-            ("5", "b", "c", 1.0, 1.0, "partial"),
+            ("1", "a", "b", 0.0, 0.0),
+            ("2", "b", "c", 1.0, 0.0),
+            ("3", "a", "c", 0.5, 0.5),
+            ("4", "a", "b", 0.0, np.nan),
+            ("5", "b", "c", 1.0, np.nan),
         ]
     )
 
@@ -95,7 +93,6 @@ def test_agreement_reports_attempted_missing_and_numeric_kappa_semantics():
         "reference_pref": 0.0,
         "pref": np.nan,
         "sampled": False,
-        "parse_status": None,
     }
     result = MetaEvalAgreementMetric(n_bootstraps=0).calculate(battles)
 
@@ -104,11 +101,11 @@ def test_agreement_reports_attempted_missing_and_numeric_kappa_semantics():
         "n_complete": 3,
         "coverage": pytest.approx(0.6),
         "accuracy_attempted": pytest.approx(0.4),
-        "accuracy_parsed": pytest.approx(2 / 3),
+        "accuracy_complete": pytest.approx(2 / 3),
         "cohen_kappa": pytest.approx(0.5),
         "accuracy_attempted_se": pytest.approx(float("nan"), nan_ok=True),
-        "accuracy_parsed_se": pytest.approx(float("nan"), nan_ok=True),
-        "accuracy_parsed_bootstraps_valid": 0,
+        "accuracy_complete_se": pytest.approx(float("nan"), nan_ok=True),
+        "accuracy_complete_bootstraps_valid": 0,
         "cohen_kappa_se": pytest.approx(float("nan"), nan_ok=True),
         "n_bootstraps_requested": 0,
         "n_kappa_bootstraps_valid": 0,
@@ -118,16 +115,16 @@ def test_agreement_reports_attempted_missing_and_numeric_kappa_semantics():
     assert no_ties["n_complete"] == 2
     assert no_ties["coverage"] == pytest.approx(0.5)
     assert no_ties["accuracy_attempted"] == pytest.approx(0.25)
-    assert no_ties["accuracy_parsed"] == pytest.approx(0.5)
+    assert no_ties["accuracy_complete"] == pytest.approx(0.5)
     assert no_ties["cohen_kappa"] == pytest.approx(0.0)
 
 
 def test_agreement_bootstrap_is_row_order_invariant_and_reports_finite_draws():
     battles = _rows(
         [
-            ("1", "a", "b", 0.0, 0.0, "complete"),
-            ("2", "b", "c", 1.0, 0.0, "complete"),
-            ("3", "a", "c", 0.0, np.nan, "missing"),
+            ("1", "a", "b", 0.0, 0.0),
+            ("2", "b", "c", 1.0, 0.0),
+            ("3", "a", "c", 0.0, np.nan),
         ]
     )
     metric = MetaEvalAgreementMetric(n_bootstraps=8)
@@ -137,27 +134,27 @@ def test_agreement_bootstrap_is_row_order_invariant_and_reports_finite_draws():
     ]
 
     expected_rng = np.random.default_rng(7)
-    parsed_accuracies = []
+    complete_accuracies = []
     outcomes = np.array([1.0, 0.0, np.nan])
     for _ in range(8):
         sampled = outcomes[expected_rng.integers(0, 3, size=3)]
-        parsed = sampled[np.isfinite(sampled)]
-        if len(parsed):
-            parsed_accuracies.append(float(parsed.mean()))
+        complete = sampled[np.isfinite(sampled)]
+        if len(complete):
+            complete_accuracies.append(float(complete.mean()))
 
     assert result == pytest.approx(reordered, nan_ok=True)
-    assert result["accuracy_parsed_bootstraps_valid"] == len(parsed_accuracies)
-    assert result["accuracy_parsed_se"] == pytest.approx(
-        np.std(parsed_accuracies, ddof=1)
+    assert result["accuracy_complete_bootstraps_valid"] == len(complete_accuracies)
+    assert result["accuracy_complete_se"] == pytest.approx(
+        np.std(complete_accuracies, ddof=1)
     )
 
 
 def test_no_human_ties_drops_only_reference_ties_and_keeps_judge_ties():
     battles = _rows(
         [
-            ("1", "a", "b", 0.5, 0.0, "complete"),
-            ("2", "b", "c", 1.0, 0.5, "complete"),
-            ("3", "a", "c", 0.0, 0.0, "complete"),
+            ("1", "a", "b", 0.5, 0.0),
+            ("2", "b", "c", 1.0, 0.5),
+            ("3", "a", "c", 0.0, 0.0),
         ]
     )
 
@@ -167,29 +164,27 @@ def test_no_human_ties_drops_only_reference_ties_and_keeps_judge_ties():
     assert view["accuracy_attempted"] == pytest.approx(0.5)
 
 
-def test_ranking_reuses_three_point_fits_and_refits_each_bootstrap(monkeypatch):
-    calls = 0
-    original = scoring_module.fit_bradley_terry
-
-    def counted_fit(*args, **kwargs):
-        nonlocal calls
-        calls += 1
-        return original(*args, **kwargs)
-
-    monkeypatch.setattr(scoring_module, "fit_bradley_terry", counted_fit)
+def test_ranking_preserves_distinct_hard_and_soft_results():
     point = MetaEvalRankingMetric(n_bootstraps=0).calculate(_ranking_battles())
-    assert calls == 3
+
     assert math.isfinite(point["hard"]["spearman"])
     assert math.isfinite(point["soft"]["elo_mae"])
     assert point["hard"]["elo_mae"] != pytest.approx(point["soft"]["elo_mae"])
 
-    calls = 0
-    result = MetaEvalRankingMetric(n_bootstraps=3).calculate(
+    bootstrapped = MetaEvalRankingMetric(n_bootstraps=3).calculate(
         _ranking_battles(), rng=np.random.default_rng(4)
     )
-    assert calls == 12
-    assert result["n_bootstraps_requested"] == 3
-    assert 0 <= result["n_bootstraps_valid"] <= 3
+    assert bootstrapped["n_bootstraps_requested"] == 3
+    assert 0 <= bootstrapped["n_bootstraps_valid"] <= 3
+
+
+def test_ranking_surfaces_unexpected_fit_errors(monkeypatch):
+    def fail_fit(*args, **kwargs):
+        raise ValueError("unexpected fit failure")
+
+    monkeypatch.setattr(scoring_module, "fit_bradley_terry", fail_fit)
+    with pytest.raises(ValueError, match="unexpected fit failure"):
+        MetaEvalRankingMetric(n_bootstraps=0).calculate(_ranking_battles())
 
 
 def test_ranking_is_invariant_to_row_order_and_global_ab_swap():
@@ -239,10 +234,10 @@ def test_ranking_human_ties_are_configurable_and_model_set_stays_fixed():
 def test_ranking_returns_numeric_unavailable_for_insufficient_graphs():
     disconnected = _rows(
         [
-            ("1", "a", "b", 0.0, 0.0, "complete"),
-            ("2", "a", "b", 1.0, 1.0, "complete"),
-            ("3", "c", "d", 0.0, 0.0, "complete"),
-            ("4", "c", "d", 1.0, 1.0, "complete"),
+            ("1", "a", "b", 0.0, 0.0),
+            ("2", "a", "b", 1.0, 1.0),
+            ("3", "c", "d", 0.0, 0.0),
+            ("4", "c", "d", 1.0, 1.0),
         ]
     )
     too_few = disconnected.iloc[:2]
@@ -259,9 +254,11 @@ def test_ranking_returns_numeric_unavailable_for_insufficient_graphs():
     [
         ("pref", 1.1, "numeric preferences"),
         ("reference_pref", 0.25, "must be 0, 0.5, or 1"),
+        ("model_a", None, "non-null strings"),
+        ("model_b", "a", "self-comparisons"),
     ],
 )
-def test_malformed_preferences_raise_instead_of_becoming_unavailable(
+def test_malformed_battles_raise_instead_of_becoming_unavailable(
     column, value, message
 ):
     battles = _ranking_battles()
@@ -276,8 +273,8 @@ def _elo_gap_battles() -> pd.DataFrame:
     for model_a, model_b in (("a", "b"), ("a", "c"), ("b", "c")):
         specs.extend(
             [
-                (f"{model_a}{model_b}-0", model_a, model_b, 0.0, 0.0, "complete"),
-                (f"{model_a}{model_b}-1", model_a, model_b, 1.0, 1.0, "complete"),
+                (f"{model_a}{model_b}-0", model_a, model_b, 0.0, 0.0),
+                (f"{model_a}{model_b}-1", model_a, model_b, 1.0, 1.0),
             ]
         )
     return _rows(specs)
@@ -297,6 +294,17 @@ def _elo_gap_battles() -> pd.DataFrame:
 def test_elo_gap_configuration_rejects_invalid_parameters(parameters):
     with pytest.raises(ValueError, match="Invalid parameters"):
         build_metric("meta_eval_elo_gap", parameters)
+
+
+def test_elo_gap_surfaces_unexpected_fit_errors(monkeypatch):
+    def fail_fit(*args, **kwargs):
+        raise TypeError("unexpected Elo fit failure")
+
+    monkeypatch.setattr(scoring_module, "fit_bradley_terry", fail_fit)
+    with pytest.raises(TypeError, match="unexpected Elo fit failure"):
+        MetaEvalEloGapMetric(battle_counts=(1,), n_seeds=1).calculate(
+            _elo_gap_battles(), rng=np.random.default_rng(11)
+        )
 
 
 def test_elo_gap_bundles_shared_variants_and_is_row_order_invariant():
@@ -323,20 +331,17 @@ def test_elo_gap_bundles_shared_variants_and_is_row_order_invariant():
 
 def test_elo_gap_draws_attempts_before_parse_filtering_and_uses_nested_prefixes():
     battles = _elo_gap_battles()
-    battles.loc[battles["battle_id"].eq("ab-0"), ["pref", "parse_status"]] = [
-        np.nan,
-        "missing",
-    ]
+    battles.loc[battles["battle_id"].eq("ab-0"), "pref"] = np.nan
     result = MetaEvalEloGapMetric(battle_counts=(1, 2, 4), n_seeds=4).calculate(
         battles, rng=np.random.default_rng(7)
     )
 
     for variant in ("hard", "soft", "hard_no_judge_ties"):
         rows = result[variant]
-        parsed = [row["mean_parsed_per_model"] for row in rows]
-        assert parsed == sorted(parsed)
+        complete = [row["mean_complete_per_model"] for row in rows]
+        assert complete == sorted(complete)
         assert rows[-1]["attempted_battles_per_model"] == 4
-        assert rows[-1]["mean_parsed_per_model"] == pytest.approx(10 / 3)
+        assert rows[-1]["mean_complete_per_model"] == pytest.approx(10 / 3)
         assert rows[-1]["mean_used_per_model"] == pytest.approx(10 / 3)
 
 
@@ -344,7 +349,6 @@ def test_elo_gap_keeps_fixed_model_set_and_fails_whole_replicates():
     battles = _elo_gap_battles()
     focal_a = battles["model_a"].eq("a") | battles["model_b"].eq("a")
     battles.loc[focal_a, "pref"] = np.nan
-    battles.loc[focal_a, "parse_status"] = "missing"
     result = MetaEvalEloGapMetric(battle_counts=(4,), n_seeds=2).calculate(
         battles, rng=np.random.default_rng(3)
     )
@@ -357,32 +361,10 @@ def test_elo_gap_keeps_fixed_model_set_and_fails_whole_replicates():
         assert math.isnan(row["mean_gap"])
 
 
-def test_elo_gap_fits_the_full_human_reference_once(monkeypatch):
-    battles = _elo_gap_battles()
-    full_pool_fits = 0
-    original = scoring_module.fit_bradley_terry
-
-    def counted_fit(rows, *args, **kwargs):
-        nonlocal full_pool_fits
-        if len(rows) == len(battles):
-            full_pool_fits += 1
-        return original(rows, *args, **kwargs)
-
-    monkeypatch.setattr(scoring_module, "fit_bradley_terry", counted_fit)
-    MetaEvalEloGapMetric(battle_counts=(1,), n_seeds=1).calculate(
-        battles, rng=np.random.default_rng(5)
-    )
-
-    assert full_pool_fits == 1
-
-
 def test_elo_gap_rejects_attempted_battle_shortfalls():
     battles = _elo_gap_battles()
     battles.loc[battles["battle_id"].eq("ab-0"), "sampled"] = False
-    battles.loc[battles["battle_id"].eq("ab-0"), ["pref", "parse_status"]] = [
-        np.nan,
-        None,
-    ]
+    battles.loc[battles["battle_id"].eq("ab-0"), "pref"] = np.nan
 
     with pytest.raises(ValueError, match="Every model needs at least 4"):
         MetaEvalEloGapMetric(battle_counts=(4,), n_seeds=1).calculate(

--- a/tests/test_meta_eval_scoring.py
+++ b/tests/test_meta_eval_scoring.py
@@ -14,23 +14,13 @@ from judgearena.benchmarks.meta_eval.scoring import (
     MetaEvalEloGapMetric,
     MetaEvalRankingMetric,
 )
-from judgearena.benchmarks.scoring import available_metrics, build_metric
+from judgearena.benchmarks.scoring import build_metric
 
 
 def _rows(specs: list[tuple[str, str, str, float, float]]) -> pd.DataFrame:
     return pd.DataFrame(
-        [
-            {
-                "battle_id": battle_id,
-                "model_a": model_a,
-                "model_b": model_b,
-                "reference_pref": reference,
-                "pref": judge,
-                "sampled": True,
-            }
-            for battle_id, model_a, model_b, reference, judge in specs
-        ]
-    )
+        specs, columns=["battle_id", "model_a", "model_b", "reference_pref", "pref"]
+    ).assign(sampled=True)
 
 
 def _agreement_metric(n_bootstraps: int = 0) -> MetaEvalAgreementMetric:
@@ -56,99 +46,45 @@ def _elo_gap_metric(
 
 
 def _ranking_battles() -> pd.DataFrame:
-    rows = []
     preferences = {
-        ("a", "b"): ([0.0, 0.0, 0.0, 1.0], [0.49, 0.49, 0.49, 1.0]),
-        ("a", "c"): ([0.0, 0.0, 0.0, 1.0], [0.01, 0.01, 0.01, 1.0]),
-        ("b", "c"): ([0.0, 0.0, 0.0, 1.0], [0.0, 0.51, 0.51, 0.51]),
+        ("a", "b"): [0.49, 0.49, 0.49, 1.0],
+        ("a", "c"): [0.01, 0.01, 0.01, 1.0],
+        ("b", "c"): [0.0, 0.51, 0.51, 0.51],
     }
-    for (model_a, model_b), (human, judge) in preferences.items():
-        for index, (reference_pref, pref) in enumerate(zip(human, judge, strict=True)):
-            rows.append(
-                {
-                    "battle_id": f"{model_a}{model_b}-{index}",
-                    "model_a": model_a,
-                    "model_b": model_b,
-                    "reference_pref": reference_pref,
-                    "pref": pref,
-                    "sampled": True,
-                }
-            )
-    return pd.DataFrame(rows)
-
-
-def test_meta_eval_metrics_are_registered_as_configured_metrics():
-    assert {
-        "meta_eval_agreement",
-        "meta_eval_elo_gap",
-        "meta_eval_ranking",
-    } <= set(available_metrics())
-    assert isinstance(
-        build_metric("meta_eval_agreement", {"n_bootstraps": 0, "tie_tolerance": 0.01}),
-        MetaEvalAgreementMetric,
-    )
-    assert isinstance(
-        build_metric(
-            "meta_eval_ranking",
-            {
-                "n_bootstraps": 0,
-                "tie_tolerance": 0.01,
-                "include_human_ties": False,
-            },
-        ),
-        MetaEvalRankingMetric,
-    )
-    assert isinstance(
-        build_metric(
-            "meta_eval_elo_gap",
-            {"battle_counts": [1, 2], "n_seeds": 2, "tie_tolerance": 0.01},
-        ),
-        MetaEvalEloGapMetric,
-    )
-
-
-def test_agreement_reports_attempted_missing_and_numeric_kappa_semantics():
-    battles = _rows(
+    return _rows(
         [
-            ("1", "a", "b", 0.0, 0.0),
-            ("2", "b", "c", 1.0, 0.0),
-            ("3", "a", "c", 0.5, 0.5),
-            ("4", "a", "b", 0.0, np.nan),
-            ("5", "b", "c", 1.0, np.nan),
+            (f"{a}{b}-{i}", a, b, float(i == 3), pref)
+            for (a, b), prefs in preferences.items()
+            for i, pref in enumerate(prefs)
         ]
     )
 
-    battles.loc[len(battles)] = {
-        "battle_id": "unsampled",
-        "model_a": "a",
-        "model_b": "b",
-        "reference_pref": 0.0,
-        "pref": np.nan,
-        "sampled": False,
-    }
+
+def test_agreement_reports_missing_judgments_and_excludes_only_human_ties():
+    battles = _rows(
+        [
+            ("1", "a", "b", 0.0, 0.0),
+            ("2", "b", "c", 1.0, 0.5),
+            ("3", "a", "c", 0.5, 0.5),
+            ("4", "a", "b", 0.0, np.nan),
+            ("5", "b", "c", 1.0, np.nan),
+            ("unsampled", "a", "b", 0.0, np.nan),
+        ]
+    )
+    battles.loc[5, "sampled"] = False
     result = _agreement_metric().calculate(battles)
 
-    assert result["all"] == {
-        "n_attempted": 5,
-        "n_complete": 3,
-        "coverage": pytest.approx(0.6),
-        "accuracy_attempted": pytest.approx(0.4),
-        "accuracy_complete": pytest.approx(2 / 3),
-        "cohen_kappa": pytest.approx(0.5),
-        "accuracy_attempted_se": pytest.approx(float("nan"), nan_ok=True),
-        "accuracy_complete_se": pytest.approx(float("nan"), nan_ok=True),
-        "accuracy_complete_bootstraps_valid": 0,
-        "cohen_kappa_se": pytest.approx(float("nan"), nan_ok=True),
-        "n_bootstraps_requested": 0,
-        "n_kappa_bootstraps_valid": 0,
-    }
+    all_rows = result["all"]
+    assert (all_rows["n_attempted"], all_rows["n_complete"]) == (5, 3)
+    assert all_rows["coverage"] == pytest.approx(3 / 5)
+    assert all_rows["accuracy_attempted"] == pytest.approx(2 / 5)
+    assert all_rows["accuracy_complete"] == pytest.approx(2 / 3)
+    assert all_rows["cohen_kappa"] == pytest.approx(0.5)
     no_ties = result["no_human_ties"]
-    assert no_ties["n_attempted"] == 4
-    assert no_ties["n_complete"] == 2
-    assert no_ties["coverage"] == pytest.approx(0.5)
-    assert no_ties["accuracy_attempted"] == pytest.approx(0.25)
-    assert no_ties["accuracy_complete"] == pytest.approx(0.5)
-    assert no_ties["cohen_kappa"] == pytest.approx(0.0)
+    assert (no_ties["n_attempted"], no_ties["n_complete"]) == (4, 2)
+    assert no_ties["accuracy_attempted"] == pytest.approx(1 / 4)
+    assert no_ties["accuracy_complete"] == pytest.approx(1 / 2)
+    assert no_ties["cohen_kappa"] == pytest.approx(1 / 3)
 
 
 def test_agreement_bootstrap_is_row_order_invariant_and_reports_finite_draws():
@@ -165,49 +101,9 @@ def test_agreement_bootstrap_is_row_order_invariant_and_reports_finite_draws():
         "all"
     ]
 
-    expected_rng = np.random.default_rng(7)
-    complete_accuracies = []
-    outcomes = np.array([1.0, 0.0, np.nan])
-    for _ in range(8):
-        sampled = outcomes[expected_rng.integers(0, 3, size=3)]
-        complete = sampled[np.isfinite(sampled)]
-        if len(complete):
-            complete_accuracies.append(float(complete.mean()))
-
     assert result == pytest.approx(reordered, nan_ok=True)
-    assert result["accuracy_complete_bootstraps_valid"] == len(complete_accuracies)
-    assert result["accuracy_complete_se"] == pytest.approx(
-        np.std(complete_accuracies, ddof=1)
-    )
-
-
-def test_no_human_ties_drops_only_reference_ties_and_keeps_judge_ties():
-    battles = _rows(
-        [
-            ("1", "a", "b", 0.5, 0.0),
-            ("2", "b", "c", 1.0, 0.5),
-            ("3", "a", "c", 0.0, 0.0),
-        ]
-    )
-
-    view = _agreement_metric().calculate(battles)["no_human_ties"]
-
-    assert view["n_attempted"] == 2
-    assert view["accuracy_attempted"] == pytest.approx(0.5)
-
-
-def test_ranking_preserves_distinct_hard_and_soft_results():
-    point = _ranking_metric().calculate(_ranking_battles())
-
-    assert math.isfinite(point["hard"]["spearman"])
-    assert math.isfinite(point["soft"]["elo_mae"])
-    assert point["hard"]["elo_mae"] != pytest.approx(point["soft"]["elo_mae"])
-
-    bootstrapped = _ranking_metric(3).calculate(
-        _ranking_battles(), rng=np.random.default_rng(4)
-    )
-    assert bootstrapped["n_bootstraps_requested"] == 3
-    assert 0 <= bootstrapped["n_bootstraps_valid"] <= 3
+    assert 0 < result["accuracy_complete_bootstraps_valid"] <= 8
+    assert 0 < result["accuracy_complete_se"] < 1
 
 
 def test_ranking_surfaces_unexpected_fit_errors(monkeypatch):
@@ -229,6 +125,10 @@ def test_ranking_is_invariant_to_row_order_and_global_ab_swap():
     metric = _ranking_metric(8)
 
     expected = metric.calculate(battles, rng=np.random.default_rng(9))
+    assert math.isfinite(expected["hard"]["spearman"])
+    assert math.isfinite(expected["soft"]["elo_mae"])
+    assert expected["hard"]["elo_mae"] != pytest.approx(expected["soft"]["elo_mae"])
+    assert expected["n_bootstraps_valid"] == 8
     reordered = metric.calculate(shuffled, rng=np.random.default_rng(9))
     reversed_ab = metric.calculate(swapped, rng=np.random.default_rng(9))
 
@@ -261,36 +161,22 @@ def test_ranking_human_ties_are_configurable_and_model_set_stays_fixed():
     assert math.isfinite(included["hard"]["elo_mae"])
 
 
-def test_ranking_returns_numeric_unavailable_for_disconnected_graphs():
-    disconnected = _rows(
-        [
-            ("1", "a", "b", 0.0, 0.0),
-            ("2", "a", "b", 1.0, 1.0),
-            ("3", "c", "d", 0.0, 0.0),
-            ("4", "c", "d", 1.0, 1.0),
-        ]
-    )
-
-    result = _ranking_metric().calculate(disconnected)
-
-    assert result["n_bootstraps_valid"] == 0
-    assert math.isnan(result["hard"]["spearman"])
-    assert math.isnan(result["soft"]["elo_mae"])
-
-
-def test_ranking_supports_connected_two_model_inputs():
-    battles = _rows(
-        [
-            ("1", "a", "b", 0.0, 0.0),
-            ("2", "a", "b", 0.5, 0.5),
-        ]
-    )
-
-    result = _ranking_metric(0, include_human_ties=True).calculate(battles)
-
+def test_ranking_supports_two_models_but_not_disconnected_groups():
+    battles = _rows([("1", "a", "b", 0.0, 0.0), ("2", "a", "b", 0.5, 0.5)])
+    metric = _ranking_metric(include_human_ties=True)
+    result = metric.calculate(battles)
     assert result["n_models"] == 2
     assert result["hard"]["spearman"] == pytest.approx(1.0)
     assert result["soft"]["elo_mae"] == pytest.approx(0.0)
+
+    disconnected = pd.concat(
+        [battles, _rows([("3", "c", "d", 0.5, 0.5)])], ignore_index=True
+    )
+    result = metric.calculate(disconnected)
+    assert result["n_models"] == 4
+    assert result["n_bootstraps_valid"] == 0
+    assert math.isnan(result["hard"]["spearman"])
+    assert math.isnan(result["soft"]["elo_mae"])
 
 
 @pytest.mark.parametrize(

--- a/tests/test_meta_eval_scoring.py
+++ b/tests/test_meta_eval_scoring.py
@@ -241,6 +241,8 @@ def test_elo_gap_surfaces_unexpected_fit_errors(monkeypatch):
 def test_elo_gap_bundles_shared_methods_and_is_row_order_invariant():
     battles = _elo_gap_battles()
     battles.loc[0, ["reference_pref", "pref"]] = 0.5
+    battles["battle_id"] = battles["battle_id"].astype(object)
+    battles.loc[0, "battle_id"] = 0  # Preserve ID types when shuffling.
     metric = _elo_gap_metric((1, 2, 4), 3)
 
     with pytest.raises(ValueError, match="requires an RNG"):
@@ -251,6 +253,11 @@ def test_elo_gap_bundles_shared_methods_and_is_row_order_invariant():
     )
 
     assert result == shuffled
+    fewer_budgets = _elo_gap_metric((1, 4), 3).calculate(
+        battles, rng=np.random.default_rng(11)
+    )
+    for method in ("hard", "soft"):
+        assert fewer_budgets[method] == [result[method][0], result[method][-1]]
     assert result["n_models"] == 3
     assert result["soft"] == result["hard"]
     full_budget = result["hard"][-1]

--- a/tests/test_meta_eval_scoring.py
+++ b/tests/test_meta_eval_scoring.py
@@ -1,0 +1,262 @@
+"""Focused tests for meta-evaluation agreement and ranking metrics."""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import judgearena.benchmarks.meta_eval.scoring as scoring_module
+from judgearena.benchmarks.meta_eval.scoring import (
+    MetaEvalAgreementMetric,
+    MetaEvalRankingMetric,
+)
+from judgearena.benchmarks.scoring import available_metrics, build_metric
+
+
+def _rows(specs: list[tuple[str, str, str, float, float, str]]) -> pd.DataFrame:
+    return pd.DataFrame(
+        [
+            {
+                "battle_id": battle_id,
+                "model_a": model_a,
+                "model_b": model_b,
+                "reference_pref": reference,
+                "pref": judge,
+                "sampled": True,
+                "parse_status": status,
+            }
+            for battle_id, model_a, model_b, reference, judge, status in specs
+        ]
+    )
+
+
+def _ranking_battles() -> pd.DataFrame:
+    rows = []
+    preferences = {
+        ("a", "b"): ([0.0, 0.0, 0.0, 1.0], [0.49, 0.49, 0.49, 1.0]),
+        ("a", "c"): ([0.0, 0.0, 0.0, 1.0], [0.01, 0.01, 0.01, 1.0]),
+        ("b", "c"): ([0.0, 0.0, 0.0, 1.0], [0.0, 0.51, 0.51, 0.51]),
+    }
+    for (model_a, model_b), (human, judge) in preferences.items():
+        for index, (reference_pref, pref) in enumerate(zip(human, judge, strict=True)):
+            rows.append(
+                {
+                    "battle_id": f"{model_a}{model_b}-{index}",
+                    "model_a": model_a,
+                    "model_b": model_b,
+                    "reference_pref": reference_pref,
+                    "pref": pref,
+                    "sampled": True,
+                    "parse_status": "complete",
+                }
+            )
+    return pd.DataFrame(rows)
+
+
+def test_meta_eval_metrics_are_registered_as_configured_metrics():
+    assert {"meta_eval_agreement", "meta_eval_ranking"} <= set(available_metrics())
+    assert isinstance(
+        build_metric("meta_eval_agreement", {"n_bootstraps": 0}),
+        MetaEvalAgreementMetric,
+    )
+    assert isinstance(
+        build_metric("meta_eval_ranking", {"n_bootstraps": 0}),
+        MetaEvalRankingMetric,
+    )
+
+
+def test_agreement_reports_attempted_missing_and_numeric_kappa_semantics():
+    battles = _rows(
+        [
+            ("1", "a", "b", 0.0, 0.0, "complete"),
+            ("2", "b", "c", 1.0, 0.0, "complete"),
+            ("3", "a", "c", 0.5, 0.5, "complete"),
+            ("4", "a", "b", 0.0, np.nan, "missing"),
+            ("5", "b", "c", 1.0, 1.0, "partial"),
+        ]
+    )
+
+    battles.loc[len(battles)] = {
+        "battle_id": "unsampled",
+        "model_a": "a",
+        "model_b": "b",
+        "reference_pref": 0.0,
+        "pref": np.nan,
+        "sampled": False,
+        "parse_status": None,
+    }
+    result = MetaEvalAgreementMetric(n_bootstraps=0).calculate(battles)
+
+    assert result["all"] == {
+        "n_attempted": 5,
+        "n_complete": 3,
+        "coverage": pytest.approx(0.6),
+        "accuracy_attempted": pytest.approx(0.4),
+        "accuracy_parsed": pytest.approx(2 / 3),
+        "cohen_kappa": pytest.approx(0.5),
+        "accuracy_attempted_se": pytest.approx(float("nan"), nan_ok=True),
+        "accuracy_parsed_se": pytest.approx(float("nan"), nan_ok=True),
+        "accuracy_parsed_bootstraps_valid": 0,
+        "cohen_kappa_se": pytest.approx(float("nan"), nan_ok=True),
+        "n_bootstraps_requested": 0,
+        "n_kappa_bootstraps_valid": 0,
+    }
+    no_ties = result["no_human_ties"]
+    assert no_ties["n_attempted"] == 4
+    assert no_ties["n_complete"] == 2
+    assert no_ties["coverage"] == pytest.approx(0.5)
+    assert no_ties["accuracy_attempted"] == pytest.approx(0.25)
+    assert no_ties["accuracy_parsed"] == pytest.approx(0.5)
+    assert no_ties["cohen_kappa"] == pytest.approx(0.0)
+
+
+def test_agreement_bootstrap_is_row_order_invariant_and_reports_finite_draws():
+    battles = _rows(
+        [
+            ("1", "a", "b", 0.0, 0.0, "complete"),
+            ("2", "b", "c", 1.0, 0.0, "complete"),
+            ("3", "a", "c", 0.0, np.nan, "missing"),
+        ]
+    )
+    metric = MetaEvalAgreementMetric(n_bootstraps=8)
+    result = metric.calculate(battles, rng=np.random.default_rng(7))["all"]
+    reordered = metric.calculate(battles.iloc[::-1], rng=np.random.default_rng(7))[
+        "all"
+    ]
+
+    expected_rng = np.random.default_rng(7)
+    parsed_accuracies = []
+    outcomes = np.array([1.0, 0.0, np.nan])
+    for _ in range(8):
+        sampled = outcomes[expected_rng.integers(0, 3, size=3)]
+        parsed = sampled[np.isfinite(sampled)]
+        if len(parsed):
+            parsed_accuracies.append(float(parsed.mean()))
+
+    assert result == pytest.approx(reordered, nan_ok=True)
+    assert result["accuracy_parsed_bootstraps_valid"] == len(parsed_accuracies)
+    assert result["accuracy_parsed_se"] == pytest.approx(
+        np.std(parsed_accuracies, ddof=1)
+    )
+
+
+def test_no_human_ties_drops_only_reference_ties_and_keeps_judge_ties():
+    battles = _rows(
+        [
+            ("1", "a", "b", 0.5, 0.0, "complete"),
+            ("2", "b", "c", 1.0, 0.5, "complete"),
+            ("3", "a", "c", 0.0, 0.0, "complete"),
+        ]
+    )
+
+    view = MetaEvalAgreementMetric(n_bootstraps=0).calculate(battles)["no_human_ties"]
+
+    assert view["n_attempted"] == 2
+    assert view["accuracy_attempted"] == pytest.approx(0.5)
+
+
+def test_ranking_reuses_three_point_fits_and_refits_each_bootstrap(monkeypatch):
+    calls = 0
+    original = scoring_module.fit_bradley_terry
+
+    def counted_fit(*args, **kwargs):
+        nonlocal calls
+        calls += 1
+        return original(*args, **kwargs)
+
+    monkeypatch.setattr(scoring_module, "fit_bradley_terry", counted_fit)
+    point = MetaEvalRankingMetric(n_bootstraps=0).calculate(_ranking_battles())
+    assert calls == 3
+    assert math.isfinite(point["hard"]["spearman"])
+    assert math.isfinite(point["soft"]["elo_mae"])
+    assert point["hard"]["elo_mae"] != pytest.approx(point["soft"]["elo_mae"])
+
+    calls = 0
+    result = MetaEvalRankingMetric(n_bootstraps=3).calculate(
+        _ranking_battles(), rng=np.random.default_rng(4)
+    )
+    assert calls == 12
+    assert result["n_bootstraps_requested"] == 3
+    assert 0 <= result["n_bootstraps_valid"] <= 3
+
+
+def test_ranking_is_invariant_to_row_order_and_global_ab_swap():
+    battles = _ranking_battles()
+    shuffled = battles.sample(frac=1, random_state=7)
+    swapped = battles.copy()
+    swapped[["model_a", "model_b"]] = swapped[["model_b", "model_a"]]
+    swapped["reference_pref"] = 1.0 - swapped["reference_pref"]
+    swapped["pref"] = 1.0 - swapped["pref"]
+    metric = MetaEvalRankingMetric(n_bootstraps=8)
+
+    expected = metric.calculate(battles, rng=np.random.default_rng(9))
+    reordered = metric.calculate(shuffled, rng=np.random.default_rng(9))
+    reversed_ab = metric.calculate(swapped, rng=np.random.default_rng(9))
+
+    for result in (reordered, reversed_ab):
+        assert result["n_bootstraps_valid"] == expected["n_bootstraps_valid"]
+        for kind in ("hard", "soft"):
+            for value in ("spearman", "spearman_se", "elo_mae", "elo_mae_se"):
+                assert result[kind][value] == pytest.approx(
+                    expected[kind][value], nan_ok=True, abs=1e-5
+                )
+
+
+def test_ranking_human_ties_are_configurable_and_model_set_stays_fixed():
+    battles = _ranking_battles()
+    tie = battles.iloc[[0]].copy()
+    tie["battle_id"] = "only-c-edge"
+    tie["model_a"] = "a"
+    tie["model_b"] = "d"
+    tie["reference_pref"] = 0.5
+    tie["pref"] = 0.0
+    battles = pd.concat([battles, tie], ignore_index=True)
+
+    excluded = MetaEvalRankingMetric(n_bootstraps=0).calculate(battles)
+    included = MetaEvalRankingMetric(n_bootstraps=0, include_human_ties=True).calculate(
+        battles
+    )
+
+    assert excluded["n_models"] == 4
+    assert excluded["n_battles"] == 12
+    assert math.isnan(excluded["hard"]["elo_mae"])
+    assert included["n_battles"] == 13
+    assert math.isfinite(included["hard"]["elo_mae"])
+
+
+def test_ranking_returns_numeric_unavailable_for_insufficient_graphs():
+    disconnected = _rows(
+        [
+            ("1", "a", "b", 0.0, 0.0, "complete"),
+            ("2", "a", "b", 1.0, 1.0, "complete"),
+            ("3", "c", "d", 0.0, 0.0, "complete"),
+            ("4", "c", "d", 1.0, 1.0, "complete"),
+        ]
+    )
+    too_few = disconnected.iloc[:2]
+
+    for battles in (disconnected, too_few):
+        result = MetaEvalRankingMetric(n_bootstraps=0).calculate(battles)
+        assert result["n_bootstraps_valid"] == 0
+        assert math.isnan(result["hard"]["spearman"])
+        assert math.isnan(result["soft"]["elo_mae"])
+
+
+@pytest.mark.parametrize(
+    ("column", "value", "message"),
+    [
+        ("pref", 1.1, "numeric preferences"),
+        ("reference_pref", 0.25, "must be 0, 0.5, or 1"),
+    ],
+)
+def test_malformed_preferences_raise_instead_of_becoming_unavailable(
+    column, value, message
+):
+    battles = _ranking_battles()
+    battles.loc[0, column] = value
+
+    with pytest.raises(ValueError, match=message):
+        MetaEvalRankingMetric(n_bootstraps=0).calculate(battles)

--- a/tests/test_meta_eval_scoring.py
+++ b/tests/test_meta_eval_scoring.py
@@ -222,11 +222,7 @@ def _elo_gap_battles() -> pd.DataFrame:
     ],
 )
 def test_elo_gap_configuration_rejects_invalid_parameters(parameters):
-    valid = {
-        "battle_counts": [1, 2],
-        "n_seeds": 2,
-        "tie_tolerance": 0.01,
-    }
+    valid = {"battle_counts": [1, 2], "n_seeds": 2, "tie_tolerance": 0.01}
     with pytest.raises(ValueError, match="Invalid parameters"):
         build_metric("meta_eval_elo_gap", valid | parameters)
 
@@ -257,11 +253,16 @@ def test_elo_gap_bundles_shared_methods_and_is_row_order_invariant():
     assert result == shuffled
     assert result["n_models"] == 3
     assert result["soft"] == result["hard"]
-    for variant in ("hard", "soft"):
-        full_budget = result[variant][-1]
-        assert full_budget["mean_gap"] == pytest.approx(0.0, abs=1e-6)
-        assert full_budget["n_seeds_valid"] == 3
-        assert full_budget["mean_used_per_model"] == 4
+    full_budget = result["hard"][-1]
+    assert full_budget["mean_gap"] == pytest.approx(0.0, abs=1e-6)
+    assert full_budget["n_seeds_valid"] == 3
+    assert full_budget["mean_used_per_model"] == 4
+
+    # Moving confidence without changing a hard label must affect only soft Elo.
+    battles.loc[battles["pref"].eq(0.0), "pref"] = 0.2
+    softened = metric.calculate(battles, rng=np.random.default_rng(11))
+    assert softened["hard"] == result["hard"]
+    assert softened["soft"][-1]["mean_gap"] != pytest.approx(full_budget["mean_gap"])
 
 
 def test_elo_gap_draws_attempts_before_parse_filtering_and_uses_nested_prefixes():
@@ -293,10 +294,13 @@ def test_elo_gap_keeps_fixed_model_set_and_fails_whole_replicates():
         assert math.isnan(row["mean_gap"])
 
 
-def test_elo_gap_rejects_attempted_battle_shortfalls():
+def test_elo_gap_warns_and_returns_empty_for_attempted_battle_shortfalls(caplog):
     battles = _elo_gap_battles()
     battles.loc[battles["battle_id"].eq("ab-0"), "sampled"] = False
     battles.loc[battles["battle_id"].eq("ab-0"), "pref"] = np.nan
 
-    with pytest.raises(ValueError, match="Every model needs at least 4"):
-        _elo_gap_metric((4,), 1).calculate(battles, rng=np.random.default_rng(1))
+    result = _elo_gap_metric((4,), 1).calculate(battles, rng=np.random.default_rng(1))
+
+    assert result == {}
+    assert "Skipping meta_eval_elo_gap" in caplog.text
+    assert "at least 4 attempted incident battles" in caplog.text

--- a/tests/test_meta_eval_task_runtime.py
+++ b/tests/test_meta_eval_task_runtime.py
@@ -74,6 +74,21 @@ def _fake_annotations(sample: pd.DataFrame) -> pd.DataFrame:
     return pd.DataFrame(rows)
 
 
+def test_prepare_arena_battles_drops_self_comparisons():
+    arena = _arena()
+    self_comparison = arena.iloc[[0]].copy()
+    self_comparison["question_id"] = "self-comparison"
+    self_comparison["model_b"] = self_comparison["model_a"]
+    source = pd.concat([arena, self_comparison], ignore_index=True)
+
+    prepared = runner_module._prepare_arena_battles(
+        source, task="meta-eval-test", arena="TestArena", languages=[]
+    )
+
+    assert len(prepared) == len(arena)
+    assert not (prepared["model_a"] == prepared["model_b"]).any()
+
+
 def test_meta_eval_runner_builds_full_metric_table_and_artifacts(tmp_path, monkeypatch):
     task = get_packaged_task("meta-eval-comparia")
     assert task is not None

--- a/tests/test_meta_eval_task_runtime.py
+++ b/tests/test_meta_eval_task_runtime.py
@@ -22,7 +22,7 @@ def _arena() -> pd.DataFrame:
         ("a", "b", "model_b", "fr"),
         ("b", "c", "tie (bothbad)", "en"),
         ("a", "c", "model_a", "fr"),
-    ]
+    ] * 20
     rows = []
     for index, (model_a, model_b, winner, language) in enumerate(pairs):
         prompt = f"prompt {index}"
@@ -46,17 +46,11 @@ def _arena() -> pd.DataFrame:
     return pd.DataFrame(rows)
 
 
-def _config(tmp_path: Path, *, battle_counts: list[int] | None = None) -> RunConfig:
+def _config(tmp_path: Path, *, battles_per_model: int = 50) -> RunConfig:
     return RunConfig(
         task="meta-eval-comparia",
         judge={"model": "Dummy/judge", "swap_mode": "fixed"},
-        meta_eval={
-            "top_models": 3,
-            "battles_per_model": 1,
-            "n_bootstraps": 0,
-            "elo_gap_battles": battle_counts or [1],
-            "elo_gap_seeds": 1,
-        },
+        meta_eval={"top_models": 3, "battles_per_model": battles_per_model},
         run={"result_folder": str(tmp_path), "no_log_file": True, "seed": 7},
     )
 
@@ -67,14 +61,14 @@ def _fake_annotations(sample: pd.DataFrame) -> pd.DataFrame:
         rows.append(
             {
                 "battle_id": battle.battle_id,
-                "question_id": battle.question_id,
-                "model_a": battle.model_a,
-                "model_b": battle.model_b,
-                "winner": battle.winner,
-                "lang": battle.lang,
-                "parse_ok": True,
-                "pref": 0.25,
                 "orientation": "single",
+                "pref": 0.25,
+                "judge_input": "input",
+                "judge_completion": "output",
+                "judge_top_logprobs_json": None,
+                "parsed_label": None,
+                "parsed_scores_json": None,
+                "parsed_details_json": None,
             }
         )
     return pd.DataFrame(rows)
@@ -110,15 +104,18 @@ def test_meta_eval_runner_builds_full_metric_table_and_artifacts(tmp_path, monke
     assert len(metric_battles) == len(_arena())
     assert metric_battles["battle_id"].is_unique
     assert set(metric_battles["reference_pref"]) == {0.0, 0.5, 1.0}
-    assert set(metric_battles["language_group"]) == {"English", "Multilingual"}
-    assert metric_battles[["language_group", "battle_id"]].equals(
-        metric_battles[["language_group", "battle_id"]].sort_values(
-            ["language_group", "battle_id"], kind="stable", ignore_index=True
-        )
-    )
+    assert list(metric_battles.columns) == [
+        "battle_id",
+        "model_a",
+        "model_b",
+        "reference_pref",
+        "sampled",
+        "pref",
+    ]
+    assert metric_battles["battle_id"].is_monotonic_increasing
     assert metric_battles["sampled"].any()
     assert (~metric_battles["sampled"]).any()
-    assert metric_battles.loc[~metric_battles["sampled"], "parse_status"].isna().all()
+    assert metric_battles.loc[~metric_battles["sampled"], "pref"].isna().all()
     assert set(captured["runtime"]) == {
         "meta_eval_agreement",
         "meta_eval_ranking",
@@ -142,7 +139,9 @@ def test_meta_eval_runner_builds_full_metric_table_and_artifacts(tmp_path, monke
     }.issubset({path.name for path in result_path.parent.iterdir()})
     saved_battles = pd.read_parquet(result_path.parent / "battles.parquet")
     assert len(saved_battles) == len(metric_battles)
-    assert {"reference_pref", "sampled", "parse_status"}.issubset(saved_battles)
+    assert list(saved_battles.columns) == list(metric_battles.columns)
+    metadata = json.loads((result_path.parent / "run-metadata.v1.json").read_text())
+    assert set(metadata["dataset_statistics"]) == {"battle_id_count"}
     saved = json.loads(result_path.read_text())
     assert saved["metrics"] == result["metrics"]
     assert "agreement" not in saved
@@ -158,7 +157,7 @@ def test_meta_eval_elo_gap_budget_is_checked_before_data_loading(tmp_path, monke
     )
 
     with pytest.raises(ValueError, match="exceeds meta_eval.battles_per_model"):
-        runner_module.run_meta_eval(_config(tmp_path, battle_counts=[2]), task)
+        runner_module.run_meta_eval(_config(tmp_path, battles_per_model=49), task)
 
 
 def test_meta_eval_rejects_unknown_human_winner_before_judge_build(

--- a/tests/test_meta_eval_task_runtime.py
+++ b/tests/test_meta_eval_task_runtime.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from copy import deepcopy
 from pathlib import Path
 
 import numpy as np
@@ -23,27 +24,10 @@ def _arena() -> pd.DataFrame:
         ("b", "c", "tie (bothbad)", "en"),
         ("a", "c", "model_a", "fr"),
     ] * 20
-    rows = []
-    for index, (model_a, model_b, winner, language) in enumerate(pairs):
-        prompt = f"prompt {index}"
-        rows.append(
-            {
-                "question_id": f"q{index}",
-                "model_a": model_a,
-                "model_b": model_b,
-                "winner": winner,
-                "lang": language,
-                "conversation_a": [
-                    {"role": "user", "content": prompt},
-                    {"role": "assistant", "content": f"{model_a} answer"},
-                ],
-                "conversation_b": [
-                    {"role": "user", "content": prompt},
-                    {"role": "assistant", "content": f"{model_b} answer"},
-                ],
-            }
-        )
-    return pd.DataFrame(rows)
+    return pd.DataFrame(
+        [(f"q{i}", *pair) for i, pair in enumerate(pairs)],
+        columns=["question_id", "model_a", "model_b", "winner", "lang"],
+    ).assign(conversation_a=None, conversation_b=None)
 
 
 def _config(tmp_path: Path, *, battles_per_model: int = 50) -> RunConfig:
@@ -70,72 +54,74 @@ def test_prepare_arena_battles_drops_self_comparisons():
     assert not (prepared["model_a"] == prepared["model_b"]).any()
 
 
-def test_meta_eval_runner_builds_full_metric_table_and_artifacts(tmp_path, monkeypatch):
-    task = get_packaged_task("meta-eval-comparia")
-    captured = {}
-    judge = object()
-
+@pytest.mark.parametrize("battles_per_model", [2, 12], ids=["unavailable", "available"])
+def test_meta_eval_scores_renders_and_saves(
+    tmp_path, monkeypatch, capsys, battles_per_model
+):
+    task = deepcopy(get_packaged_task("meta-eval-comparia"))
+    for request in task.spec.protocol.scoring.metrics:
+        if "n_bootstraps" in request.parameters:
+            request.parameters["n_bootstraps"] = 2
+        else:
+            request.parameters.update(battle_counts=[4, 8], n_seeds=2)
     monkeypatch.setattr(runner_module, "load_battles", lambda _task: _arena())
-    monkeypatch.setattr(runner_module, "build_judge", lambda _cfg: judge)
+    monkeypatch.setattr(runner_module, "build_judge", lambda _cfg: object())
 
-    def fake_annotate(sample, _cfg, *, judge_chat_model, resolved_prompt):
-        assert judge_chat_model is judge
-        assert resolved_prompt.delegated is False
-        captured["sample_ids"] = set(sample["battle_id"])
-        return sample[["battle_id"]].assign(orientation="single", pref=0.25)
+    def fake_annotate(sample, *_args, **_kwargs):
+        rows = sample[["battle_id", "reference_pref"]].rename(
+            columns={"reference_pref": "pref"}
+        )
+        rows.loc[rows.index[0], "pref"] = np.nan
+        return rows.assign(orientation="single")
 
     monkeypatch.setattr(runner_module, "annotate_sample", fake_annotate)
-
-    def fake_calculate(metric_battles, metrics, *, runtime_by_metric):
-        captured["battles"] = metric_battles.copy()
-        captured["runtime"] = runtime_by_metric
-        return {request.metric: {"ok": True} for request, _metric in metrics}
-
-    monkeypatch.setattr(runner_module, "calculate_metrics", fake_calculate)
-    monkeypatch.setattr(runner_module.MetaEvalReport, "render", lambda self: None)
-
-    result = runner_module.run_meta_eval(_config(tmp_path), task)
-
-    metric_battles = captured["battles"]
-    assert len(metric_battles) == len(_arena())
-    assert metric_battles["battle_id"].is_unique
-    assert set(metric_battles["reference_pref"]) == {0.0, 0.5, 1.0}
-    sampled = metric_battles.loc[metric_battles["sampled"]]
-    assert set(sampled["battle_id"]) == captured["sample_ids"]
-    assert set(sampled["pref"]) == {0.25}
-    assert (~metric_battles["sampled"]).any()
-    assert metric_battles.loc[~metric_battles["sampled"], "pref"].isna().all()
-    assert set(captured["runtime"]) == {
-        "meta_eval_agreement",
-        "meta_eval_ranking",
-        "meta_eval_elo_gap",
-    }
-    assert all(
-        isinstance(runtime["rng"], np.random.Generator)
-        for runtime in captured["runtime"].values()
-    )
+    cfg = _config(tmp_path, battles_per_model=battles_per_model)
+    result = runner_module.run_meta_eval(cfg, task)
 
     result_path = Path(result["result_path"])
-    assert {"sample.parquet", "annotations.parquet", "battles.parquet"}.issubset(
-        path.name for path in result_path.parent.iterdir()
+    sample = pd.read_parquet(result_path.parent / "sample.parquet")
+    annotations = pd.read_parquet(result_path.parent / "annotations.parquet")
+    battles = pd.read_parquet(result_path.parent / "battles.parquet")
+    assert battles["battle_id"].is_unique
+    assert set(battles["battle_id"]) == set("ComparIA:" + _arena()["question_id"])
+    assert set(sample["battle_id"]) == set(annotations["battle_id"])
+    sampled = battles.loc[battles["sampled"]].set_index("battle_id")
+    pd.testing.assert_series_equal(
+        sampled["pref"].sort_index(),
+        annotations.set_index("battle_id")["pref"].sort_index(),
     )
-    saved_battles = pd.read_parquet(result_path.parent / "battles.parquet")
-    pd.testing.assert_frame_equal(saved_battles, metric_battles, check_like=True)
+    assert 0 < len(sampled) == len(sample) < len(battles)
+    assert sampled["pref"].isna().sum() == 1
+    assert battles.loc[~battles["sampled"], "pref"].isna().all()
+    assert set(battles["reference_pref"]) == {0.0, 0.5, 1.0}
+
     saved = json.loads(result_path.read_text())
-    assert saved["metrics"] == result["metrics"]
-    assert "agreement" not in saved
-
-
-def test_meta_eval_elo_gap_budget_is_checked_before_data_loading(tmp_path, monkeypatch):
-    task = get_packaged_task("meta-eval-comparia")
-    monkeypatch.setattr(
-        runner_module,
-        "load_battles",
-        lambda _task: pytest.fail("data must not load before static preflight"),
-    )
-
-    with pytest.raises(ValueError, match="exceeds meta_eval.battles_per_model"):
-        runner_module.run_meta_eval(_config(tmp_path, battles_per_model=49), task)
+    agreement = saved["metrics"]["meta_eval_agreement"]["all"]
+    assert agreement["n_attempted"] == len(sample)
+    assert agreement["n_complete"] == len(sample) - 1
+    assert agreement["accuracy_complete"] == 1
+    assert agreement["accuracy_attempted"] == pytest.approx(1 - 1 / len(sample))
+    ranking = saved["metrics"]["meta_eval_ranking"]
+    complete_non_ties = sampled["pref"].notna() & sampled["reference_pref"].ne(0.5)
+    assert ranking["n_battles"] == complete_non_ties.sum()
+    output = capsys.readouterr().out
+    assert f"complete {len(sample) - 1}/{len(sample)}" in output
+    elo_gap = saved["metrics"]["meta_eval_elo_gap"]
+    if battles_per_model == 2:
+        assert elo_gap == {}
+        assert "meta_eval_elo_gap: unavailable" in output
+    else:
+        for method in ("hard", "soft"):
+            assert ranking[method]["elo_mae"] == pytest.approx(0)
+            for row, budget in zip(elo_gap[method], [4, 8], strict=True):
+                assert row["attempted_battles_per_model"] == budget
+                assert np.isfinite(row["mean_gap"])
+                assert row["n_seeds_valid"] == 2
+        assert "8 attempted battles/focal" in output
+    metadata = json.loads((result_path.parent / "run-metadata.v1.json").read_text())
+    assert metadata["results"] == saved
+    assert metadata["dataset_statistics"]["battle_id_count"] == len(sample)
+    assert metadata["run"]["meta_eval"]["battles_per_model"] == battles_per_model
 
 
 def test_meta_eval_rejects_unknown_human_winner_before_judge_build(

--- a/tests/test_meta_eval_task_runtime.py
+++ b/tests/test_meta_eval_task_runtime.py
@@ -55,25 +55,6 @@ def _config(tmp_path: Path, *, battles_per_model: int = 50) -> RunConfig:
     )
 
 
-def _fake_annotations(sample: pd.DataFrame) -> pd.DataFrame:
-    rows = []
-    for battle in sample.itertuples(index=False):
-        rows.append(
-            {
-                "battle_id": battle.battle_id,
-                "orientation": "single",
-                "pref": 0.25,
-                "judge_input": "input",
-                "judge_completion": "output",
-                "judge_top_logprobs_json": None,
-                "parsed_label": None,
-                "parsed_scores_json": None,
-                "parsed_details_json": None,
-            }
-        )
-    return pd.DataFrame(rows)
-
-
 def test_prepare_arena_battles_drops_self_comparisons():
     arena = _arena()
     self_comparison = arena.iloc[[0]].copy()
@@ -91,7 +72,6 @@ def test_prepare_arena_battles_drops_self_comparisons():
 
 def test_meta_eval_runner_builds_full_metric_table_and_artifacts(tmp_path, monkeypatch):
     task = get_packaged_task("meta-eval-comparia")
-    assert task is not None
     captured = {}
     judge = object()
 
@@ -101,7 +81,8 @@ def test_meta_eval_runner_builds_full_metric_table_and_artifacts(tmp_path, monke
     def fake_annotate(sample, _cfg, *, judge_chat_model, resolved_prompt):
         assert judge_chat_model is judge
         assert resolved_prompt.delegated is False
-        return _fake_annotations(sample)
+        captured["sample_ids"] = set(sample["battle_id"])
+        return sample[["battle_id"]].assign(orientation="single", pref=0.25)
 
     monkeypatch.setattr(runner_module, "annotate_sample", fake_annotate)
 
@@ -119,16 +100,9 @@ def test_meta_eval_runner_builds_full_metric_table_and_artifacts(tmp_path, monke
     assert len(metric_battles) == len(_arena())
     assert metric_battles["battle_id"].is_unique
     assert set(metric_battles["reference_pref"]) == {0.0, 0.5, 1.0}
-    assert list(metric_battles.columns) == [
-        "battle_id",
-        "model_a",
-        "model_b",
-        "reference_pref",
-        "sampled",
-        "pref",
-    ]
-    assert metric_battles["battle_id"].is_monotonic_increasing
-    assert metric_battles["sampled"].any()
+    sampled = metric_battles.loc[metric_battles["sampled"]]
+    assert set(sampled["battle_id"]) == captured["sample_ids"]
+    assert set(sampled["pref"]) == {0.25}
     assert (~metric_battles["sampled"]).any()
     assert metric_battles.loc[~metric_battles["sampled"], "pref"].isna().all()
     assert set(captured["runtime"]) == {
@@ -142,21 +116,11 @@ def test_meta_eval_runner_builds_full_metric_table_and_artifacts(tmp_path, monke
     )
 
     result_path = Path(result["result_path"])
-    assert result_path.name == "results.json"
-    assert result_path.parent.name.startswith("meta-eval-comparia-dummy-judge-fixed-")
-    assert {
-        "config.yaml",
-        "sample.parquet",
-        "annotations.parquet",
-        "battles.parquet",
-        "results.json",
-        "run-metadata.v1.json",
-    }.issubset({path.name for path in result_path.parent.iterdir()})
+    assert {"sample.parquet", "annotations.parquet", "battles.parquet"}.issubset(
+        path.name for path in result_path.parent.iterdir()
+    )
     saved_battles = pd.read_parquet(result_path.parent / "battles.parquet")
-    assert len(saved_battles) == len(metric_battles)
-    assert list(saved_battles.columns) == list(metric_battles.columns)
-    metadata = json.loads((result_path.parent / "run-metadata.v1.json").read_text())
-    assert set(metadata["dataset_statistics"]) == {"battle_id_count"}
+    pd.testing.assert_frame_equal(saved_battles, metric_battles, check_like=True)
     saved = json.loads(result_path.read_text())
     assert saved["metrics"] == result["metrics"]
     assert "agreement" not in saved
@@ -164,7 +128,6 @@ def test_meta_eval_runner_builds_full_metric_table_and_artifacts(tmp_path, monke
 
 def test_meta_eval_elo_gap_budget_is_checked_before_data_loading(tmp_path, monkeypatch):
     task = get_packaged_task("meta-eval-comparia")
-    assert task is not None
     monkeypatch.setattr(
         runner_module,
         "load_battles",
@@ -179,7 +142,6 @@ def test_meta_eval_rejects_unknown_human_winner_before_judge_build(
     tmp_path, monkeypatch
 ):
     task = get_packaged_task("meta-eval-comparia")
-    assert task is not None
     arena = _arena()
     arena.loc[0, "winner"] = "unknown"
     monkeypatch.setattr(runner_module, "load_battles", lambda _task: arena)

--- a/tests/test_meta_eval_task_runtime.py
+++ b/tests/test_meta_eval_task_runtime.py
@@ -1,0 +1,179 @@
+"""Focused integration tests for the meta-evaluation task runner."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import judgearena.benchmarks.meta_eval.runner as runner_module
+from judgearena.config import RunConfig
+from judgearena.tasks.registry import get_packaged_task
+
+
+def _arena() -> pd.DataFrame:
+    pairs = [
+        ("a", "b", "model_a", "en"),
+        ("b", "c", "model_b", "fr"),
+        ("a", "c", "tie", "en"),
+        ("a", "b", "model_b", "fr"),
+        ("b", "c", "tie (bothbad)", "en"),
+        ("a", "c", "model_a", "fr"),
+    ]
+    rows = []
+    for index, (model_a, model_b, winner, language) in enumerate(pairs):
+        prompt = f"prompt {index}"
+        rows.append(
+            {
+                "question_id": f"q{index}",
+                "model_a": model_a,
+                "model_b": model_b,
+                "winner": winner,
+                "lang": language,
+                "conversation_a": [
+                    {"role": "user", "content": prompt},
+                    {"role": "assistant", "content": f"{model_a} answer"},
+                ],
+                "conversation_b": [
+                    {"role": "user", "content": prompt},
+                    {"role": "assistant", "content": f"{model_b} answer"},
+                ],
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+def _config(tmp_path: Path, *, battle_counts: list[int] | None = None) -> RunConfig:
+    return RunConfig(
+        task="meta-eval-comparia",
+        judge={"model": "Dummy/judge", "swap_mode": "fixed"},
+        meta_eval={
+            "top_models": 3,
+            "battles_per_model": 1,
+            "n_bootstraps": 0,
+            "elo_gap_battles": battle_counts or [1],
+            "elo_gap_seeds": 1,
+        },
+        run={"result_folder": str(tmp_path), "no_log_file": True, "seed": 7},
+    )
+
+
+def _fake_annotations(sample: pd.DataFrame) -> pd.DataFrame:
+    rows = []
+    for battle in sample.itertuples(index=False):
+        rows.append(
+            {
+                "battle_id": battle.battle_id,
+                "question_id": battle.question_id,
+                "model_a": battle.model_a,
+                "model_b": battle.model_b,
+                "winner": battle.winner,
+                "lang": battle.lang,
+                "parse_ok": True,
+                "pref": 0.25,
+                "orientation": "single",
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+def test_meta_eval_runner_builds_full_metric_table_and_artifacts(tmp_path, monkeypatch):
+    task = get_packaged_task("meta-eval-comparia")
+    assert task is not None
+    captured = {}
+    judge = object()
+
+    monkeypatch.setattr(runner_module, "load_battles", lambda _task: _arena())
+    monkeypatch.setattr(runner_module, "build_judge", lambda _cfg: judge)
+
+    def fake_annotate(sample, _cfg, *, judge_chat_model, resolved_prompt):
+        assert judge_chat_model is judge
+        assert resolved_prompt.delegated is False
+        return _fake_annotations(sample)
+
+    monkeypatch.setattr(runner_module, "annotate_sample", fake_annotate)
+
+    def fake_calculate(metric_battles, metrics, *, runtime_by_metric):
+        captured["battles"] = metric_battles.copy()
+        captured["runtime"] = runtime_by_metric
+        return {request.metric: {"ok": True} for request, _metric in metrics}
+
+    monkeypatch.setattr(runner_module, "calculate_metrics", fake_calculate)
+    monkeypatch.setattr(runner_module.MetaEvalReport, "render", lambda self: None)
+
+    result = runner_module.run_meta_eval(_config(tmp_path), task)
+
+    metric_battles = captured["battles"]
+    assert len(metric_battles) == len(_arena())
+    assert metric_battles["battle_id"].is_unique
+    assert set(metric_battles["reference_pref"]) == {0.0, 0.5, 1.0}
+    assert set(metric_battles["language_group"]) == {"English", "Multilingual"}
+    assert metric_battles[["language_group", "battle_id"]].equals(
+        metric_battles[["language_group", "battle_id"]].sort_values(
+            ["language_group", "battle_id"], kind="stable", ignore_index=True
+        )
+    )
+    assert metric_battles["sampled"].any()
+    assert (~metric_battles["sampled"]).any()
+    assert metric_battles.loc[~metric_battles["sampled"], "parse_status"].isna().all()
+    assert set(captured["runtime"]) == {
+        "meta_eval_agreement",
+        "meta_eval_ranking",
+        "meta_eval_elo_gap",
+    }
+    assert all(
+        isinstance(runtime["rng"], np.random.Generator)
+        for runtime in captured["runtime"].values()
+    )
+
+    result_path = Path(result["result_path"])
+    assert result_path.name == "results.json"
+    assert result_path.parent.name.startswith("meta-eval-comparia-dummy-judge-fixed-")
+    assert {
+        "config.yaml",
+        "sample.parquet",
+        "annotations.parquet",
+        "battles.parquet",
+        "results.json",
+        "run-metadata.v1.json",
+    }.issubset({path.name for path in result_path.parent.iterdir()})
+    saved_battles = pd.read_parquet(result_path.parent / "battles.parquet")
+    assert len(saved_battles) == len(metric_battles)
+    assert {"reference_pref", "sampled", "parse_status"}.issubset(saved_battles)
+    saved = json.loads(result_path.read_text())
+    assert saved["metrics"] == result["metrics"]
+    assert "agreement" not in saved
+
+
+def test_meta_eval_elo_gap_budget_is_checked_before_data_loading(tmp_path, monkeypatch):
+    task = get_packaged_task("meta-eval-comparia")
+    assert task is not None
+    monkeypatch.setattr(
+        runner_module,
+        "load_battles",
+        lambda _task: pytest.fail("data must not load before static preflight"),
+    )
+
+    with pytest.raises(ValueError, match="exceeds meta_eval.battles_per_model"):
+        runner_module.run_meta_eval(_config(tmp_path, battle_counts=[2]), task)
+
+
+def test_meta_eval_rejects_unknown_human_winner_before_judge_build(
+    tmp_path, monkeypatch
+):
+    task = get_packaged_task("meta-eval-comparia")
+    assert task is not None
+    arena = _arena()
+    arena.loc[0, "winner"] = "unknown"
+    monkeypatch.setattr(runner_module, "load_battles", lambda _task: arena)
+    monkeypatch.setattr(
+        runner_module,
+        "build_judge",
+        lambda _cfg: pytest.fail("judge must not be built before validation"),
+    )
+
+    with pytest.raises(ValueError, match="invalid human winners.*unknown"):
+        runner_module.run_meta_eval(_config(tmp_path), task)

--- a/tests/test_pairwise_scoring.py
+++ b/tests/test_pairwise_scoring.py
@@ -313,3 +313,13 @@ def test_build_metrics_preserves_order_and_applies_overrides():
     ]
     assert configured[1][1].n_bootstraps == 3
     assert configured[1][0].parameters == {"n_bootstraps": 2}
+
+
+def test_render_metrics_handles_empty_overall_and_group_results():
+    results = {
+        "pairwise_win_rate": {"groups": {"lang": [{"group": "en", "values": {}}]}}
+    }
+
+    assert render_metrics(results) == (
+        "pairwise_win_rate: unavailable\n\nlang=en:\n  pairwise_win_rate: unavailable"
+    )

--- a/tests/test_task_registry.py
+++ b/tests/test_task_registry.py
@@ -658,3 +658,48 @@ def test_mt_bench_accepts_any_registered_metric(tmp_path):
     task = load_tasks(tmp_path)["mt-test"]
 
     assert task.spec.protocol.scoring.metrics[0].metric == "length_controlled_winrate"
+
+
+def test_packaged_meta_eval_tasks_use_pinned_battle_sources_and_metrics():
+    from judgearena.tasks.registry import get_packaged_task
+    from judgearena.tasks.schema import MetaEvalProtocol
+
+    expected = {
+        "meta-eval-comparia": (
+            "ComparIA",
+            "ministere-culture/comparia-votes",
+            "7a40bce496c1f2aa3be4001da85a49cb4743042b",
+        ),
+        "meta-eval-lmarena-100k": (
+            "LMArena-100k",
+            "lmarena-ai/arena-human-preference-100k",
+            "72e85b3ddc9c81bf7b659d6b03d4126dfd8fb34a",
+        ),
+        "meta-eval-lmarena-140k": (
+            "LMArena-140k",
+            "lmarena-ai/arena-human-preference-140k",
+            "6322995ab34d7c2693e3f47dd13fa5caa0789a74",
+        ),
+    }
+    for task_id, (arena, repo_id, revision) in expected.items():
+        task = get_packaged_task(task_id)
+        assert task is not None
+        assert isinstance(task.spec.protocol, MetaEvalProtocol)
+        assert task.spec.protocol.arena == arena
+        assert task.spec.protocol.baseline.strategy == "none"
+        source = next(iter(task.spec.dataset.sources.values()))
+        assert (source.repo_id, source.revision) == (repo_id, revision)
+        metrics = task.spec.protocol.scoring.metrics
+        assert [metric.metric for metric in metrics] == [
+            "meta_eval_agreement",
+            "meta_eval_ranking",
+            "meta_eval_elo_gap",
+        ]
+        assert metrics[0].group_by == ("language_group",)
+        assert metrics[1].group_by == ("language_group",)
+        assert metrics[2].group_by == ()
+
+    english = get_packaged_task("meta-eval-lmarena-100k-en")
+    assert english is not None
+    assert english.selection is not None
+    assert english.selection.values == ("en",)

--- a/tests/test_task_registry.py
+++ b/tests/test_task_registry.py
@@ -662,7 +662,6 @@ def test_mt_bench_accepts_any_registered_metric(tmp_path):
 
 def test_packaged_meta_eval_tasks_use_pinned_battle_sources_and_metrics():
     from judgearena.tasks.registry import get_packaged_task
-    from judgearena.tasks.schema import MetaEvalProtocol
 
     expected = {
         "meta-eval-comparia": (
@@ -683,10 +682,7 @@ def test_packaged_meta_eval_tasks_use_pinned_battle_sources_and_metrics():
     }
     for task_id, (arena, repo_id, revision) in expected.items():
         task = get_packaged_task(task_id)
-        assert task is not None
-        assert isinstance(task.spec.protocol, MetaEvalProtocol)
         assert task.spec.protocol.arena == arena
-        assert task.spec.protocol.baseline.strategy == "none"
         source = next(iter(task.spec.dataset.sources.values()))
         assert (source.repo_id, source.revision) == (repo_id, revision)
         metrics = task.spec.protocol.scoring.metrics
@@ -695,9 +691,6 @@ def test_packaged_meta_eval_tasks_use_pinned_battle_sources_and_metrics():
             "meta_eval_ranking",
             "meta_eval_elo_gap",
         ]
-        assert all(metric.group_by == () for metric in metrics)
 
     english = get_packaged_task("meta-eval-lmarena-100k-en")
-    assert english is not None
-    assert english.selection is not None
     assert english.selection.values == ("en",)

--- a/tests/test_task_registry.py
+++ b/tests/test_task_registry.py
@@ -660,37 +660,22 @@ def test_mt_bench_accepts_any_registered_metric(tmp_path):
     assert task.spec.protocol.scoring.metrics[0].metric == "length_controlled_winrate"
 
 
-def test_packaged_meta_eval_tasks_use_pinned_battle_sources_and_metrics():
+@pytest.mark.parametrize(
+    "task_id, repo_id",
+    [
+        ("meta-eval-comparia", "ministere-culture/comparia-votes"),
+        ("meta-eval-lmarena-100k", "lmarena-ai/arena-human-preference-100k"),
+        ("meta-eval-lmarena-140k", "lmarena-ai/arena-human-preference-140k"),
+    ],
+)
+def test_meta_eval_language_variants_preserve_the_dataset_and_protocol(
+    task_id, repo_id
+):
     from judgearena.tasks.registry import get_packaged_task
 
-    expected = {
-        "meta-eval-comparia": (
-            "ComparIA",
-            "ministere-culture/comparia-votes",
-            "7a40bce496c1f2aa3be4001da85a49cb4743042b",
-        ),
-        "meta-eval-lmarena-100k": (
-            "LMArena-100k",
-            "lmarena-ai/arena-human-preference-100k",
-            "72e85b3ddc9c81bf7b659d6b03d4126dfd8fb34a",
-        ),
-        "meta-eval-lmarena-140k": (
-            "LMArena-140k",
-            "lmarena-ai/arena-human-preference-140k",
-            "6322995ab34d7c2693e3f47dd13fa5caa0789a74",
-        ),
-    }
-    for task_id, (arena, repo_id, revision) in expected.items():
-        task = get_packaged_task(task_id)
-        assert task.spec.protocol.arena == arena
-        source = next(iter(task.spec.dataset.sources.values()))
-        assert (source.repo_id, source.revision) == (repo_id, revision)
-        metrics = task.spec.protocol.scoring.metrics
-        assert [metric.metric for metric in metrics] == [
-            "meta_eval_agreement",
-            "meta_eval_ranking",
-            "meta_eval_elo_gap",
-        ]
+    task = get_packaged_task(task_id)
+    english = get_packaged_task(f"{task_id}-en")
 
-    english = get_packaged_task("meta-eval-lmarena-100k-en")
+    assert next(iter(task.spec.dataset.sources.values())).repo_id == repo_id
+    assert english.spec == task.spec
     assert english.selection.values == ("en",)

--- a/tests/test_task_registry.py
+++ b/tests/test_task_registry.py
@@ -695,9 +695,7 @@ def test_packaged_meta_eval_tasks_use_pinned_battle_sources_and_metrics():
             "meta_eval_ranking",
             "meta_eval_elo_gap",
         ]
-        assert metrics[0].group_by == ("language_group",)
-        assert metrics[1].group_by == ("language_group",)
-        assert metrics[2].group_by == ()
+        assert all(metric.group_by == () for metric in metrics)
 
     english = get_packaged_task("meta-eval-lmarena-100k-en")
     assert english is not None


### PR DESCRIPTION
 ## Problem

   JudgeArena can use judges to evaluate models, but it needs a way to evaluate the judges themselves against human preferences. This PR adds that comparison within the existing task and metric framework. 

   ## What this PR introduces

   Meta-evaluation tasks for **LMArena-100k, LMArena-140k, and ComparIA**, with three types of comparison:

   - **Agreement:** accuracy and Cohen’s kappa against human votes, with parse coverage reported separately.
   - **Ranking:** Spearman correlation and Elo MAE between human and judge rankings.
   - **Elo-gap:** held-out Elo error at different annotation budgets, using hard and soft preferences.

All of these metrics can be improved,removed or added easily - for example one can easily add Kendells-$\tau$ to the correlation without changing the pipeline.

   ## How it works

   The runner selects the most frequent models and samples a connected set of battles with a per-model quota. It judges those battles through the existing prompt and parsing pipeline, then passes canonical numeric preferences to the configured metrics. 

   The implementation reuses the existing dataset loaders, `ParsedPreference`, Bradley–Terry fitter, and metric/report APIs. Task YAML defines the dataset, prompt, and metric settings. Runtime options control sampling.

   Both fixed and two-orientation judging are supported. With two orientations, both passes must parse before a battle contributes a preference. Failed judgments count against attempted agreement accuracy rather than disappearing from the denominator.
   For example:

   ```bash
   uv run judgearena \
     --task meta-eval-lmarena-140k-en \
     --judge.model OpenRouter/deepseek/deepseek-v3.2 \
     --judge.temperature 0 \
     --judge.swap_mode fixed \
     --meta_eval.top_models 10 \
     --meta_eval.battles_per_model 50 \
     --run.seed 0 \
     --run.result_folder results/meta-eval
   ```

   The run saves the sampled battles, judge annotations, metric inputs, and results for inspection.

## Size and validation

Relative to #115 at `e38ccae`. Parent changes are excluded. Pre-existing tests are restored; remaining test reductions apply only to stack-added coverage.

| File type | Added | Deleted | Changed |
|---|---:|---:|---:|
| Production Python | 1,486 | 77 | 1,563 |
| Tests | 601 | 6 | 607 |
| Task YAML, prompts, README | 199 | 1 | 200 |
| **Total** | **2,286** | **84** | **2,370** |

Most core additions are in scoring (576 lines), the runner (217), annotation (184), and sampling (164).

Full local suite: `389 passed`.
