### PR TITLE
Cache: WIP (5/6) Browse content-addressed inference caches

### DIFF
--- a/judgearena/benchmarks/elo/runner.py
+++ b/judgearena/benchmarks/elo/runner.py
@@ -1,6 +1,4 @@
-import hashlib
 from datetime import UTC, datetime
-from functools import partial
 from pathlib import Path
 from typing import TYPE_CHECKING
 
@@ -19,10 +17,13 @@ from judgearena.benchmarks.elo.calibration import calibrate_pairscore_temperatur
 from judgearena.benchmarks.elo.rating import (
     arena_anchor_battles,
     prefs_to_battle_results,
-    sampling_cache_token,
     select_seeded_random_arena_battles,
 )
-from judgearena.benchmarks.execution import build_generation_kwargs
+from judgearena.benchmarks.execution import (
+    build_completion_cache,
+    build_generation_kwargs,
+    build_judgement_cache,
+)
 from judgearena.benchmarks.scoring import build_metrics, calculate_metrics
 from judgearena.datasets import load_battles
 from judgearena.evaluate import (
@@ -33,10 +34,9 @@ from judgearena.evaluate import (
 )
 from judgearena.generate import generate_instructions
 from judgearena.log import get_logger
-from judgearena.models import build_default_judge_model_kwargs, make_model
+from judgearena.models import build_default_judge_model_kwargs, prepare_model
 from judgearena.reports import EloReport
 from judgearena.tasks.schema import EloProtocol, ResolvedTaskSpec
-from judgearena.utils import cache_function_dataframe
 
 if TYPE_CHECKING:
     from judgearena.config import RunConfig
@@ -107,6 +107,11 @@ def run_elo(cfg: "RunConfig", task: ResolvedTaskSpec | None = None) -> dict:
             extract_turn_text(row["conversation_a"][0])
             for _, row in df_battles.iterrows()
         ],
+        index=(
+            arena + ":" + df_battles["question_id"].astype(str)
+            if "question_id" in df_battles
+            else df_battles.index.astype(str)
+        ),
         name="instruction",
     )
     logger.debug("First instruction:\n%s", instructions.iloc[0][:300])
@@ -120,48 +125,13 @@ def run_elo(cfg: "RunConfig", task: ResolvedTaskSpec | None = None) -> dict:
     # dropped battle_thinking_token_budget).
     extra_kwargs = build_generation_kwargs(cfg, cfg.model.name, role="A")
     use_tqdm = False
-    gen_fun = partial(
-        generate_instructions,
+    completions_df = generate_instructions(
+        instructions=instructions,
+        model=cfg.model.name,
         truncate_input_chars=cfg.generation.truncate_all_input_chars,
         use_tqdm=use_tqdm,
+        inference_cache=build_completion_cache(cfg),
         **extra_kwargs,
-    )
-
-    def replace_slash(s: str) -> str:
-        return s.replace("/", "_")
-
-    languages_str = (
-        "-".join(sorted(selected_languages)) if selected_languages else "all"
-    )
-    extra_kwargs_str = (
-        "_".join(f"{k}={v}" for k, v in sorted(extra_kwargs.items()))
-        if extra_kwargs
-        else ""
-    )
-    cache_token = sampling_cache_token(
-        sampling_metadata,
-        n_instructions=cfg.generation.n_instructions,
-        n_instructions_per_language=cfg.elo.n_instructions_per_language,
-    )
-    cache_suffix = (
-        f"{arena}_{replace_slash(cfg.model.name)}_"
-        f"{cache_token}_"
-        f"{languages_str}_{cfg.generation.truncate_all_input_chars}_{extra_kwargs['max_tokens']}"
-        + (f"_{extra_kwargs_str}" if extra_kwargs_str else "")
-    )
-    if len(cache_suffix) > 100:
-        cache_hash = hashlib.sha256(cache_suffix.encode()).hexdigest()[:16]
-        logger.debug(
-            "Cache suffix too long (%d chars), using hash: %s (full: %s)",
-            len(cache_suffix),
-            cache_hash,
-            cache_suffix,
-        )
-        cache_suffix = cache_hash
-    completions_df = cache_function_dataframe(
-        lambda: gen_fun(instructions=instructions, model=cfg.model.name),
-        ignore_cache=cfg.run.ignore_cache,
-        cache_name=f"elo/{cache_suffix}",
     ).set_index("instruction_index")
     completions = completions_df.loc[:, "completion"]
 
@@ -209,8 +179,9 @@ def run_elo(cfg: "RunConfig", task: ResolvedTaskSpec | None = None) -> dict:
     )
 
     def run_judge() -> pd.DataFrame:
-        judge_chat_model = make_model(
+        judge_chat_model = prepare_model(
             model=cfg.judge.model,
+            cache=build_judgement_cache(cfg),
             **judge_extra_kwargs,
         )
         annotations, annotations_reversed, prefs = judge_and_parse_prefs(
@@ -226,6 +197,25 @@ def run_elo(cfg: "RunConfig", task: ResolvedTaskSpec | None = None) -> dict:
             parse=resolved_prompt.parser,
             truncate_input_chars=cfg.generation.truncate_judge_input_chars,
             use_tqdm=use_tqdm,
+            cache_metadata=[
+                {
+                    "instruction_id": str(instructions.index[index]),
+                    "model_a": (
+                        cfg.model.name
+                        if our_model_is_position_a[index]
+                        else opponent_models[index]
+                    ),
+                    "model_b": (
+                        opponent_models[index]
+                        if our_model_is_position_a[index]
+                        else cfg.model.name
+                    ),
+                    "orientation": (
+                        "direct" if our_model_is_position_a[index] else "reversed"
+                    ),
+                }
+                for index in range(n)
+            ],
         )
         if annotations_reversed is None:
             row_annotations = list(annotations)
@@ -258,17 +248,7 @@ def run_elo(cfg: "RunConfig", task: ResolvedTaskSpec | None = None) -> dict:
         )
         return frame
 
-    # Stripping reasoning traces changes the judged text but not the cached
-    # completions, so it must be part of the judge cache key. Only append when
-    # enabled so prior (non-stripped) runs keep their existing cache hashes.
-    judge_cache_suffix = f"judge_{cache_suffix}"
-    if cfg.judge.strip_thinking_before_judging:
-        judge_cache_suffix += "_stripthinking"
-    df_judge = cache_function_dataframe(
-        run_judge,
-        ignore_cache=cfg.run.ignore_cache,
-        cache_name=f"elo/{judge_cache_suffix}",
-    )
+    df_judge = run_judge()
 
     # Restore position arrays and prefs from cache (in case loaded from disk)
     use_model_a_as_opponent = df_judge["use_model_a_as_opponent"].to_numpy()

--- a/judgearena/benchmarks/execution.py
+++ b/judgearena/benchmarks/execution.py
@@ -2,12 +2,14 @@
 
 from __future__ import annotations
 
+from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 
+from judgearena.inference import CompletionInferenceCache, JudgementInferenceCache
 from judgearena.models import (
     build_default_judge_model_kwargs,
     is_thinking_model,
-    make_model,
+    prepare_model,
 )
 
 if TYPE_CHECKING:
@@ -35,8 +37,9 @@ def build_generation_kwargs(
 
 def build_judge(cfg: RunConfig):
     """Construct the configured judge consistently across benchmark runners."""
-    return make_model(
+    return prepare_model(
         model=cfg.judge.model,
+        cache=build_judgement_cache(cfg),
         **build_default_judge_model_kwargs(
             cfg.judge.model,
             cfg.model.engine_kwargs,
@@ -45,3 +48,15 @@ def build_judge(cfg: RunConfig):
             ),
         ),
     )
+
+
+def build_completion_cache(cfg: RunConfig) -> CompletionInferenceCache | None:
+    if cfg.run.store_root is None:
+        return None
+    return CompletionInferenceCache(Path(cfg.run.store_root), cfg.task)
+
+
+def build_judgement_cache(cfg: RunConfig) -> JudgementInferenceCache | None:
+    if cfg.run.store_root is None:
+        return None
+    return JudgementInferenceCache(Path(cfg.run.store_root), cfg.task)

--- a/judgearena/benchmarks/meta_eval/annotate.py
+++ b/judgearena/benchmarks/meta_eval/annotate.py
@@ -161,6 +161,15 @@ def annotate_sample(
         parse=parser,
         truncate_input_chars=cfg.generation.truncate_judge_input_chars,
         use_tqdm=cfg.run.use_tqdm,
+        cache_metadata=[
+            {
+                "instruction_id": battle["battle_id"],
+                "model_a": battle["model_a"],
+                "model_b": battle["model_b"],
+                "orientation": "direct",
+            }
+            for _, battle in df_sample.iterrows()
+        ],
     )
 
     n_battles = len(df_sample)

--- a/judgearena/benchmarks/mt_bench/fastchat_compat.py
+++ b/judgearena/benchmarks/mt_bench/fastchat_compat.py
@@ -362,6 +362,8 @@ def judge_mt_bench_pairwise_fastchat(
         items=items,
         use_tqdm=use_tqdm,
         swap_answers=False,
+        model_a=model_a,
+        model_b=model_b,
     )
 
     g2_judgments: list[str] | None = None
@@ -371,6 +373,8 @@ def judge_mt_bench_pairwise_fastchat(
             items=items,
             use_tqdm=use_tqdm,
             swap_answers=True,
+            model_a=model_a,
+            model_b=model_b,
         )
 
     annotations: list[dict[str, Any]] = []

--- a/judgearena/benchmarks/mt_bench/pairwise_judging.py
+++ b/judgearena/benchmarks/mt_bench/pairwise_judging.py
@@ -76,6 +76,8 @@ def infer_pairwise_judgments_by_prompt_groups(
     items: list[MTBenchJudgeItem],
     use_tqdm: bool,
     swap_answers: bool,
+    model_a: str,
+    model_b: str,
 ) -> tuple[list[str], list[dict[str, str]]]:
     judgments: list[str] = [""] * len(items)
     used_prompt_kwargs: list[dict[str, str]] = [{} for _ in items]
@@ -97,6 +99,17 @@ def infer_pairwise_judgments_by_prompt_groups(
             inputs=prompt_inputs,
             use_tqdm=use_tqdm,
             stage="judging",
+            cache_metadata=[
+                {
+                    "instruction_id": (
+                        f"{items[item_index].question_id}:turn-{items[item_index].turn}"
+                    ),
+                    "model_a": model_b if swap_answers else model_a,
+                    "model_b": model_a if swap_answers else model_b,
+                    "orientation": "reversed" if swap_answers else "direct",
+                }
+                for item_index in idxs
+            ],
         )
         for item_index, output, prompt_kwargs in zip(
             idxs, outputs, batch_kwargs, strict=True

--- a/judgearena/benchmarks/mt_bench/preset_judging.py
+++ b/judgearena/benchmarks/mt_bench/preset_judging.py
@@ -178,6 +178,8 @@ def judge_mt_bench_with_preset(
         items=items,
         use_tqdm=use_tqdm,
         swap_answers=False,
+        model_a=model_a,
+        model_b=model_b,
     )
 
     annotations: list[dict[str, Any]] = []
@@ -246,6 +248,8 @@ def judge_mt_bench_with_preset(
                 items=items,
                 use_tqdm=use_tqdm,
                 swap_answers=True,
+                model_a=model_a,
+                model_b=model_b,
             )
         )
         _append_results(swapped_judgments, swapped_prompt_kwargs, swapped=True)

--- a/judgearena/benchmarks/mt_bench/runner.py
+++ b/judgearena/benchmarks/mt_bench/runner.py
@@ -14,6 +14,10 @@ from typing import TYPE_CHECKING
 import pandas as pd
 
 from judgearena.artifacts import prepare_run_directory, write_run_metadata_safely
+from judgearena.benchmarks.execution import (
+    build_completion_cache,
+    build_judgement_cache,
+)
 from judgearena.benchmarks.mt_bench.fastchat_compat import (
     judge_mt_bench_pairwise_fastchat,
 )
@@ -26,14 +30,10 @@ from judgearena.datasets.mt_bench import (
 )
 from judgearena.generate import generate_multiturn
 from judgearena.log import get_logger
-from judgearena.models import is_thinking_model, make_model
+from judgearena.models import is_thinking_model, prepare_model
 from judgearena.prompts.registry import ResolvedJudgePrompt, resolve_run_judge_prompt
 from judgearena.reports import BattleReport
 from judgearena.tasks.schema import MTBenchProtocol
-from judgearena.utils import (
-    cache_function_dataframe,
-    generation_cache_token,
-)
 
 logger = get_logger(__name__)
 
@@ -86,8 +86,6 @@ def _generate_mt_bench_completions(
     protocol: MTBenchProtocol,
     questions_df: pd.DataFrame,
 ) -> tuple[pd.DataFrame, pd.DataFrame]:
-    cache_prefix = cfg.task
-
     def _run_generation(
         model_name: str, *, generation_kwargs: dict[str, object]
     ) -> pd.DataFrame:
@@ -106,6 +104,7 @@ def _generate_mt_bench_completions(
             use_tqdm=cfg.run.use_tqdm,
             temperature_config=temperature_config,
             strip_thinking_before_turn_2_prompt=cfg.judge.strip_thinking_before_judging,
+            inference_cache=build_completion_cache(cfg),
             **generation_kwargs,
         )
 
@@ -119,19 +118,12 @@ def _generate_mt_bench_completions(
                 completions=loaded_answers,
                 model_name=model_name,
             )
-        # Fold the resolved generation kwargs into the cache key so changing any
-        # sampling param busts cached completions instead of reusing a stale run.
         generation_kwargs = _build_mt_bench_generation_kwargs(
             cfg=cfg, model_spec=model_name, role=role
         )
-        sampling_token = generation_cache_token(generation_kwargs)
-        generated_answers = cache_function_dataframe(
-            lambda: _run_generation(model_name, generation_kwargs=generation_kwargs),
-            ignore_cache=cfg.run.ignore_cache,
-            cache_name=(
-                f"{cache_prefix}_{model_name}_{cfg.generation.n_instructions}_"
-                f"{sampling_token}"
-            ),
+        generated_answers = _run_generation(
+            model_name,
+            generation_kwargs=generation_kwargs,
         )
         return _align_mt_bench_completions(
             questions_df=questions_df,
@@ -435,7 +427,11 @@ def run_mt_bench_benchmark(cfg: RunConfig, task: ResolvedTaskSpec | None = None)
         judge_model_kwargs.setdefault(
             "temperature", protocol.judge.fastchat_temperature
         )
-    judge_chat_model = make_model(model=cfg.judge.model, **judge_model_kwargs)
+    judge_chat_model = prepare_model(
+        model=cfg.judge.model,
+        cache=build_judgement_cache(cfg),
+        **judge_model_kwargs,
+    )
     if resolved_prompt.delegated:
         return _run_mt_bench_fastchat(
             cfg=cfg,

--- a/judgearena/benchmarks/pairwise/runner.py
+++ b/judgearena/benchmarks/pairwise/runner.py
@@ -11,7 +11,11 @@ from typing import TYPE_CHECKING
 import pandas as pd
 
 from judgearena.artifacts import prepare_run_directory, write_run_metadata_safely
-from judgearena.benchmarks.execution import build_generation_kwargs, build_judge
+from judgearena.benchmarks.execution import (
+    build_completion_cache,
+    build_generation_kwargs,
+    build_judge,
+)
 from judgearena.benchmarks.pairwise.baselines import resolve_baseline_plan
 from judgearena.benchmarks.scoring import build_metrics, calculate_metrics
 from judgearena.datasets.pairwise import load_pairwise_task_data
@@ -21,7 +25,6 @@ from judgearena.log import get_logger
 from judgearena.reports import BattleReport
 from judgearena.tasks.registry import get_packaged_task
 from judgearena.tasks.schema import ResolvedTaskSpec
-from judgearena.utils import cache_function_dataframe, generation_cache_token
 
 if TYPE_CHECKING:
     from judgearena.config import RunConfig
@@ -97,11 +100,6 @@ def run_pairwise(cfg: "RunConfig", resolved_task: ResolvedTaskSpec | None = None
     """
 
     run_started_at = datetime.now(UTC)
-
-    # Not working with vllm, not detecting model changes and serving the same cache for two different models...
-    # if not cfg.run.ignore_cache:
-    #     set_langchain_cache()
-    ignore_cache = cfg.run.ignore_cache
 
     resolved_task = resolved_task or get_packaged_task(cfg.task)
     if resolved_task is None:
@@ -198,6 +196,7 @@ def run_pairwise(cfg: "RunConfig", resolved_task: ResolvedTaskSpec | None = None
             model=model_spec,
             truncate_input_chars=cfg.generation.truncate_all_input_chars,
             use_tqdm=cfg.run.use_tqdm,
+            inference_cache=build_completion_cache(cfg),
             **generation_kwargs,
         )
 
@@ -216,18 +215,10 @@ def run_pairwise(cfg: "RunConfig", resolved_task: ResolvedTaskSpec | None = None
         )
         if preloaded is not None:
             return preloaded
-        # Fold the resolved generation kwargs into the cache key so that changing
-        # any sampling param (temperature, seed, top_p/k, max_tokens, ...) busts
-        # the cached completions instead of silently reusing a stale run.
         generation_kwargs = build_generation_kwargs(cfg, model_spec, role=role)
-        sampling_token = generation_cache_token(generation_kwargs)
-        generated = cache_function_dataframe(
-            lambda: _run_generation(model_spec, generation_kwargs=generation_kwargs),
-            ignore_cache=ignore_cache,
-            cache_name=(
-                f"{cfg.task}_{model_spec}_{cfg.generation.n_instructions}_"
-                f"{sampling_token}"
-            ),
+        generated = _run_generation(
+            model_spec,
+            generation_kwargs=generation_kwargs,
         )
         completions = _align_completion_series(generated)
         return (
@@ -294,6 +285,12 @@ def run_pairwise(cfg: "RunConfig", resolved_task: ResolvedTaskSpec | None = None
         judged_B = completions_A.mask(swap_mask, completions_B)
     else:
         judged_A, judged_B = completions_A, completions_B
+    candidate_models = pd.Series(cfg.model.name, index=instructions.index)
+    if swap_mask is not None:
+        judged_model_a = baseline_per_index.mask(swap_mask, cfg.model.name)
+        judged_model_b = candidate_models.mask(swap_mask, baseline_per_index)
+    else:
+        judged_model_a, judged_model_b = baseline_per_index, candidate_models
 
     annotations = []
     annotations_reversed = [] if cfg.judge.swap_mode == "both" else None
@@ -312,6 +309,19 @@ def run_pairwise(cfg: "RunConfig", resolved_task: ResolvedTaskSpec | None = None
             parse=group_prompt.parser,
             truncate_input_chars=cfg.generation.truncate_judge_input_chars,
             use_tqdm=cfg.run.use_tqdm,
+            cache_metadata=[
+                {
+                    "instruction_id": str(index),
+                    "model_a": judged_model_a.loc[index],
+                    "model_b": judged_model_b.loc[index],
+                    "orientation": (
+                        "direct"
+                        if judged_model_a.loc[index] == cfg.model.name
+                        else "reversed"
+                    ),
+                }
+                for index in group_index
+            ],
         )
         annotations.extend(group_annotations)
         if group_reversed is not None:

--- a/judgearena/browse_cache.py
+++ b/judgearena/browse_cache.py
@@ -1,0 +1,470 @@
+"""Inspect content-addressed JudgeArena cache cells."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+from dataclasses import dataclass
+from functools import cache
+from pathlib import Path
+from typing import Literal
+from urllib.parse import unquote
+
+import pandas as pd
+
+from judgearena.arenas_utils import extract_turn_text
+from judgearena.cache_sqlite import (
+    COMPLETION_DB_NAME,
+    JUDGEMENT_DB_NAME,
+    CompletionCache,
+    JudgementCache,
+    read_descriptor,
+)
+from judgearena.datasets import load_battles, load_instructions
+from judgearena.evaluate import PairScore
+from judgearena.tasks.registry import get_packaged_task
+from judgearena.tasks.schema import EloProtocol, MetaEvalProtocol
+
+try:
+    from textual.app import App, ComposeResult
+    from textual.binding import Binding
+    from textual.containers import Horizontal, ScrollableContainer, Vertical
+    from textual.widgets import (
+        Button,
+        Checkbox,
+        Footer,
+        Header,
+        Label,
+        Markdown,
+        Select,
+    )
+except ImportError:
+    App = None
+
+CacheRole = Literal["completions", "judgements"]
+
+
+@dataclass(frozen=True)
+class CacheCell:
+    """One role/task/provider/model/descriptor cache partition."""
+
+    role: CacheRole
+    task: str
+    provider: str
+    model: str
+    descriptor_hash: str
+    folder: Path
+    descriptor: dict
+
+    @property
+    def model_spec(self) -> str:
+        return f"{self.provider}/{self.model}"
+
+    @property
+    def db_path(self) -> Path:
+        name = COMPLETION_DB_NAME if self.role == "completions" else JUDGEMENT_DB_NAME
+        return self.folder / name
+
+    @property
+    def key(self) -> str:
+        return f"{self.role}/{self.task}/{self.model_spec}/{self.descriptor_hash}"
+
+
+def iter_cache_cells(
+    store_root: Path | str,
+    *,
+    role: CacheRole | None = None,
+) -> list[CacheCell]:
+    """Return valid cache cells in deterministic path order."""
+    root = Path(store_root).expanduser()
+    roles = (role,) if role is not None else ("completions", "judgements")
+    cells = []
+    for current_role in roles:
+        role_root = root / current_role
+        if not role_root.exists():
+            continue
+        for metadata_path in sorted(role_root.glob("*/*/*/*/metadata.json")):
+            folder = metadata_path.parent
+            relative = folder.relative_to(role_root)
+            task, provider, model, descriptor_hash = relative.parts
+            cell = CacheCell(
+                role=current_role,
+                task=unquote(task),
+                provider=unquote(provider),
+                model=unquote(model),
+                descriptor_hash=descriptor_hash,
+                folder=folder,
+                descriptor=read_descriptor(folder),
+            )
+            if cell.db_path.exists():
+                cells.append(cell)
+    return cells
+
+
+def load_cache_cell(
+    cell: CacheCell,
+    *,
+    instruction_id: str | None = None,
+    model: str | None = None,
+) -> pd.DataFrame:
+    """Load rows from one cell using its typed filters."""
+    store_type = CompletionCache if cell.role == "completions" else JudgementCache
+    with store_type(cell.db_path) as store:
+        return store.query(instruction_id=instruction_id, model=model)
+
+
+def cell_row_count(cell: CacheCell) -> int:
+    table = "completions" if cell.role == "completions" else "judgements"
+    with sqlite3.connect(cell.db_path) as conn:
+        return int(conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0])
+
+
+def list_tasks(store_root: Path | str) -> list[str]:
+    return sorted({cell.task for cell in iter_cache_cells(store_root)})
+
+
+def list_models(store_root: Path | str, task: str | None = None) -> list[str]:
+    return sorted(
+        {
+            cell.model_spec
+            for cell in iter_cache_cells(store_root, role="completions")
+            if task is None or cell.task == task
+        }
+    )
+
+
+def list_judges(store_root: Path | str, task: str | None = None) -> list[str]:
+    return sorted(
+        {
+            cell.model_spec
+            for cell in iter_cache_cells(store_root, role="judgements")
+            if task is None or cell.task == task
+        }
+    )
+
+
+@cache
+def load_context(task: str) -> pd.DataFrame:
+    """Load instruction and language columns indexed by cache instruction ID."""
+    resolved = get_packaged_task(task)
+    if resolved is None:
+        return pd.DataFrame(columns=["instruction", "language"])
+    protocol = resolved.spec.protocol
+    if isinstance(protocol, (EloProtocol, MetaEvalProtocol)):
+        source = load_battles(resolved)
+        index = protocol.arena + ":" + source["question_id"].astype(str)
+        instruction = source["conversation_a"].map(
+            lambda conversation: extract_turn_text(conversation[0])
+        )
+    else:
+        source = load_instructions(task)
+        index = source.index.astype(str)
+        column = "instruction" if "instruction" in source else "turn_1"
+        instruction = source[column]
+    language_column = next(
+        (column for column in ("lang", "language") if column in source),
+        None,
+    )
+    language = (
+        source[language_column]
+        if language_column is not None
+        else pd.Series(None, index=source.index)
+    )
+    return pd.DataFrame(
+        {
+            "instruction": instruction.astype(str).to_numpy(),
+            "language": language.to_numpy(),
+        },
+        index=index,
+    )
+
+
+def list_languages(store_root: Path | str, task: str) -> list[str]:
+    del store_root
+    context = load_context(task)
+    return sorted(str(value) for value in context["language"].dropna().unique())
+
+
+def _completion_rows(
+    store_root: Path | str,
+    *,
+    task: str,
+) -> pd.DataFrame:
+    frames = []
+    for cell in iter_cache_cells(store_root, role="completions"):
+        if cell.task != task:
+            continue
+        frame = load_cache_cell(cell)
+        frame["descriptor_hash"] = cell.descriptor_hash
+        frames.append(frame)
+    if not frames:
+        return pd.DataFrame()
+    return (
+        pd.concat(frames, ignore_index=True)
+        .sort_values("pushed_at", kind="stable")
+        .drop_duplicates(["instruction_id", "model"], keep="last")
+    )
+
+
+def load_subset(
+    *,
+    store_root: Path | str,
+    task: str,
+    model: str,
+    judge: str | None = None,
+    languages: list[str] | None = None,
+) -> pd.DataFrame:
+    """Join cached judge rows with contexts and the latest model completions."""
+    judgement_frames = []
+    for cell in iter_cache_cells(store_root, role="judgements"):
+        if cell.task != task or (judge is not None and cell.model_spec != judge):
+            continue
+        frame = load_cache_cell(cell, model=model)
+        frame["judge_descriptor_hash"] = cell.descriptor_hash
+        judgement_frames.append(frame)
+    if not judgement_frames:
+        return pd.DataFrame()
+
+    rows = pd.concat(judgement_frames, ignore_index=True)
+    completions = _completion_rows(store_root, task=task)
+    completion_map = (
+        completions.set_index(["instruction_id", "model"])["completion"].to_dict()
+        if not completions.empty
+        else {}
+    )
+    rows["completion_a"] = [
+        completion_map.get((str(row.instruction_id), row.model_a))
+        for row in rows.itertuples()
+    ]
+    rows["completion_b"] = [
+        completion_map.get((str(row.instruction_id), row.model_b))
+        for row in rows.itertuples()
+    ]
+    context = load_context(task)
+    rows["instruction"] = rows["instruction_id"].astype(str).map(context["instruction"])
+    rows["language"] = rows["instruction_id"].astype(str).map(context["language"])
+    if languages:
+        rows = rows.loc[rows["language"].isin(languages)]
+
+    parser = PairScore()
+    rows["preference"] = [
+        (
+            parsed.preference
+            if (parsed := parser.parse_result(completion)) is not None
+            else None
+        )
+        for completion in rows["judge_completion"]
+    ]
+    return rows.reset_index(drop=True)
+
+
+def render_row(row: pd.Series, *, show_judge_input: bool = False) -> str:
+    """Render one joined cache row for terminal and notebook browsers."""
+
+    def display_value(value: object) -> str:
+        return "*(not found)*" if value is None or pd.isna(value) else str(value)
+
+    preference = row.get("preference")
+    verdict = (
+        "Could not parse"
+        if pd.isna(preference)
+        else f"Preference for B: {float(preference):.2f}"
+    )
+    sections = [
+        f"**Model A:** `{row['model_a']}`  \n**Model B:** `{row['model_b']}`",
+        f"### Instruction\n{display_value(row.get('instruction'))}",
+        f"### Completion A\n{display_value(row.get('completion_a'))}",
+        f"### Completion B\n{display_value(row.get('completion_b'))}",
+        f"### Judge output\n**{verdict}**\n\n{row['judge_completion']}",
+    ]
+    if show_judge_input:
+        sections.append(f"### Judge input\n{row['judge_input']}")
+    return "\n\n---\n\n".join(sections)
+
+
+if App is not None:
+
+    class BrowserApp(App):
+        """Interactive terminal browser for cached judge rows."""
+
+        TITLE = "JudgeArena Cache Browser"
+        BINDINGS = [
+            Binding("q", "quit", "Quit"),
+            Binding("left", "previous", "Previous", show=False),
+            Binding("right", "next", "Next", show=False),
+        ]
+
+        def __init__(self, store_root: Path | str):
+            super().__init__()
+            self.store_root = Path(store_root).expanduser()
+            self.rows = pd.DataFrame()
+            self.row_index = 0
+
+        def compose(self) -> ComposeResult:
+            tasks = list_tasks(self.store_root)
+            yield Header()
+            with Horizontal():
+                with Vertical(id="sidebar"):
+                    yield Select([(task, task) for task in tasks], id="task")
+                    yield Select([], prompt="Model", id="model")
+                    yield Select([], prompt="Judge", id="judge", allow_blank=True)
+                    yield Select([], prompt="Language", id="language", allow_blank=True)
+                    yield Button("Load", id="load")
+                    with Horizontal():
+                        yield Button("◀", id="previous")
+                        yield Label("—", id="position")
+                        yield Button("▶", id="next")
+                    yield Checkbox("Show judge input", id="show-input")
+                with ScrollableContainer():
+                    yield Markdown("*Select a task and model.*", id="content")
+            yield Footer()
+
+        def on_select_changed(self, event: Select.Changed) -> None:
+            if event.select.id != "task" or event.value is Select.BLANK:
+                return
+            task = str(event.value)
+            self.query_one("#model", Select).set_options(
+                [(value, value) for value in list_models(self.store_root, task)]
+            )
+            self.query_one("#judge", Select).set_options(
+                [(value, value) for value in list_judges(self.store_root, task)]
+            )
+            self.query_one("#language", Select).set_options(
+                [(value, value) for value in list_languages(self.store_root, task)]
+            )
+
+        def on_button_pressed(self, event: Button.Pressed) -> None:
+            if event.button.id == "load":
+                self._load()
+            elif event.button.id == "previous":
+                self.action_previous()
+            elif event.button.id == "next":
+                self.action_next()
+
+        def on_checkbox_changed(self, _event: Checkbox.Changed) -> None:
+            self._show()
+
+        def action_previous(self) -> None:
+            self.row_index = max(0, self.row_index - 1)
+            self._show()
+
+        def action_next(self) -> None:
+            self.row_index = min(max(0, len(self.rows) - 1), self.row_index + 1)
+            self._show()
+
+        def _select_value(self, selector: str) -> str | None:
+            value = self.query_one(selector, Select).value
+            return None if value is Select.BLANK else str(value)
+
+        def _load(self) -> None:
+            task = self._select_value("#task")
+            model = self._select_value("#model")
+            if task is None or model is None:
+                return
+            language = self._select_value("#language")
+            self.rows = load_subset(
+                store_root=self.store_root,
+                task=task,
+                model=model,
+                judge=self._select_value("#judge"),
+                languages=[language] if language is not None else None,
+            )
+            self.row_index = 0
+            self._show()
+
+        def _show(self) -> None:
+            content = self.query_one("#content", Markdown)
+            position = self.query_one("#position", Label)
+            if self.rows.empty:
+                position.update("—")
+                content.update("*No matching rows.*")
+                return
+            position.update(f"{self.row_index + 1}/{len(self.rows)}")
+            content.update(
+                render_row(
+                    self.rows.iloc[self.row_index],
+                    show_judge_input=self.query_one("#show-input", Checkbox).value,
+                )
+            )
+
+
+def launch_browser(store_root: Path | str) -> None:
+    if App is None:
+        raise ImportError("Install JudgeArena's browser extra to use the terminal UI.")
+    BrowserApp(store_root).run()
+
+
+def _select_cells(cells: list[CacheCell], args: argparse.Namespace) -> list[CacheCell]:
+    return [
+        cell
+        for cell in cells
+        if (args.task is None or cell.task == args.task)
+        and (args.provider is None or cell.provider == args.provider)
+        and (args.model is None or cell.model == args.model)
+        and (
+            args.descriptor is None or cell.descriptor_hash.startswith(args.descriptor)
+        )
+    ]
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--store-root", type=Path, required=True)
+    parser.add_argument("--role", choices=("completions", "judgements"))
+    parser.add_argument("--task")
+    parser.add_argument("--provider")
+    parser.add_argument("--model")
+    parser.add_argument("--descriptor")
+    parser.add_argument("--instruction-id")
+    parser.add_argument("--candidate-model")
+    parser.add_argument("--limit", type=int, default=20)
+    parser.add_argument("--list", action="store_true", dest="list_cells")
+    parser.add_argument("--interactive", action="store_true")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> None:
+    args = _parser().parse_args(argv)
+    if args.interactive or not any(
+        (
+            args.role,
+            args.task,
+            args.provider,
+            args.model,
+            args.descriptor,
+            args.instruction_id,
+            args.candidate_model,
+            args.list_cells,
+        )
+    ):
+        launch_browser(args.store_root)
+        return
+    cells = _select_cells(
+        iter_cache_cells(args.store_root, role=args.role),
+        args,
+    )
+    if args.list_cells or len(cells) != 1:
+        for cell in cells:
+            print(
+                json.dumps(
+                    {
+                        "cell": cell.key,
+                        "rows": cell_row_count(cell),
+                        "descriptor": cell.descriptor,
+                    },
+                    sort_keys=True,
+                )
+            )
+        return
+
+    rows = load_cache_cell(
+        cells[0],
+        instruction_id=args.instruction_id,
+        model=args.candidate_model,
+    )
+    print(rows.head(args.limit).to_json(orient="records", force_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/judgearena/browse_widgets.py
+++ b/judgearena/browse_widgets.py
@@ -1,0 +1,107 @@
+"""Notebook widgets for browsing content-addressed cache rows."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+try:
+    import ipywidgets as widgets
+    from IPython.display import Markdown, clear_output, display
+except ImportError:
+    widgets = None
+    Markdown = None
+    clear_output = None
+    display = None
+
+from judgearena.browse_cache import (
+    list_judges,
+    list_languages,
+    list_models,
+    list_tasks,
+    load_subset,
+    render_row,
+)
+
+
+def make_ui(store_root: Path | str) -> Any:
+    """Display selectors and rows for the cache cells under ``store_root``."""
+    if widgets is None or Markdown is None or clear_output is None or display is None:
+        raise ImportError("Install ipywidgets and IPython to use the cache browser.")
+
+    root = Path(store_root).expanduser()
+    task = widgets.Dropdown(options=list_tasks(root), description="Task:")
+    model = widgets.Dropdown(description="Model:")
+    judge = widgets.Dropdown(description="Judge:")
+    language = widgets.Dropdown(description="Language:")
+    show_input = widgets.Checkbox(description="Show judge input")
+    previous = widgets.Button(description="◀")
+    next_button = widgets.Button(description="▶")
+    position = widgets.Label("—")
+    output = widgets.Output()
+    state = {"rows": None, "index": 0}
+
+    def render() -> None:
+        with output:
+            clear_output()
+            rows = state["rows"]
+            if rows is None or rows.empty:
+                position.value = "—"
+                display(Markdown("*No matching rows.*"))
+                return
+            position.value = f"{state['index'] + 1}/{len(rows)}"
+            display(
+                Markdown(
+                    render_row(
+                        rows.iloc[state["index"]],
+                        show_judge_input=show_input.value,
+                    )
+                )
+            )
+
+    def refresh_options(_event=None) -> None:
+        if task.value is None:
+            return
+        model.options = list_models(root, task.value)
+        judge.options = [None, *list_judges(root, task.value)]
+        language.options = [None, *list_languages(root, task.value)]
+
+    def load(_event=None) -> None:
+        if task.value is None or model.value is None:
+            return
+        state["rows"] = load_subset(
+            store_root=root,
+            task=task.value,
+            model=model.value,
+            judge=judge.value,
+            languages=[language.value] if language.value is not None else None,
+        )
+        state["index"] = 0
+        render()
+
+    def move(delta: int) -> None:
+        rows = state["rows"]
+        if rows is None or rows.empty:
+            return
+        state["index"] = max(0, min(len(rows) - 1, state["index"] + delta))
+        render()
+
+    task.observe(refresh_options, names="value")
+    for selector in (model, judge, language):
+        selector.observe(load, names="value")
+    show_input.observe(lambda _event: render(), names="value")
+    previous.on_click(lambda _event: move(-1))
+    next_button.on_click(lambda _event: move(1))
+
+    controls = widgets.VBox(
+        [
+            widgets.HBox([task, model]),
+            widgets.HBox([judge, language, show_input]),
+            widgets.HBox([previous, position, next_button]),
+        ]
+    )
+    ui = widgets.VBox([controls, output])
+    refresh_options()
+    load()
+    display(ui)
+    return ui

--- a/judgearena/config.py
+++ b/judgearena/config.py
@@ -371,8 +371,8 @@ class RunArgs(BaseModel):
     """Directory where annotations, results, and the resolved ``config.yaml``
     are written (under a per-run subfolder)."""
 
-    ignore_cache: bool = False
-    """If set, ignore cached completions and regenerate them."""
+    store_root: str | None = None
+    """Root directory for content-addressed completion and judgement caches."""
 
     use_tqdm: bool = False
     """Show a tqdm progress bar (not compatible with vLLM)."""

--- a/judgearena/evaluate.py
+++ b/judgearena/evaluate.py
@@ -111,6 +111,7 @@ def annotate_battles(
     prompt_preset: str = DEFAULT_JUDGE_PROMPT_PRESET,
     strip_thinking_before_judging: bool = False,
     collect_top_logprobs: bool = False,
+    cache_metadata: list[dict] | None = None,
 ) -> list[JudgeAnnotation]:
     """
     Directly evaluate from list of instructions and completions
@@ -182,6 +183,7 @@ def annotate_battles(
         use_tqdm=use_tqdm,
         return_top_logprobs=collect_top_logprobs,
         stage="judging",
+        cache_metadata=cache_metadata,
     )
     if not collect_top_logprobs:
         judge_results = [InferenceResult(text=text) for text in judge_results]
@@ -229,6 +231,7 @@ def judge_and_parse_prefs(
     truncate_input_chars: int = 8192,
     use_tqdm: bool = False,
     parse: JudgeParser | None = None,
+    cache_metadata: list[dict] | None = None,
 ) -> tuple[list[JudgeAnnotation], list[JudgeAnnotation] | None, pd.Series]:
     """Run judge annotation and parse preferences, handling swap_mode='both'.
 
@@ -262,10 +265,28 @@ def judge_and_parse_prefs(
         truncate_input_chars=truncate_input_chars,
         use_tqdm=use_tqdm,
         collect_top_logprobs=parse.requires_top_logprobs,
+        cache_metadata=cache_metadata,
     )
 
     annotations_reversed = None
     if swap_mode == "both":
+        reversed_cache_metadata = (
+            [
+                {
+                    **metadata,
+                    "model_a": metadata["model_b"],
+                    "model_b": metadata["model_a"],
+                    "orientation": (
+                        "reversed"
+                        if metadata.get("orientation") == "direct"
+                        else "direct"
+                    ),
+                }
+                for metadata in cache_metadata
+            ]
+            if cache_metadata is not None
+            else None
+        )
         annotations_reversed = annotate_battles(
             judge_chat_model=judge_chat_model,
             instructions=instructions,
@@ -278,6 +299,7 @@ def judge_and_parse_prefs(
             truncate_input_chars=truncate_input_chars,
             use_tqdm=use_tqdm,
             collect_top_logprobs=parse.requires_top_logprobs,
+            cache_metadata=reversed_cache_metadata,
         )
 
     def _none_to_nan(x):

--- a/judgearena/generate.py
+++ b/judgearena/generate.py
@@ -1,7 +1,8 @@
 import pandas as pd
 from langchain_core.prompts import ChatPromptTemplate
 
-from judgearena.models import batch_inference_once, do_inference, make_model
+from judgearena.inference import CompletionInferenceCache
+from judgearena.models import PreparedModel, do_inference, prepare_model
 from judgearena.utils import strip_thinking_tags, truncate
 
 
@@ -12,9 +13,15 @@ def generate_instructions(
     max_tokens: int | None = 32768,
     use_tqdm: bool = True,
     system_prompt: str | None = None,
+    inference_cache: CompletionInferenceCache | None = None,
     **engine_kwargs,
 ) -> pd.DataFrame:
-    chat_model = make_model(model, max_tokens=max_tokens, **engine_kwargs)
+    chat_model = prepare_model(
+        model,
+        max_tokens=max_tokens,
+        cache=inference_cache,
+        **engine_kwargs,
+    )
 
     # TODO improve prompt to generate instructions
     if system_prompt is None:
@@ -39,6 +46,7 @@ def generate_instructions(
         inputs=inputs,
         use_tqdm=use_tqdm,
         stage="generation",
+        cache_metadata=[{"instruction_id": str(index)} for index in instructions.index],
     )
     df_outputs = pd.DataFrame(
         data={
@@ -57,16 +65,23 @@ def _set_temperature_on_model(chat_model, temperature: float) -> None:
         chat_model.temperature = temperature
 
 
+def _materialize_at_temperature(base_model: PreparedModel, temperature: float):
+    model = base_model.materialize()
+    _set_temperature_on_model(model, temperature)
+    return model
+
+
 def _infer_grouped_by_temperature(
     *,
     model_spec: str,
-    provider: str,
     max_tokens: int | None,
     model_kwargs: dict,
-    base_model,
+    base_model: PreparedModel | None,
     inputs: list,
+    instruction_ids: list[str],
     temperatures: list[float],
     use_tqdm: bool,
+    inference_cache: CompletionInferenceCache | None,
 ) -> list[str]:
     outputs: list[str] = [""] * len(inputs)
     groups: dict[float, list[int]] = {}
@@ -77,12 +92,16 @@ def _infer_grouped_by_temperature(
         idxs = groups[temp]
         group_inputs = [inputs[i] for i in idxs]
 
-        if provider in {"VLLM", "LlamaCpp"}:
-            _set_temperature_on_model(base_model, temp)
-            group_model = base_model
-        else:
-            group_model = make_model(
-                model_spec, max_tokens=max_tokens, temperature=temp, **model_kwargs
+        group_model = prepare_model(
+            model_spec,
+            max_tokens=max_tokens,
+            temperature=temp,
+            cache=inference_cache,
+            **model_kwargs,
+        )
+        if base_model is not None:
+            group_model.factory = lambda temperature=temp: _materialize_at_temperature(
+                base_model, temperature
             )
 
         group_outs = do_inference(
@@ -90,6 +109,9 @@ def _infer_grouped_by_temperature(
             inputs=group_inputs,
             use_tqdm=use_tqdm,
             stage="generation",
+            cache_metadata=[
+                {"instruction_id": instruction_ids[index]} for index in idxs
+            ],
         )
         for i, out in zip(idxs, group_outs, strict=True):
             outputs[i] = out
@@ -105,6 +127,7 @@ def generate_multiturn(
     use_tqdm: bool = True,
     temperature_config: dict[str, float] | None = None,
     strip_thinking_before_turn_2_prompt: bool = False,
+    inference_cache: CompletionInferenceCache | None = None,
     **model_kwargs,
 ) -> pd.DataFrame:
     """Generate two-turn completions for MT-Bench style questions."""
@@ -112,12 +135,22 @@ def generate_multiturn(
     use_category_temperatures = temperature_config is not None
     local_provider = provider in {"VLLM", "LlamaCpp"}
 
-    if use_category_temperatures and local_provider:
-        chat_model = make_model(
-            model, max_tokens=max_tokens, temperature=0.0, **model_kwargs
+    base_model = (
+        prepare_model(
+            model,
+            max_tokens=max_tokens,
+            temperature=0.0,
+            **model_kwargs,
         )
-    else:
-        chat_model = make_model(model, max_tokens=max_tokens, **model_kwargs)
+        if use_category_temperatures and local_provider
+        else None
+    )
+    chat_model = prepare_model(
+        model,
+        max_tokens=max_tokens,
+        cache=inference_cache,
+        **model_kwargs,
+    )
 
     system_prompt = "You are a helpful assistant."
     idxs = questions.index.tolist()
@@ -141,13 +174,14 @@ def generate_multiturn(
     if use_category_temperatures:
         completions_turn_1 = _infer_grouped_by_temperature(
             model_spec=model,
-            provider=provider,
             max_tokens=max_tokens,
             model_kwargs=model_kwargs,
-            base_model=chat_model,
+            base_model=base_model,
             inputs=turn1_inputs,
+            instruction_ids=[f"{index}:turn-1" for index in idxs],
             temperatures=temperatures,
             use_tqdm=use_tqdm,
+            inference_cache=inference_cache,
         )
     else:
         completions_turn_1 = do_inference(
@@ -155,6 +189,7 @@ def generate_multiturn(
             inputs=turn1_inputs,
             use_tqdm=use_tqdm,
             stage="generation",
+            cache_metadata=[{"instruction_id": f"{index}:turn-1"} for index in idxs],
         )
 
     turn2_inputs = []
@@ -196,13 +231,14 @@ def generate_multiturn(
     if use_category_temperatures:
         completions_turn_2 = _infer_grouped_by_temperature(
             model_spec=model,
-            provider=provider,
             max_tokens=max_tokens,
             model_kwargs=model_kwargs,
-            base_model=chat_model,
+            base_model=base_model,
             inputs=turn2_inputs,
+            instruction_ids=[f"{index}:turn-2" for index in idxs],
             temperatures=temperatures,
             use_tqdm=use_tqdm,
+            inference_cache=inference_cache,
         )
     else:
         completions_turn_2 = do_inference(
@@ -210,6 +246,7 @@ def generate_multiturn(
             inputs=turn2_inputs,
             use_tqdm=use_tqdm,
             stage="generation",
+            cache_metadata=[{"instruction_id": f"{index}:turn-2"} for index in idxs],
         )
 
     return pd.DataFrame(
@@ -227,20 +264,26 @@ def generate_base(
     truncate_input_chars: int | None = 8192,
     max_tokens: int | None = 32768,
     use_tqdm: bool = False,
+    inference_cache: CompletionInferenceCache | None = None,
     **engine_kwargs,
 ) -> pd.DataFrame:
-    chat_model = make_model(model, max_tokens=max_tokens, **engine_kwargs)
+    chat_model = prepare_model(
+        model,
+        max_tokens=max_tokens,
+        cache=inference_cache,
+        **engine_kwargs,
+    )
 
     inputs = [
         truncate(instruction, max_len=truncate_input_chars)
         for instruction in instructions
     ]
 
-    completions = batch_inference_once(
-        chat_model,
-        inputs,
-        max_tokens=max_tokens,
+    completions = do_inference(
+        chat_model=chat_model,
+        inputs=inputs,
         stage="generation",
+        cache_metadata=[{"instruction_id": str(index)} for index in instructions.index],
     )
 
     df_outputs = pd.DataFrame(

--- a/judgearena/inference.py
+++ b/judgearena/inference.py
@@ -6,8 +6,9 @@ import json
 from abc import ABC, abstractmethod
 from collections.abc import Callable
 from dataclasses import dataclass, field
+from importlib import metadata as importlib_metadata
 from pathlib import Path
-from typing import Any, ClassVar
+from typing import Any, ClassVar, Literal
 
 import pandas as pd
 
@@ -23,25 +24,51 @@ from judgearena.cache_sqlite import (
 )
 
 _ROLE_MAP = {"human": "user", "ai": "assistant", "system": "system"}
+_CHAT_PROVIDERS = {"ChatOpenAI", "Dummy", "OpenRouter", "VLLM"}
+_TEXT_PROVIDERS = {"LlamaCpp", "OpenAI", "Together"}
+VLLM_EXECUTION_ONLY_KWARGS = {
+    "enforce_eager",
+    "gpu_memory_utilization",
+    "tensor_parallel_size",
+}
+
+InputMode = Literal["chat", "text"]
 
 
-def canonicalize_chat_input(input_item: Any) -> str:
-    """Serialize a logical model input for content-addressed cache lookup."""
+def provider_input_mode(provider: str) -> InputMode | None:
+    if provider in _CHAT_PROVIDERS:
+        return "chat"
+    if provider in _TEXT_PROVIDERS:
+        return "text"
+    return None
+
+
+def _canonical_messages(input_item: Any) -> list[dict[str, Any]]:
     if isinstance(input_item, str):
-        payload = {"type": "text", "text": input_item}
-    elif hasattr(input_item, "to_messages"):
-        payload = {
-            "type": "messages",
-            "messages": [
-                {
-                    "role": _ROLE_MAP.get(message.type, message.type),
-                    "content": message.content,
-                }
-                for message in input_item.to_messages()
-            ],
-        }
+        return [{"role": "user", "content": input_item}]
+    if hasattr(input_item, "to_messages"):
+        return [
+            {
+                "role": _ROLE_MAP.get(message.type, message.type),
+                "content": message.content,
+            }
+            for message in input_item.to_messages()
+        ]
+    raise TypeError(f"Unsupported inference input: {type(input_item)!r}")
+
+
+def canonicalize_model_input(input_item: Any, input_mode: InputMode) -> str:
+    """Serialize the chat messages or flattened text sent to a provider."""
+    if input_mode == "text":
+        if isinstance(input_item, str):
+            text = input_item
+        elif hasattr(input_item, "to_string"):
+            text = input_item.to_string()
+        else:
+            raise TypeError(f"Unsupported inference input: {type(input_item)!r}")
+        payload = {"type": "text", "text": text}
     else:
-        raise TypeError(f"Unsupported inference input: {type(input_item)!r}")
+        payload = {"type": "messages", "messages": _canonical_messages(input_item)}
     return stable_json_dumps(payload)
 
 
@@ -49,17 +76,51 @@ def build_model_descriptor(
     provider: str,
     model_name: str,
     resolved_kwargs: dict[str, Any],
+    endpoint: str | None = None,
 ) -> dict[str, Any] | None:
-    """Describe output-affecting settings without constructing the backend."""
-    if provider != "Dummy":
+    """Describe output-affecting settings without constructing the backend.
+
+    Omitted hosted settings retain provider defaults. Local-engine versions are
+    part of the key. VLLM tokenizer-template changes require a distinct model
+    revision or an explicit ``chat_template``.
+    """
+    input_mode = provider_input_mode(provider)
+    if input_mode is None:
         return None
-    return {
+
+    descriptor_kwargs = resolved_kwargs.copy()
+    if provider == "VLLM":
+        descriptor_kwargs["temperature"] = (
+            0.6
+            if descriptor_kwargs.get("temperature") is None
+            else descriptor_kwargs["temperature"]
+        )
+        descriptor_kwargs["top_p"] = (
+            0.95
+            if descriptor_kwargs.get("top_p") is None
+            else descriptor_kwargs["top_p"]
+        )
+        descriptor_kwargs["chat_template"] = descriptor_kwargs.get("chat_template")
+        descriptor_kwargs = {
+            key: value
+            for key, value in descriptor_kwargs.items()
+            if key not in VLLM_EXECUTION_ONLY_KWARGS
+        }
+
+    descriptor = {
         "schema_version": "judgearena-inference-cache/v1",
         "provider": provider,
         "model": model_name,
-        "input_mode": "chat",
-        "model_kwargs": resolved_kwargs,
+        "input_mode": input_mode,
+        "model_kwargs": descriptor_kwargs,
     }
+    if provider == "VLLM":
+        descriptor["backend_version"] = importlib_metadata.version("vllm")
+    elif provider == "LlamaCpp":
+        descriptor["backend_version"] = importlib_metadata.version("llama-cpp-python")
+    if endpoint is not None:
+        descriptor["endpoint"] = endpoint.rstrip("/")
+    return descriptor
 
 
 @dataclass(frozen=True)

--- a/judgearena/inference.py
+++ b/judgearena/inference.py
@@ -1,0 +1,213 @@
+"""Lazy model preparation and inference-cache context."""
+
+from __future__ import annotations
+
+import json
+from abc import ABC, abstractmethod
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, ClassVar
+
+import pandas as pd
+
+from judgearena.cache_sqlite import (
+    COMPLETION_DB_NAME,
+    JUDGEMENT_DB_NAME,
+    CacheKind,
+    CompletionCache,
+    JudgementCache,
+    cache_folder,
+    stable_json_dumps,
+    write_descriptor,
+)
+
+_ROLE_MAP = {"human": "user", "ai": "assistant", "system": "system"}
+
+
+def canonicalize_chat_input(input_item: Any) -> str:
+    """Serialize a logical model input for content-addressed cache lookup."""
+    if isinstance(input_item, str):
+        payload = {"type": "text", "text": input_item}
+    elif hasattr(input_item, "to_messages"):
+        payload = {
+            "type": "messages",
+            "messages": [
+                {
+                    "role": _ROLE_MAP.get(message.type, message.type),
+                    "content": message.content,
+                }
+                for message in input_item.to_messages()
+            ],
+        }
+    else:
+        raise TypeError(f"Unsupported inference input: {type(input_item)!r}")
+    return stable_json_dumps(payload)
+
+
+def build_model_descriptor(
+    provider: str,
+    model_name: str,
+    resolved_kwargs: dict[str, Any],
+) -> dict[str, Any] | None:
+    """Describe output-affecting settings without constructing the backend."""
+    if provider != "Dummy":
+        return None
+    return {
+        "schema_version": "judgearena-inference-cache/v1",
+        "provider": provider,
+        "model": model_name,
+        "input_mode": "chat",
+        "model_kwargs": resolved_kwargs,
+    }
+
+
+@dataclass(frozen=True)
+class CachedInferenceResult:
+    """Provider output fields required by downstream parsing."""
+
+    text: str
+    first_token_top_logprobs: dict[str, float] | None = None
+
+
+@dataclass
+class PreparedModel:
+    """Carry cache identity while deferring backend construction until a miss."""
+
+    model_spec: str
+    descriptor: dict[str, Any] | None
+    factory: Callable[[], Any]
+    cache: InferenceCache | None = None
+    _model: Any = field(default=None, init=False, repr=False)
+
+    def materialize(self) -> Any:
+        if self._model is None:
+            self._model = self.factory()
+        return self._model
+
+
+@dataclass(frozen=True)
+class InferenceCache(ABC):
+    """Share cache lifecycle while subclasses define role-specific rows."""
+
+    store_root: Path
+    task: str
+    pushed_by: str = "judgearena"
+
+    kind: ClassVar[CacheKind]
+    db_name: ClassVar[str]
+    output_column: ClassVar[str]
+    store_type: ClassVar[type[CompletionCache] | type[JudgementCache]]
+
+    def open_store(self, model: PreparedModel) -> CompletionCache | JudgementCache:
+        assert model.descriptor is not None
+        folder = cache_folder(
+            self.store_root,
+            self.kind,
+            self.task,
+            model.model_spec,
+            model.descriptor,
+        )
+        write_descriptor(folder, model.descriptor)
+        return self.store_type(folder / self.db_name)
+
+    def save_outputs(
+        self,
+        store: CompletionCache | JudgementCache,
+        model: PreparedModel,
+        input_texts: list[str],
+        outputs: list[Any],
+        metadata: list[dict[str, Any]],
+        indices: list[int],
+    ) -> None:
+        rows = [
+            self.make_row(
+                model=model,
+                input_text=input_texts[index],
+                output=output,
+                metadata=metadata[index],
+            )
+            for index, output in zip(indices, outputs, strict=True)
+        ]
+        store.save(pd.DataFrame(rows), pushed_by=self.pushed_by)
+
+    @abstractmethod
+    def make_row(
+        self,
+        *,
+        model: PreparedModel,
+        input_text: str,
+        output: Any,
+        metadata: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Convert one inference output to its role-specific storage row."""
+
+    @abstractmethod
+    def cached_result(self, row: pd.Series) -> CachedInferenceResult:
+        """Restore output fields from a stored row."""
+
+
+class CompletionInferenceCache(InferenceCache):
+    """Cache generated model completions."""
+
+    kind = "completions"
+    db_name = COMPLETION_DB_NAME
+    output_column = "completion"
+    store_type = CompletionCache
+
+    def make_row(
+        self,
+        *,
+        model: PreparedModel,
+        input_text: str,
+        output: Any,
+        metadata: dict[str, Any],
+    ) -> dict[str, Any]:
+        return {
+            "input_text": input_text,
+            "completion": output.text,
+            "benchmark": self.task,
+            "instruction_id": metadata["instruction_id"],
+            "model": model.model_spec,
+        }
+
+    def cached_result(self, row: pd.Series) -> CachedInferenceResult:
+        return CachedInferenceResult(text=str(row["completion"]))
+
+
+class JudgementInferenceCache(InferenceCache):
+    """Cache raw judge completions."""
+
+    kind = "judgements"
+    db_name = JUDGEMENT_DB_NAME
+    output_column = "judge_completion"
+    store_type = JudgementCache
+
+    def make_row(
+        self,
+        *,
+        model: PreparedModel,
+        input_text: str,
+        output: Any,
+        metadata: dict[str, Any],
+    ) -> dict[str, Any]:
+        return {
+            "judge_input": input_text,
+            "judge_completion": output.text,
+            "benchmark": self.task,
+            "instruction_id": metadata["instruction_id"],
+            "model_a": metadata["model_a"],
+            "model_b": metadata["model_b"],
+            "judge": model.model_spec,
+            "top_logprobs": output.first_token_top_logprobs,
+            "orientation": metadata.get("orientation"),
+        }
+
+    def cached_result(self, row: pd.Series) -> CachedInferenceResult:
+        top_logprobs = row["top_logprobs"]
+        return CachedInferenceResult(
+            text=str(row["judge_completion"]),
+            first_token_top_logprobs=(
+                json.loads(top_logprobs) if pd.notna(top_logprobs) else None
+            ),
+        )

--- a/judgearena/models.py
+++ b/judgearena/models.py
@@ -22,7 +22,7 @@ from judgearena.inference import (
     InferenceCache,
     PreparedModel,
     build_model_descriptor,
-    canonicalize_chat_input,
+    canonicalize_model_input,
 )
 from judgearena.log import get_logger
 from judgearena.usage import RequestUsage, RunUsage, record_usage
@@ -811,7 +811,8 @@ def do_inference(
     if cache_metadata is None or len(cache_metadata) != len(inputs):
         raise ValueError("cache_metadata must contain one row per inference input.")
 
-    input_texts = [canonicalize_chat_input(item) for item in inputs]
+    input_mode = chat_model.descriptor["input_mode"]
+    input_texts = [canonicalize_model_input(item, input_mode) for item in inputs]
     input_hashes = [input_hash(input_text) for input_text in input_texts]
     with cache.open_store(chat_model) as store:
         cached_rows = store.query(input_hashes).set_index("input_hash")
@@ -893,6 +894,61 @@ def _route_sampling_params(
     return engine_kwargs
 
 
+_VLLM_ONLY_KWARGS = (
+    "max_model_len",
+    "chat_template",
+    "language_model_only",
+    "gpu_memory_utilization",
+    "enforce_eager",
+    "tensor_parallel_size",
+    "quantization",
+    "kv_cache_dtype",
+    "reasoning_parser",
+    "reasoning_config",
+    "trust_remote_code",
+)
+_REMOTE_ENDPOINTS = {
+    "ChatOpenAI": "https://api.openai.com/v1",
+    "OpenAI": "https://api.openai.com/v1",
+    "OpenRouter": "https://openrouter.ai/api/v1",
+    "Together": "https://api.together.xyz/v1/completions",
+}
+
+
+def _resolve_model_config(
+    model: str,
+    max_tokens: int | None,
+    engine_kwargs: dict,
+) -> tuple[str, str, dict, dict]:
+    """Resolve shared provider and sampling inputs once."""
+    resolved_kwargs = engine_kwargs.copy()
+    resolved_kwargs["max_tokens"] = max_tokens or 8192
+    sampling = {
+        key: resolved_kwargs.pop(key, None)
+        for key in ("temperature", "top_p", "top_k", "seed", "top_logprobs")
+    }
+    provider, model_name = _split_model_spec(model)
+    if provider != "VLLM":
+        for key in _VLLM_ONLY_KWARGS:
+            resolved_kwargs.pop(key, None)
+    return provider, model_name, resolved_kwargs, sampling
+
+
+def _resolve_model_endpoint(provider: str, resolved_kwargs: dict) -> str | None:
+    if provider == "OpenRouter":
+        return _REMOTE_ENDPOINTS[provider]
+    for key in ("base_url", "openai_api_base", "together_api_base"):
+        if resolved_kwargs.get(key):
+            return str(resolved_kwargs[key])
+    if provider in {"ChatOpenAI", "OpenAI"}:
+        return (
+            os.getenv("OPENAI_BASE_URL")
+            or os.getenv("OPENAI_API_BASE")
+            or _REMOTE_ENDPOINTS[provider]
+        )
+    return _REMOTE_ENDPOINTS.get(provider)
+
+
 def prepare_model(
     model: str,
     max_tokens: int | None = 8192,
@@ -901,13 +957,28 @@ def prepare_model(
     **engine_kwargs,
 ) -> PreparedModel:
     """Prepare cache identity without constructing the provider backend."""
-    provider, model_name = _split_model_spec(model)
-    resolved_kwargs = {**engine_kwargs, "max_tokens": max_tokens or 8192}
+    provider, model_name, resolved_kwargs, sampling = _resolve_model_config(
+        model, max_tokens, engine_kwargs
+    )
     descriptor = (
-        build_model_descriptor(provider, model_name, resolved_kwargs)
+        build_model_descriptor(
+            provider,
+            model_name,
+            {**resolved_kwargs, **sampling},
+            endpoint=_resolve_model_endpoint(provider, resolved_kwargs),
+        )
         if cache is not None
         else None
     )
+    routing = (resolved_kwargs.get("extra_body") or {}).get("provider") or {}
+    if (
+        cache is not None
+        and provider == "OpenRouter"
+        and (not routing.get("order") or routing.get("allow_fallbacks") is not False)
+    ):
+        logger.warning("OpenRouter cache identity uses unpinned provider routing.")
+    if cache is not None and descriptor is None:
+        logger.warning("Caching is not supported for %s; running uncached.", model)
     factory_kwargs = engine_kwargs.copy()
     return PreparedModel(
         model_spec=model,
@@ -933,40 +1004,14 @@ def make_model(model: str, max_tokens: int | None = 8192, **engine_kwargs):
             ``top_k``, ``seed``. vLLM-only keys (``max_model_len``,
             ``chat_template``) are stripped before reaching hosted providers.
     """
-    # Avoid mutating the original engine_kwargs dictionary
-    # NOTE: this is a shallow copy since we are not modifying any
-    # mutable objects in the dictionary.
-    engine_kwargs = engine_kwargs.copy()
-
-    # Dedicated arguments like max_tokens always win over engine_kwargs.
-    engine_kwargs["max_tokens"] = max_tokens or 8192
-
-    temperature = engine_kwargs.pop("temperature", None)
-    top_p = engine_kwargs.pop("top_p", None)
-    top_k = engine_kwargs.pop("top_k", None)
-    seed = engine_kwargs.pop("seed", None)
-    top_logprobs = engine_kwargs.pop("top_logprobs", None)
-
-    model_provider, model_name = _split_model_spec(model)
-
-    # vLLM-engine-only kwargs must not leak to remote-API providers
-    # (OpenRouter, OpenAI, Together): langchain-openai forwards unknown
-    # kwargs via model_kwargs into chat.completions.create, which rejects them.
-    if model_provider != "VLLM":
-        for key in (
-            "max_model_len",
-            "chat_template",
-            "language_model_only",
-            "gpu_memory_utilization",
-            "enforce_eager",
-            "tensor_parallel_size",
-            "quantization",
-            "kv_cache_dtype",
-            "reasoning_parser",
-            "reasoning_config",
-            "trust_remote_code",
-        ):
-            engine_kwargs.pop(key, None)
+    model_provider, model_name, engine_kwargs, sampling = _resolve_model_config(
+        model, max_tokens, engine_kwargs
+    )
+    temperature = sampling["temperature"]
+    top_p = sampling["top_p"]
+    top_k = sampling["top_k"]
+    seed = sampling["seed"]
+    top_logprobs = sampling["top_logprobs"]
 
     if model_provider == "Dummy":
         if top_logprobs is not None:

--- a/judgearena/models.py
+++ b/judgearena/models.py
@@ -16,7 +16,14 @@ from langchain_openai import ChatOpenAI
 from tqdm.asyncio import tqdm
 from tqdm.contrib.logging import logging_redirect_tqdm
 
+from judgearena.cache_sqlite import input_hash
 from judgearena.constants import VLLM_REASONING_END_STR, VLLM_REASONING_START_STR
+from judgearena.inference import (
+    InferenceCache,
+    PreparedModel,
+    build_model_descriptor,
+    canonicalize_chat_input,
+)
 from judgearena.log import get_logger
 from judgearena.usage import RequestUsage, RunUsage, record_usage
 from judgearena.utils.io import safe_parse_int
@@ -663,7 +670,7 @@ def batch_inference_once(
     return [result.text for result in results]
 
 
-def do_inference(
+def _do_inference_uncached(
     chat_model,
     inputs,
     use_tqdm: bool = False,
@@ -772,6 +779,78 @@ def do_inference(
     return [result.text for result in results]
 
 
+def do_inference(
+    chat_model,
+    inputs,
+    use_tqdm: bool = False,
+    return_top_logprobs: bool = False,
+    *,
+    stage: str = "unspecified",
+    cache_metadata: list[dict] | None = None,
+):
+    """Reuse raw provider outputs and invoke the backend only for cache misses."""
+    inputs = list(inputs)
+    if not isinstance(chat_model, PreparedModel):
+        return _do_inference_uncached(
+            chat_model,
+            inputs,
+            use_tqdm,
+            return_top_logprobs,
+            stage=stage,
+        )
+
+    cache = chat_model.cache
+    if cache is None or chat_model.descriptor is None:
+        return _do_inference_uncached(
+            chat_model.materialize(),
+            inputs,
+            use_tqdm,
+            return_top_logprobs,
+            stage=stage,
+        )
+    if cache_metadata is None or len(cache_metadata) != len(inputs):
+        raise ValueError("cache_metadata must contain one row per inference input.")
+
+    input_texts = [canonicalize_chat_input(item) for item in inputs]
+    input_hashes = [input_hash(input_text) for input_text in input_texts]
+    with cache.open_store(chat_model) as store:
+        cached_rows = store.query(input_hashes).set_index("input_hash")
+        results: list[InferenceResult | None] = [
+            (
+                InferenceResult(**cache.cached_result(cached_rows.loc[key]).__dict__)
+                if key in cached_rows.index
+                else None
+            )
+            for key in input_hashes
+        ]
+        missing_indices = [
+            index for index, result in enumerate(results) if result is None
+        ]
+        if missing_indices:
+            generated = _do_inference_uncached(
+                chat_model.materialize(),
+                [inputs[index] for index in missing_indices],
+                use_tqdm,
+                True,
+                stage=stage,
+            )
+            for index, result in zip(missing_indices, generated, strict=True):
+                results[index] = result
+            cache.save_outputs(
+                store,
+                chat_model,
+                input_texts,
+                generated,
+                cache_metadata,
+                missing_indices,
+            )
+
+    resolved_results = [result for result in results if result is not None]
+    if return_top_logprobs:
+        return resolved_results
+    return [result.text for result in resolved_results]
+
+
 def _route_sampling_params(
     engine_kwargs: dict,
     *,
@@ -812,6 +891,34 @@ def _route_sampling_params(
             continue
         engine_kwargs[key] = value
     return engine_kwargs
+
+
+def prepare_model(
+    model: str,
+    max_tokens: int | None = 8192,
+    *,
+    cache: InferenceCache | None = None,
+    **engine_kwargs,
+) -> PreparedModel:
+    """Prepare cache identity without constructing the provider backend."""
+    provider, model_name = _split_model_spec(model)
+    resolved_kwargs = {**engine_kwargs, "max_tokens": max_tokens or 8192}
+    descriptor = (
+        build_model_descriptor(provider, model_name, resolved_kwargs)
+        if cache is not None
+        else None
+    )
+    factory_kwargs = engine_kwargs.copy()
+    return PreparedModel(
+        model_spec=model,
+        descriptor=descriptor,
+        factory=lambda: make_model(
+            model,
+            max_tokens=max_tokens,
+            **factory_kwargs,
+        ),
+        cache=cache,
+    )
 
 
 def make_model(model: str, max_tokens: int | None = 8192, **engine_kwargs):

--- a/judgearena/utils/__init__.py
+++ b/judgearena/utils/__init__.py
@@ -13,12 +13,9 @@ from judgearena.utils.eval import (
     compute_pref_summary,
 )
 from judgearena.utils.io import (
-    Timeblock,
-    cache_function_dataframe,
     data_root,
     download_all,
     download_hf,
-    generation_cache_token,
     read_df,
     safe_parse_int,
 )
@@ -33,13 +30,10 @@ __all__ = [
     "BattleReport",
     "PrefSummary",
     "Report",
-    "Timeblock",
-    "cache_function_dataframe",
     "compute_pref_summary",
     "data_root",
     "download_all",
     "download_hf",
-    "generation_cache_token",
     "read_df",
     "safe_parse_int",
     "safe_text",

--- a/judgearena/utils/io.py
+++ b/judgearena/utils/io.py
@@ -2,10 +2,7 @@
 
 from __future__ import annotations
 
-import hashlib
 import os
-import time
-from collections.abc import Callable
 from pathlib import Path
 
 import pandas as pd
@@ -72,105 +69,6 @@ def download_all():
     local_path_tables = data_root / "tables"
     for task_id in load_tasks():
         download_hf(name=task_id, local_path=local_path_tables)
-
-
-class Timeblock:
-    """Timer context manager"""
-
-    def __init__(self, name: str | None = None, verbose: bool = True):
-        self.name = name
-        self.verbose = verbose
-
-    def __enter__(self):
-        """Start a new timer as a context manager"""
-        self.start = time.time()
-        return self
-
-    def __exit__(self, *args):
-        """Stop the context manager timer"""
-        self.end = time.time()
-        self.duration = self.end - self.start
-        if self.verbose:
-            logger.info("%s", self)
-
-    def __str__(self):
-        name = self.name if self.name else "block"
-        msg = f"{name} took {self.duration} seconds"
-        return msg
-
-
-def generation_cache_token(kwargs: dict[str, object]) -> str:
-    """Short, deterministic token of generation kwargs for cache-key busting.
-
-    Folds the resolved per-role generation kwargs (sampling params, max_tokens,
-    chat_template, ...) into a stable 16-char hash so that changing any of them
-    invalidates cached completions. Hashing keeps the cache name bounded even
-    when a long ``chat_template`` is present.
-    """
-    serialized = "_".join(f"{k}={kwargs[k]!r}" for k in sorted(kwargs))
-    return hashlib.sha256(serialized.encode()).hexdigest()[:16]
-
-
-def cache_function_dataframe(
-    fun: Callable[[], pd.DataFrame],
-    cache_name: str,
-    ignore_cache: bool = False,
-    cache_path: Path | None = None,
-    parquet: bool = False,
-) -> pd.DataFrame:
-    """
-    :param fun: a function whose dataframe result obtained `fun()` will be cached
-    :param cache_name: the cache of the function result is written into `{cache_path}/{cache_name}.csv.zip`
-    :param ignore_cache: whether to recompute even if the cache is present
-    :param cache_path: folder where to write cache files, default to ~/cache-zeroshot/
-    :param parquet: whether to store the data in parquet, if not specified use csv.zip
-    :return: result of fun()
-    """
-    if cache_path is None:
-        cache_path = data_root / "cache"
-
-    if parquet:
-        cache_file = cache_path / (cache_name + ".parquet")
-    else:
-        cache_file = cache_path / (cache_name + ".csv.zip")
-    cache_file.parent.mkdir(parents=True, exist_ok=True)
-    if cache_file.exists() and not ignore_cache:
-        logger.info("Loading cache %s", cache_file)
-        if parquet:
-            return pd.read_parquet(cache_file)
-        else:
-            return pd.read_csv(cache_file)
-    else:
-        logger.info(
-            "Cache %s not found or ignore_cache set to True, regenerating the file",
-            cache_file,
-        )
-        with Timeblock("Evaluate function."):
-            df = fun()
-            assert isinstance(df, pd.DataFrame)
-            if parquet:
-                # object cols cannot be saved easily in parquet; numpy arrays must be
-                # deep-converted to plain Python so str() produces ast.literal_eval-safe
-                # repr (no "array([...])" syntax, which breaks literal_eval)
-                import numpy as np
-
-                def _to_python(x):
-                    """Recursively convert numpy arrays/scalars to Python lists/dicts."""
-                    if isinstance(x, np.ndarray):
-                        return [_to_python(i) for i in x]
-                    if isinstance(x, dict):
-                        return {k: _to_python(v) for k, v in x.items()}
-                    if isinstance(x, list):
-                        return [_to_python(i) for i in x]
-                    return x
-
-                for col in df.select_dtypes(include="object").columns:
-                    df[col] = df[col].apply(_to_python).astype(str)
-                df.to_parquet(cache_file, index=False)
-                return pd.read_parquet(cache_file)
-            else:
-                df.to_csv(cache_file, index=False)
-                return pd.read_csv(cache_file)
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,6 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project.scripts]
 judgearena = "judgearena.cli:cli"
+judgearena-cache-browse = "judgearena.browse_cache:main"
 
 [project]
 name = "judgearena"
@@ -97,6 +98,11 @@ quote-style = "double"
 indent-style = "space"
 
 [project.optional-dependencies]
+browser = [
+    "ipython>=9.5.0",
+    "ipywidgets>=8.1.7",
+    "textual>=6.1.0",
+]
 # vLLM 0.19.1 is the pinned judge/battle runtime on this branch. Its own
 # Requires-Dist is `transformers!=5.0.*,...,!=5.5.0,>=4.56.0`, so the
 # only sub-range >=5.x that vLLM 0.19.1 accepts is >=5.5.1 — hence the

--- a/tests/test_browse_cache.py
+++ b/tests/test_browse_cache.py
@@ -1,0 +1,91 @@
+import pandas as pd
+
+import judgearena.browse_cache as browser
+from judgearena.browse_cache import cell_row_count, iter_cache_cells, load_cache_cell
+from judgearena.cache_sqlite import (
+    COMPLETION_DB_NAME,
+    JUDGEMENT_DB_NAME,
+    CompletionCache,
+    JudgementCache,
+    cache_folder,
+    write_descriptor,
+)
+
+
+def test_browser_discovers_and_joins_content_addressed_cells(tmp_path, monkeypatch):
+    descriptor = {
+        "schema_version": "judgearena-inference-cache/v1",
+        "provider": "Dummy",
+        "model": "org/model",
+    }
+    folder = cache_folder(
+        tmp_path,
+        "completions",
+        "arena-hard",
+        "Dummy/org/model",
+        descriptor,
+    )
+    write_descriptor(folder, descriptor)
+    rows = pd.DataFrame(
+        [
+            {
+                "input_text": "prompt",
+                "completion": "answer",
+                "benchmark": "arena-hard",
+                "instruction_id": "7",
+                "model": "Dummy/org/model",
+            }
+        ]
+    )
+    with CompletionCache(folder / COMPLETION_DB_NAME) as cache:
+        cache.save(rows, pushed_by="test")
+    judgement_folder = cache_folder(
+        tmp_path,
+        "judgements",
+        "arena-hard",
+        "Dummy/judge",
+        {**descriptor, "model": "judge"},
+    )
+    write_descriptor(judgement_folder, {**descriptor, "model": "judge"})
+    with JudgementCache(judgement_folder / JUDGEMENT_DB_NAME) as cache:
+        cache.save(
+            pd.DataFrame(
+                [
+                    {
+                        "judge_input": "judge prompt",
+                        "judge_completion": "score_A: 1\nscore_B: 9",
+                        "benchmark": "arena-hard",
+                        "instruction_id": "7",
+                        "model_a": "baseline",
+                        "model_b": "Dummy/org/model",
+                        "judge": "Dummy/judge",
+                        "orientation": "reversed",
+                    }
+                ]
+            ),
+            pushed_by="test",
+        )
+
+    cells = iter_cache_cells(tmp_path)
+
+    assert len(cells) == 2
+    assert cell_row_count(cells[0]) == 1
+    assert load_cache_cell(cells[0], instruction_id="7")["completion"].tolist() == [
+        "answer"
+    ]
+    context = pd.DataFrame(
+        {"instruction": ["question"], "language": ["en"]},
+        index=["7"],
+    )
+    monkeypatch.setattr(browser, "load_context", lambda _task: context)
+    joined = browser.load_subset(
+        store_root=tmp_path,
+        task="arena-hard",
+        model="Dummy/org/model",
+        judge="Dummy/judge",
+        languages=["en"],
+    )
+
+    assert joined["completion_b"].tolist() == ["answer"]
+    assert joined["instruction"].tolist() == ["question"]
+    assert "score_A: 1" in browser.render_row(joined.iloc[0])

--- a/tests/test_estimate_elo_ratings.py
+++ b/tests/test_estimate_elo_ratings.py
@@ -86,13 +86,6 @@ def mock_external_deps(monkeypatch, synthetic_arena_df):
 
     monkeypatch.setattr(estimate_elo_ratings, "generate_instructions", mock_generate)
 
-    def _run_without_cache(fun, **_kwargs):
-        return fun()
-
-    monkeypatch.setattr(
-        estimate_elo_ratings, "cache_function_dataframe", _run_without_cache
-    )
-
 
 def _default_args(*, result_folder: str, **kwargs) -> RunConfig:
     task = kwargs.pop("task", "elo-comparia")

--- a/tests/test_generate_and_evaluate.py
+++ b/tests/test_generate_and_evaluate.py
@@ -79,13 +79,6 @@ def mock_external_data_and_cache(monkeypatch):
         ),
     )
 
-    def _run_without_cache(fun, **_kwargs):
-        return fun()
-
-    monkeypatch.setattr(
-        generate_and_evaluate, "cache_function_dataframe", _run_without_cache
-    )
-
 
 def _mock_alpaca_judge(monkeypatch, message) -> dict[str, object]:
     from judgearena.benchmarks.pairwise.scoring import alpaca_eval
@@ -100,7 +93,7 @@ def _mock_alpaca_judge(monkeypatch, message) -> dict[str, object]:
         captured.update(kwargs)
         return FakeJudge()
 
-    monkeypatch.setattr(benchmark_execution, "make_model", make_fake_judge)
+    monkeypatch.setattr(benchmark_execution, "prepare_model", make_fake_judge)
     monkeypatch.setattr(
         alpaca_eval,
         "_length_controlled_metrics",
@@ -336,7 +329,7 @@ def test_generate_and_evaluate_passes_judge_side_controls(monkeypatch, tmp_path)
 
         return FakeJudge()
 
-    monkeypatch.setattr(benchmark_execution, "make_model", fake_make_model)
+    monkeypatch.setattr(benchmark_execution, "prepare_model", fake_make_model)
 
     prefs = run_pairwise(
         _cfg(

--- a/tests/test_inference_cache.py
+++ b/tests/test_inference_cache.py
@@ -1,7 +1,17 @@
-from langchain_core.messages import AIMessage
+import json
 
+import pytest
+from langchain_core.messages import AIMessage
+from langchain_core.prompts import ChatPromptTemplate
+
+import judgearena.inference as inference
 import judgearena.models as models
-from judgearena.inference import CompletionInferenceCache, JudgementInferenceCache
+from judgearena.inference import (
+    CompletionInferenceCache,
+    JudgementInferenceCache,
+    canonicalize_model_input,
+    provider_input_mode,
+)
 from judgearena.models import InferenceResult, do_inference, prepare_model
 from judgearena.usage import track_usage
 
@@ -104,3 +114,101 @@ def test_judgement_hit_preserves_top_logprobs(tmp_path, monkeypatch):
     assert second[0].text == first[0].text
     assert second[0].first_token_top_logprobs == first[0].first_token_top_logprobs
     assert second[0].usage is None
+
+
+def test_vllm_descriptor_contains_output_configuration(tmp_path, monkeypatch):
+    monkeypatch.setattr(inference.importlib_metadata, "version", lambda _name: "0.10.2")
+    cache = CompletionInferenceCache(tmp_path, "arena-hard")
+
+    descriptor = prepare_model(
+        "VLLM/Qwen/Qwen3-8B",
+        max_tokens=32,
+        cache=cache,
+        temperature=0.2,
+        enforce_eager=True,
+        gpu_memory_utilization=0.9,
+        max_model_len=4096,
+        tensor_parallel_size=2,
+    ).descriptor
+
+    assert descriptor["backend_version"] == "0.10.2"
+    assert descriptor["model_kwargs"]["temperature"] == 0.2
+    assert descriptor["model_kwargs"]["top_p"] == 0.95
+    assert descriptor["model_kwargs"]["max_model_len"] == 4096
+    assert "tensor_parallel_size" not in descriptor["model_kwargs"]
+
+
+@pytest.mark.parametrize(
+    ("model_spec", "expected_mode", "expected_endpoint"),
+    [
+        ("Dummy/model", "chat", None),
+        ("VLLM/org/model", "chat", None),
+        ("OpenRouter/org/model", "chat", "https://openrouter.ai/api/v1"),
+        ("ChatOpenAI/model", "chat", "https://api.openai.com/v1"),
+        ("OpenAI/model", "text", "https://api.openai.com/v1"),
+        ("Together/org/model", "text", "https://api.together.xyz/v1/completions"),
+        ("LlamaCpp/./models/model.gguf", "text", None),
+    ],
+)
+def test_supported_provider_descriptors(
+    tmp_path,
+    monkeypatch,
+    model_spec,
+    expected_mode,
+    expected_endpoint,
+):
+    versions = {"vllm": "0.10.2", "llama-cpp-python": "0.3.0"}
+    monkeypatch.setattr(inference.importlib_metadata, "version", versions.__getitem__)
+    monkeypatch.delenv("OPENAI_BASE_URL", raising=False)
+    monkeypatch.delenv("OPENAI_API_BASE", raising=False)
+    cache = CompletionInferenceCache(tmp_path, "arena-hard")
+
+    descriptor = prepare_model(model_spec, cache=cache).descriptor
+
+    assert descriptor["input_mode"] == expected_mode
+    assert descriptor.get("endpoint") == expected_endpoint
+
+
+def test_hosted_descriptor_hashes_routing_and_endpoint(tmp_path, monkeypatch, caplog):
+    cache = CompletionInferenceCache(tmp_path, "arena-hard")
+    unpinned = prepare_model("OpenRouter/org/model", cache=cache).descriptor
+    assert "uses unpinned provider routing" in caplog.text
+
+    caplog.clear()
+    pinned = prepare_model(
+        "OpenRouter/org/model",
+        cache=cache,
+        extra_body={"provider": {"order": ["Together"], "allow_fallbacks": False}},
+    ).descriptor
+    assert "uses unpinned provider routing" not in caplog.text
+    assert unpinned != pinned
+
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://ambient.example/v1")
+    ambient = prepare_model("ChatOpenAI/model", cache=cache).descriptor
+    assert ambient["endpoint"] == "https://ambient.example/v1"
+
+
+def test_unsupported_provider_runs_uncached(tmp_path, caplog):
+    model = prepare_model(
+        "Unsupported/model",
+        cache=CompletionInferenceCache(tmp_path, "arena-hard"),
+    )
+
+    assert model.descriptor is None
+    assert "Caching is not supported" in caplog.text
+
+
+@pytest.mark.parametrize(
+    ("provider", "expected_type"),
+    [("OpenRouter", "messages"), ("Together", "text"), ("VLLM", "messages")],
+)
+def test_input_canonicalization_matches_provider_mode(provider, expected_type):
+    prompt = ChatPromptTemplate.from_messages(
+        [("system", "System"), ("user", "Question")]
+    ).invoke({})
+
+    payload = json.loads(
+        canonicalize_model_input(prompt, provider_input_mode(provider))
+    )
+
+    assert payload["type"] == expected_type

--- a/tests/test_inference_cache.py
+++ b/tests/test_inference_cache.py
@@ -1,0 +1,106 @@
+from langchain_core.messages import AIMessage
+
+import judgearena.models as models
+from judgearena.inference import CompletionInferenceCache, JudgementInferenceCache
+from judgearena.models import InferenceResult, do_inference, prepare_model
+from judgearena.usage import track_usage
+
+
+class EchoModel:
+    def __init__(self):
+        self.calls = []
+
+    def batch(self, inputs, **_kwargs):
+        self.calls.append(inputs)
+        return [AIMessage(content=f"generated:{item}") for item in inputs]
+
+
+def test_full_hit_does_not_materialize_model(tmp_path, monkeypatch):
+    cache = CompletionInferenceCache(tmp_path, "arena-hard")
+    monkeypatch.setattr(models, "make_model", lambda *_args, **_kwargs: EchoModel())
+    metadata = [{"instruction_id": "1"}]
+    do_inference(
+        prepare_model("Dummy/test-model", cache=cache),
+        ["prompt"],
+        cache_metadata=metadata,
+    )
+
+    def fail_if_materialized(*_args, **_kwargs):
+        raise AssertionError("cache hit materialized the model")
+
+    monkeypatch.setattr(models, "make_model", fail_if_materialized)
+    with track_usage() as tracker:
+        outputs = do_inference(
+            prepare_model("Dummy/test-model", cache=cache),
+            ["prompt"],
+            cache_metadata=metadata,
+        )
+
+    assert outputs == ["generated:prompt"]
+    assert tracker.snapshot().requests == ()
+
+
+def test_mixed_hits_and_misses_preserve_order(tmp_path, monkeypatch):
+    cache = CompletionInferenceCache(tmp_path, "arena-hard")
+    first_backend = EchoModel()
+    monkeypatch.setattr(models, "make_model", lambda *_args, **_kwargs: first_backend)
+    do_inference(
+        prepare_model("Dummy/test-model", cache=cache),
+        ["hit"],
+        cache_metadata=[{"instruction_id": "hit"}],
+    )
+
+    backend = EchoModel()
+    monkeypatch.setattr(models, "make_model", lambda *_args, **_kwargs: backend)
+    outputs = do_inference(
+        prepare_model("Dummy/test-model", cache=cache),
+        ["miss-a", "hit", "miss-b"],
+        cache_metadata=[
+            {"instruction_id": "a"},
+            {"instruction_id": "hit"},
+            {"instruction_id": "b"},
+        ],
+    )
+
+    assert outputs == ["generated:miss-a", "generated:hit", "generated:miss-b"]
+    assert backend.calls == [["miss-a", "miss-b"]]
+
+
+def test_judgement_hit_preserves_top_logprobs(tmp_path, monkeypatch):
+    cache = JudgementInferenceCache(tmp_path, "arena-hard")
+
+    class LogprobModel:
+        def batch(self, inputs, **_kwargs):
+            return [
+                InferenceResult(
+                    text="m",
+                    first_token_top_logprobs={"m": -0.1, "M": -2.0},
+                )
+                for _ in inputs
+            ]
+
+    monkeypatch.setattr(models, "make_model", lambda *_args, **_kwargs: LogprobModel())
+    metadata = [
+        {
+            "instruction_id": "1",
+            "model_a": "candidate",
+            "model_b": "baseline",
+            "orientation": "direct",
+        }
+    ]
+    first = do_inference(
+        prepare_model("Dummy/judge", cache=cache),
+        ["judge prompt"],
+        return_top_logprobs=True,
+        cache_metadata=metadata,
+    )
+    second = do_inference(
+        prepare_model("Dummy/judge", cache=cache),
+        ["judge prompt"],
+        return_top_logprobs=True,
+        cache_metadata=metadata,
+    )
+
+    assert second[0].text == first[0].text
+    assert second[0].first_token_top_logprobs == first[0].first_token_top_logprobs
+    assert second[0].usage is None

--- a/tests/test_meta_eval_annotations.py
+++ b/tests/test_meta_eval_annotations.py
@@ -23,6 +23,8 @@ def _sample() -> pd.DataFrame:
         [
             {
                 "battle_id": "arena:q1",
+                "model_a": "alpha",
+                "model_b": "beta",
                 "conversation_a": [
                     {"role": "user", "content": "Same prompt"},
                     {"role": "assistant", "content": "Alpha answer"},

--- a/tests/test_mt_bench_downloads.py
+++ b/tests/test_mt_bench_downloads.py
@@ -104,10 +104,6 @@ def test_generate_mt_bench_completions_uses_pregenerated_baseline(monkeypatch):
     )
     generated_models = []
 
-    monkeypatch.setattr(
-        mt_bench_runner, "cache_function_dataframe", lambda fun, **_kwargs: fun()
-    )
-
     def fake_generate_multiturn(**kwargs):
         generated_models.append(kwargs["model"])
         return pd.DataFrame(
@@ -266,7 +262,7 @@ def test_run_mt_bench_resolves_native_baseline_and_judge_controls(
         captured["make_model"] = kwargs
         return object()
 
-    monkeypatch.setattr(mt_bench_runner, "make_model", fake_make_model)
+    monkeypatch.setattr(mt_bench_runner, "prepare_model", fake_make_model)
 
     def fake_run_mt_bench_fastchat(**kwargs):
         captured["fastchat"] = kwargs
@@ -334,7 +330,7 @@ def _stub_mt_bench_dispatch(monkeypatch, captured):
         captured["make_model"] = kwargs
         return object()
 
-    monkeypatch.setattr(mt_bench_runner, "make_model", make_model)
+    monkeypatch.setattr(mt_bench_runner, "prepare_model", make_model)
 
     def dispatch(path, kwargs):
         captured.setdefault("dispatch", []).append(path)
@@ -397,9 +393,6 @@ def test_generate_mt_bench_completions_forwards_thinking_controls(monkeypatch):
     )
     captured: dict[str, dict] = {}
 
-    monkeypatch.setattr(
-        mt_bench_runner, "cache_function_dataframe", lambda fun, **_kwargs: fun()
-    )
     monkeypatch.setattr(
         mt_bench_runner,
         "load_mt_bench_model_answers",
@@ -476,7 +469,7 @@ def test_run_mt_bench_forwards_strip_thinking_to_fastchat_judge(monkeypatch, tmp
             ),
         ),
     )
-    monkeypatch.setattr(mt_bench_runner, "make_model", lambda **kwargs: object())
+    monkeypatch.setattr(mt_bench_runner, "prepare_model", lambda **kwargs: object())
     monkeypatch.setattr(
         mt_bench_runner, "_finalize_mt_bench_run", lambda **kwargs: kwargs["prefs"]
     )

--- a/tests/test_seed_plumbing.py
+++ b/tests/test_seed_plumbing.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from judgearena.config import RunConfig, build_run_config
 from judgearena.models import make_model
-from judgearena.utils import generation_cache_token
 
 
 def test_make_model_dummy_captures_temperature_and_seed():
@@ -91,17 +90,6 @@ def test_baseline_sampling_params_inherit_from_model_when_unset():
         "top_k": 40,  # inherited from model.top_k
         "seed": 7,  # inherited from model.seed
     }
-
-
-def test_generation_cache_token_is_sensitive_to_sampling_params():
-    base = {"max_tokens": 32768, "temperature": 0.0, "seed": 1}
-    same = {"seed": 1, "temperature": 0.0, "max_tokens": 32768}  # order independent
-    changed_seed = {**base, "seed": 2}
-    changed_temp = {**base, "temperature": 1.0}
-
-    assert generation_cache_token(base) == generation_cache_token(same)
-    assert generation_cache_token(base) != generation_cache_token(changed_seed)
-    assert generation_cache_token(base) != generation_cache_token(changed_temp)
 
 
 def test_model_args_per_role_kwargs_are_independent():

--- a/tests/test_usage.py
+++ b/tests/test_usage.py
@@ -190,7 +190,13 @@ def test_failed_inference_reports_no_recorded_responses(monkeypatch, capsys):
 
 def test_generation_paths_preserve_existing_sync_async_behavior(monkeypatch):
     model = FakeModel(["batch", "batch"], async_response="async")
-    monkeypatch.setattr(generate_module, "make_model", lambda *args, **kwargs: model)
+    prepared_kwargs = {}
+
+    def fake_prepare_model(*args, **kwargs):
+        prepared_kwargs.update(kwargs)
+        return model
+
+    monkeypatch.setattr(generate_module, "prepare_model", fake_prepare_model)
     instructions = pd.Series(["one", "two"])
 
     instruction_outputs = generate_module.generate_instructions(
@@ -202,4 +208,4 @@ def test_generation_paths_preserve_existing_sync_async_behavior(monkeypatch):
         instructions, "Dummy/model", max_tokens=123, use_tqdm=True
     )
     assert base_outputs["completion"].tolist() == ["batch", "batch"]
-    assert model.batch_kwargs["max_tokens"] == 123
+    assert prepared_kwargs["max_tokens"] == 123


### PR DESCRIPTION
# Description

> [!NOTE]
> WIP: This is a replacement cache stack on top of #118. It is not final and may still change before review.

Ports the cache browser from #71 onto the content-addressed store.

- Discovers completion and judgement cells under `store_root`.
- Filters by task, model, judge, and language, and joins context with completions for rendering.
- Adds the terminal browser and notebook widgets under the optional `browser` extra.

This is stacked on #124.
